### PR TITLE
feat: Phase 2 — HTML Reports, YAML Sources, GitHub Pages, Tier 2 expansion

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: Deploy Reports to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Regenerate index page
+        run: pnpm index-page
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: reports
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Create Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          makeLatest: true

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist/
 data/articles/**
 
 AGENTS.md
+
+# User-customized source config (see sources.example.yaml)
+sources.yaml

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ git clone https://github.com/colorful-tones/wp-trend-watcher.git
 cd wp-trend-watcher
 pnpm install
 cp .env.example .env   # edit if using a different model or provider
+cp sources.example.yaml sources.yaml  # optional: customize sources
 pnpm collect           # add -- --days 7 for recent articles
 pnpm summarize         # requires Ollama (local, $0) by default
 ```
@@ -60,7 +61,6 @@ Tier 2 sources (Gutenberg Times, ACF Chat Fridays) added to the default collecti
 - No agent swarms.
 - No UI/dashboard.
 - No historical trend engine.
-- No custom source registry.
 
 ## Report Format
 
@@ -102,6 +102,9 @@ See:
 Public launch prep is complete. The repo is ready to share, and the first human-reviewed report is committed.
 
 ## Changelog
+
+### 0.1.4
+Source configuration via `sources.yaml`. Users can now customize the source list without editing TypeScript. Copy `sources.example.yaml` to `sources.yaml` and edit. If the file is missing, built-in defaults are used.
 
 ### 0.1.3
 Tier 2 sources (Gutenberg Times, ACF Chat Fridays) added to the default collection. Collection now prints a clean summary with article counts, filtered counts, and source error reporting.

--- a/README.md
+++ b/README.md
@@ -44,10 +44,17 @@ Phase 1+ workflow (working):
 
 ```bash
 pnpm collect    # Fetch RSS feeds from 6 sources (4 Tier 1 + 2 Tier 2), store articles as JSON
-pnpm summarize  # Fetch article content, generate per-article summaries, synthesize weekly report
+pnpm summarize  # Fetch article content, generate per-article summaries, synthesize weekly report (also generates HTML + index)
+pnpm index-page # Regenerate the reports index.html listing page
 ```
 
 See [Summarization](docs/summarization.md) for provider configuration, model options, and synthesis strategy.
+
+### HTML Reports & GitHub Pages
+
+`pnpm summarize` now produces a self-contained HTML version of each report alongside the Markdown file. An `index.html` listing page is also generated automatically in `reports/`.
+
+Reports are deployed to GitHub Pages on every push to `main` via the `pages.yml` workflow. Configure GitHub Pages to deploy from the `github-pages` environment (Settings → Pages → Source: GitHub Actions).
 
 ### 0.1.3
 Tier 2 sources (Gutenberg Times, ACF Chat Fridays) added to the default collection. Collection now prints a clean summary with article counts, filtered counts, and source error reporting.
@@ -102,6 +109,9 @@ See:
 Public launch prep is complete. The repo is ready to share, and the first human-reviewed report is committed.
 
 ## Changelog
+
+### 0.1.5
+HTML report generation. `pnpm summarize` now produces self-contained HTML reports alongside Markdown. Index page auto-generated in `reports/`. GitHub Pages deployment via GitHub Actions workflow.
 
 ### 0.1.4
 Source configuration via `sources.yaml`. Users can now customize the source list without editing TypeScript. Copy `sources.example.yaml` to `sources.yaml` and edit. If the file is missing, built-in defaults are used.

--- a/README.md
+++ b/README.md
@@ -39,14 +39,18 @@ Prerequisites: Node.js 18+, pnpm 9+. Ollama is optional for collection but requi
 
 ## What This Does
 
-Phase 1 workflow (working):
+Phase 1+ workflow (working):
 
 ```bash
-pnpm collect    # Fetch RSS feeds from Tier 1 sources, store articles as JSON
+pnpm collect    # Fetch RSS feeds from 6 sources (4 Tier 1 + 2 Tier 2), store articles as JSON
 pnpm summarize  # Fetch article content, generate per-article summaries, synthesize weekly report
 ```
 
 See [Summarization](docs/summarization.md) for provider configuration, model options, and synthesis strategy.
+
+### 0.1.3
+Tier 2 sources (Gutenberg Times, ACF Chat Fridays) added to the default collection. Collection now prints a clean summary with article counts, filtered counts, and source error reporting.
+
 
 ## What This Does Not Do Yet
 
@@ -98,6 +102,9 @@ See:
 Public launch prep is complete. The repo is ready to share, and the first human-reviewed report is committed.
 
 ## Changelog
+
+### 0.1.3
+Tier 2 sources (Gutenberg Times, ACF Chat Fridays) added to the default collection. Collection now prints a clean summary with article counts, filtered counts, and source error reporting.
 
 ### 0.1.2
 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,15 @@ The goal is not to automate opinions, replace expertise, or publish without revi
 
 The goal is to collect useful WordPress ecosystem updates, summarize them efficiently, review them with human judgment, and produce a weekly report that developers can actually use.
 
-## Launch Status
+## Status
 
-- Repo is public.
-- First human-reviewed weekly report is committed.
-- Ready to share.
+Phase 2 complete. The repo now has:
 
-## Phase 1 Goal
-
-Ship one human-reviewed weekly WordPress trend report.
-
-Phase 1 should prove the workflow before adding automation, dashboards, historical trend tracking, or complex storage.
+- **6 sources** (4 Tier 1 + 2 Tier 2) with clean collection summaries
+- **sources.yaml** for user-customizable sources
+- **HTML reports** with self-contained styling, generated alongside Markdown
+- **GitHub Pages** deployment via GitHub Actions on push to main
+- **First weekly report** published and committed
 
 ## Intended Audience
 
@@ -106,7 +104,7 @@ See:
 
 ## Status
 
-Public launch prep is complete. The repo is ready to share, and the first human-reviewed report is committed.
+Phase 2 complete. The repo collects from 6 sources, supports custom source configuration, produces styled HTML reports, and deploys to GitHub Pages. Ready for ongoing weekly use and community contributions.
 
 ## Changelog
 

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -4,7 +4,7 @@ This file defines the Phase 1 source list and source-selection rules.
 
 ## Phase 1 Source Rules
 
-A source belongs in Phase 1 if it:
+A source belongs in this project if it:
 
 - publishes WordPress developer-relevant updates
 - has an RSS feed or predictable public URL
@@ -79,3 +79,20 @@ Community discussion and emerging ACF-related topics that may not appear in offi
 ## Phase 1 Decision
 
 Phase 1 started with Tier 1 only. Tier 2 sources (Gutenberg Times, ACF Chat Fridays) were added once the core workflow was proven.
+
+## Custom Sources
+
+To customize the source list, copy `sources.example.yaml` to `sources.yaml` and edit. The collector reads from `sources.yaml` if it exists, otherwise uses the built-in defaults.
+
+```bash
+cp sources.example.yaml sources.yaml
+```
+
+Each source needs:
+- `id` — unique identifier
+- `name` — display name
+- `feedUrl` — RSS feed URL
+
+Optional:
+- `url` — homepage URL
+- `tier` — 1 or 2 (default 2)

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -22,7 +22,7 @@ A source should be excluded if it is mostly:
 
 ## Tier 1 Sources
 
-Start here. Tier 1 should be enough to test the core workflow.
+Phase 1 started with Tier 1 only. As of v0.1.3, Tier 2 sources are included in the default collection.
 
 ### WordPress Developer Blog
 
@@ -58,7 +58,7 @@ ACF-specific developer workflow updates and modern WordPress implementation patt
 
 ## Tier 2 Sources
 
-Add these only if Tier 1 feels too thin for the first report.
+Included in the default collection since v0.1.3. The collector fetches all sources (Tier 1 + Tier 2) by default.
 
 ### Gutenberg Times
 
@@ -78,4 +78,4 @@ Community discussion and emerging ACF-related topics that may not appear in offi
 
 ## Phase 1 Decision
 
-Start with Tier 1 only unless the collection is too thin to produce a useful weekly report.
+Phase 1 started with Tier 1 only. Tier 2 sources (Gutenberg Times, ACF Chat Fridays) were added once the core workflow was proven.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,
@@ -19,9 +19,11 @@
   "author": "Damon Cook",
   "license": "MIT",
   "dependencies": {
+    "js-yaml": "^4.2.0",
     "rss-parser": "^3.13.0"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.10.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,
   "scripts": {
     "collect": "tsx src/collect/index.ts",
     "summarize": "tsx src/summarize/index.ts",
+    "index-page": "tsx src/summarize/index-page.ts",
     "test": "tsx --test tests/**/*.test.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,10 +8,16 @@ importers:
 
   .:
     dependencies:
+      js-yaml:
+        specifier: ^4.2.0
+        version: 4.2.0
       rss-parser:
         specifier: ^3.13.0
         version: 3.13.0
     devDependencies:
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^24.10.1
         version: 24.13.1
@@ -180,8 +186,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/node@24.13.1':
     resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
@@ -195,6 +207,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
 
   rss-parser@3.13.0:
     resolution: {integrity: sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==}
@@ -304,9 +320,13 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/node@24.13.1':
     dependencies:
       undici-types: 7.18.2
+
+  argparse@2.0.1: {}
 
   entities@2.2.0: {}
 
@@ -341,6 +361,10 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
 
   rss-parser@3.13.0:
     dependencies:

--- a/reports/2026-06-12.html
+++ b/reports/2026-06-12.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>WordPress Trend Report — 2026-06-12</title>
+  <style>* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.6;
+  color: #1a1a1a;
+  background: #fff;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+h1 { font-size: 1.75rem; margin-bottom: 0.5rem; line-height: 1.3; }
+h2 { font-size: 1.35rem; margin-top: 2rem; margin-bottom: 0.5rem; border-bottom: 1px solid #e0e0e0; padding-bottom: 0.25rem; }
+h3 { font-size: 1.1rem; margin-top: 1.5rem; margin-bottom: 0.4rem; }
+p { margin-bottom: 1rem; }
+ul { margin: 0 0 1rem 1.5rem; }
+li { margin-bottom: 0.35rem; }
+a { color: #0969da; text-decoration: none; }
+a:hover { text-decoration: underline; }
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.9em;
+  background: #f0f0f0;
+  padding: 0.15em 0.35em;
+  border-radius: 3px;
+}
+pre {
+  background: #f6f8fa;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  margin-bottom: 1rem;
+}
+pre code { background: none; padding: 0; font-size: 0.85em; }
+hr { border: none; border-top: 1px solid #e0e0e0; margin: 2rem 0; }
+strong { font-weight: 600; }
+em { font-style: italic; }
+.meta { color: #666; font-size: 0.85rem; margin-bottom: 2rem; }</style>
+</head>
+<body>
+  <h1>WordPress Trend Report — 2026-06-12</h1>
+<h3>Weekly Summary</h3>
+<p>Here's a summary of the latest articles from WordPress developer sources:</p>
+<ul>
+<li><strong>Gutenberg 23.3 and Media Editor Modal</strong>: The media editor modal in Gutenberg 23.3 is now the default crop experience, featuring freeform and aspect-ratio cropping, flip, rotation, zoom, and metadata editing.</li>
+<li><strong>Client-side Media Processing and Testing</strong>: Client-side media processing is ready for testing using a VIPS/WASM pipeline to generate image sub-sizes in the browser when possible. A call for testing has been issued for this feature.</li>
+<li><strong>WordPress 7.1 Collaborative Editing Outreach</strong>: Collaborative editing outreach has started for WordPress 7.1, asking testers to report any issues with real-time collaboration features that store editor state or modify block editor data.</li>
+<li><strong>Call for Release Managers for WordPress 7.0.x Releases</strong>: WordPress is seeking release managers for the 7.0.x maintenance releases, which are smaller teams responsible for releasing minor updates after a major release.</li>
+<li><strong>WordCamp Europe 2026 Recap</strong>: WordCamp Europe 2026 took place in Kraków, Poland from June 4-6, drawing 2,458 attendees from 81 countries.</li>
+</ul>
+<h3>Emerging Trends</h3>
+<p>None notable this week.</p>
+<h3>Developer Implications</h3>
+<p>For freelance or agency WordPress developers:</p>
+<ul>
+<li>When working with Gutenberg 23.3, be aware of the new media editor modal and its features.</li>
+<li>Test Client-side Media Processing using the VIPS/WASM pipeline to generate image sub-sizes in the browser when possible.</li>
+<li>Participate in collaborative editing outreach for WordPress 7.1 by reporting any issues with real-time collaboration features that store editor state or modify block editor data.</li>
+<li>Consider applying for release manager positions for WordPress 7.0.x releases if you're interested in contributing to minor updates after a major release.</li>
+</ul>
+<p>Note: ACF version 6.8.4 is now available, but there are no notable implications for freelance or agency developers at this time.</p>
+<hr>
+<h2>What I'm Watching</h2>
+<ul>
+<li>Collaborative editing in WordPress 7.1 feels like the biggest real workflow shift in this batch.</li>
+<li>The client-side media processing work is promising, but I want to see it behave on real sites before I trust it.</li>
+<li>ACF 6.8.4 is worth noting, but it does not change my immediate weekly priorities.</li>
+</ul>
+<hr>
+<h2>Source Articles</h2>
+<h3>WordPress Developer Blog</h3>
+<ul>
+<li><a href="https://developer.wordpress.org/news/2026/06/whats-new-for-developers-june-2026/">What’s new for developers? (June 2026)</a> — 6/10/2026</li>
+</ul>
+<h3>Make Core</h3>
+<ul>
+<li><a href="https://make.wordpress.org/core/2026/06/10/call-for-testing-unicode-email-addresses/">Call for Testing: Unicode email addresses.</a> — 6/10/2026</li>
+<li><a href="https://make.wordpress.org/core/2026/06/10/dev-chat-agenda-june-10-2026/">Dev Chat Agenda – June 10, 2026</a> — 6/9/2026</li>
+<li><a href="https://make.wordpress.org/core/2026/06/08/call-for-wordpress-7-0-x-release-managers/">Call for WordPress 7.0.x Release Managers</a> — 6/8/2026</li>
+</ul>
+<h3>WordPress.org News</h3>
+<ul>
+<li><a href="https://wordpress.org/news/2026/06/wceu-2026-recap/">What Happened at WordCamp Europe 2026</a> — 6/6/2026</li>
+<li><a href="https://wordpress.org/news/2026/06/pts/">Protect The Shire</a> — 6/5/2026</li>
+</ul>
+<h3>ACF Blog</h3>
+<ul>
+<li><a href="https://www.advancedcustomfields.com/blog/acf-6-8-4/">ACF 6.8.4</a> — 6/10/2026</li>
+</ul>
+<hr>
+<h2>Build Notes</h2>
+<ul>
+<li>Articles analyzed: 7</li>
+<li>Sources: WordPress Developer Blog, Make Core, WordPress.org News, ACF Blog</li>
+<li>Model: ollama/llama3.2:3b</li>
+<li>Tokens: 6421 prompt + 1083 completion</li>
+<li>Estimated cost: $0.00 (local model)</li>
+<li>Review time: ~15 minutes</li>
+</ul>
+</body>
+</html>

--- a/reports/index.html
+++ b/reports/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>WP Trend Watcher — Reports</title>
+  <style>* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.6;
+  color: #1a1a1a;
+  background: #fff;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+h1 { font-size: 1.75rem; margin-bottom: 0.5rem; line-height: 1.3; }
+h2 { font-size: 1.35rem; margin-top: 2rem; margin-bottom: 0.5rem; border-bottom: 1px solid #e0e0e0; padding-bottom: 0.25rem; }
+h3 { font-size: 1.1rem; margin-top: 1.5rem; margin-bottom: 0.4rem; }
+p { margin-bottom: 1rem; }
+ul { margin: 0 0 1rem 1.5rem; }
+li { margin-bottom: 0.35rem; }
+a { color: #0969da; text-decoration: none; }
+a:hover { text-decoration: underline; }
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.9em;
+  background: #f0f0f0;
+  padding: 0.15em 0.35em;
+  border-radius: 3px;
+}
+pre {
+  background: #f6f8fa;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  margin-bottom: 1rem;
+}
+pre code { background: none; padding: 0; font-size: 0.85em; }
+hr { border: none; border-top: 1px solid #e0e0e0; margin: 2rem 0; }
+strong { font-weight: 600; }
+em { font-style: italic; }
+.meta { color: #666; font-size: 0.85rem; margin-bottom: 2rem; }
+h1 { border-bottom: none; }
+  </style>
+</head>
+<body>
+  <h1>WP Trend Watcher — Reports</h1>
+  <p class="meta">Weekly WordPress ecosystem trend reports.</p>
+  <ul>
+    <li><a href="2026-06-12.html">2026-06-12</a></li>
+  </ul>
+</body>
+</html>

--- a/sources.example.yaml
+++ b/sources.example.yaml
@@ -1,0 +1,53 @@
+# WP Trend Watcher — Source Configuration
+#
+# Copy this file to sources.yaml and customize.
+# If sources.yaml is missing, the built-in defaults are used.
+#
+# Each source needs: id, name, feedUrl
+# Optional: url (homepage), tier (1 or 2, default 2)
+
+sources:
+  # ── Tier 1: Core WordPress sources ──────────────────────────────
+  - id: wordpress-developer-blog
+    name: WordPress Developer Blog
+    url: https://developer.wordpress.org/news/
+    feedUrl: https://developer.wordpress.org/news/feed/
+    tier: 1
+
+  - id: make-core
+    name: Make Core
+    url: https://make.wordpress.org/core/
+    feedUrl: https://make.wordpress.org/core/feed/
+    tier: 1
+
+  - id: wordpress-org-news
+    name: WordPress.org News
+    url: https://wordpress.org/news/
+    feedUrl: https://wordpress.org/news/feed/
+    tier: 1
+
+  - id: acf-blog
+    name: ACF Blog
+    url: https://www.advancedcustomfields.com/blog/
+    feedUrl: https://www.advancedcustomfields.com/blog/feed/
+    tier: 1
+
+  # ── Tier 2: Broader ecosystem ──────────────────────────────────
+  - id: gutenberg-times
+    name: Gutenberg Times
+    url: https://gutenbergtimes.com/
+    feedUrl: https://gutenbergtimes.com/feed/
+    tier: 2
+
+  - id: acf-chat-fridays
+    name: ACF Chat Fridays
+    url: https://www.advancedcustomfields.com/blog/tag/acf-chat-fridays/
+    feedUrl: https://www.advancedcustomfields.com/blog/tag/acf-chat-fridays/feed/
+    tier: 2
+
+  # ── Your own sources ───────────────────────────────────────────
+  # - id: my-plugin-blog
+  #   name: My Plugin Blog
+  #   url: https://myplugin.com/
+  #   feedUrl: https://myplugin.com/feed/
+  #   tier: 2

--- a/src/collect/index.ts
+++ b/src/collect/index.ts
@@ -1,5 +1,6 @@
 import Parser from "rss-parser";
-import { sources, type Source } from "../sources.js";
+import { type Source } from "../sources.js";
+import { loadSources } from "../load-sources.js";
 import { writeArticlesJson, type CollectedArticle } from "./storage.js";
 
 type FeedItem = {
@@ -84,6 +85,7 @@ function filterRecentArticles(articles: CollectedArticle[], days: number): Colle
 
 async function main(): Promise<void> {
   const recentDays = parseDaysArg();
+  const sources = await loadSources();
   const sourceCount = sources.length;
   const tier1Count = sources.filter((s) => s.tier === 1).length;
   const tier2Count = sources.filter((s) => s.tier === 2).length;

--- a/src/collect/index.ts
+++ b/src/collect/index.ts
@@ -10,37 +10,28 @@ type FeedItem = {
   isoDate?: string;
 };
 
+type SourceResult = {
+  source: Source;
+  articles: CollectedArticle[];
+  error: string | null;
+};
+
 const parser = new Parser<Record<string, unknown>, FeedItem>({
   timeout: 15_000,
 });
 
-async function collectSource(source: Source): Promise<CollectedArticle[]> {
+async function collectSource(source: Source): Promise<SourceResult> {
   try {
     const feed = await parser.parseURL(source.feedUrl);
-    const latestItem = feed.items[0];
     const articles = feed.items.flatMap((item) => toCollectedArticle(source, item));
 
-    console.log(`\n${source.name}`);
-    console.log(`Feed: ${source.feedUrl}`);
-    console.log(`Items: ${feed.items.length}`);
+    console.log(`  [ok] ${source.name} — ${articles.length} items`);
 
-    if (!latestItem) {
-      console.log("Latest: No items found");
-      return articles;
-    }
-
-    console.log(`Latest title: ${latestItem.title ?? "Untitled"}`);
-    console.log(`Latest URL: ${latestItem.link ?? latestItem.guid ?? "No URL found"}`);
-
-    return articles;
+    return { source, articles, error: null };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-
-    console.error(`\n${source.name}`);
-    console.error(`Feed: ${source.feedUrl}`);
-    console.error(`Error: ${message}`);
-
-    return [];
+    console.error(`  [err] ${source.name} — ${message}`);
+    return { source, articles: [], error: message };
   }
 }
 
@@ -93,26 +84,40 @@ function filterRecentArticles(articles: CollectedArticle[], days: number): Colle
 
 async function main(): Promise<void> {
   const recentDays = parseDaysArg();
-  const tierOneSources = sources.filter((source) => source.tier === 1);
+  const sourceCount = sources.length;
+  const tier1Count = sources.filter((s) => s.tier === 1).length;
+  const tier2Count = sources.filter((s) => s.tier === 2).length;
 
-  console.log(`Collecting ${tierOneSources.length} Tier 1 sources...`);
+  console.log(`Collecting from ${sourceCount} sources (${tier1Count} Tier 1, ${tier2Count} Tier 2)...`);
   if (recentDays > 0) {
-    console.log(`Filtering to articles from the last ${recentDays} days`);
+    console.log(`Filtering to articles from the last ${recentDays} days\n`);
   }
 
-  const articleGroups = await Promise.all(tierOneSources.map((source) => collectSource(source)));
-  let articles = articleGroups.flat();
+  const results = await Promise.all(sources.map((source) => collectSource(source)));
 
-  const totalCollected = articles.length;
-  articles = filterRecentArticles(articles, recentDays);
-  const filteredOut = totalCollected - articles.length;
+  const totalCollected = results.reduce((sum, r) => sum + r.articles.length, 0);
+  const errors = results.filter((r) => r.error !== null);
+  const errorCount = errors.length;
+
+  let allArticles = results.flatMap((r) => r.articles);
+  allArticles = filterRecentArticles(allArticles, recentDays);
+  const filteredOut = totalCollected - allArticles.length;
+
+  const result = await writeArticlesJson({ articles: allArticles });
+
+  // Summary
+  console.log("");
+  console.log(`Collection complete`);
+  console.log(`  Saved:      ${result.articleCount} articles to ${result.filePath}`);
   if (filteredOut > 0) {
-    console.log(`\nFiltered out ${filteredOut} articles older than ${recentDays} days`);
+    console.log(`  Filtered:   ${filteredOut} older than ${recentDays} days`);
   }
-
-  const result = await writeArticlesJson({ articles });
-
-  console.log(`\nSaved ${result.articleCount} articles to ${result.filePath}`);
+  if (errorCount > 0) {
+    console.log(`  Errors:     ${errorCount} source(s) failed`);
+    for (const e of errors) {
+      console.log(`    - ${e.source.name}: ${e.error}`);
+    }
+  }
 }
 
 await main();

--- a/src/load-sources.ts
+++ b/src/load-sources.ts
@@ -1,0 +1,68 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import yaml from "js-yaml";
+import { sources as defaultSources, type Source, type SourceTier } from "./sources.js";
+
+type RawSource = {
+  id?: string;
+  name?: string;
+  url?: string;
+  feedUrl?: string;
+  tier?: number;
+};
+
+type RawSourcesFile = {
+  sources?: RawSource[];
+};
+
+export async function loadSources(rootDir: string = process.cwd()): Promise<Source[]> {
+  const yamlPath = join(rootDir, "sources.yaml");
+
+  try {
+    const raw = await readFile(yamlPath, "utf8");
+    const parsed = yaml.load(raw) as RawSourcesFile;
+
+    if (!parsed || !Array.isArray(parsed.sources) || parsed.sources.length === 0) {
+      console.warn(`sources.yaml found but empty or invalid, using default sources`);
+      return defaultSources;
+    }
+
+    const sources: Source[] = [];
+    for (const [index, raw] of parsed.sources.entries()) {
+      const source = validateSource(raw, index);
+      if (source) {
+        sources.push(source);
+      }
+    }
+
+    if (sources.length === 0) {
+      console.warn(`sources.yaml found but no valid sources, using default sources`);
+      return defaultSources;
+    }
+
+    console.log(`Loaded ${sources.length} sources from sources.yaml`);
+    return sources;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return defaultSources;
+    }
+    throw error;
+  }
+}
+
+function validateSource(raw: RawSource, index: number): Source | null {
+  if (!raw.id || !raw.name || !raw.feedUrl) {
+    console.warn(`  Skipping source at index ${index}: missing required fields (id, name, feedUrl)`);
+    return null;
+  }
+
+  const tier = raw.tier === 1 ? 1 : 2;
+
+  return {
+    id: raw.id,
+    name: raw.name,
+    url: raw.url ?? "",
+    feedUrl: raw.feedUrl,
+    tier,
+  };
+}

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -37,4 +37,18 @@ export const sources: Source[] = [
     feedUrl: "https://www.advancedcustomfields.com/blog/feed/",
     tier: 1,
   },
+  {
+    id: "gutenberg-times",
+    name: "Gutenberg Times",
+    url: "https://gutenbergtimes.com/",
+    feedUrl: "https://gutenbergtimes.com/feed/",
+    tier: 2,
+  },
+  {
+    id: "acf-chat-fridays",
+    name: "ACF Chat Fridays",
+    url: "https://www.advancedcustomfields.com/blog/tag/acf-chat-fridays/",
+    feedUrl: "https://www.advancedcustomfields.com/blog/tag/acf-chat-fridays/feed/",
+    tier: 2,
+  },
 ];

--- a/src/summarize/html.ts
+++ b/src/summarize/html.ts
@@ -1,0 +1,229 @@
+import { readFile, writeFile, readdir } from "node:fs/promises";
+import { join, basename, dirname } from "node:path";
+
+/**
+ * Minimal CSS for report pages.
+ *
+ * Single-column, system font stack, dark-on-light readable design.
+ */
+const STYLESHEET = `
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.6;
+  color: #1a1a1a;
+  background: #fff;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+h1 { font-size: 1.75rem; margin-bottom: 0.5rem; line-height: 1.3; }
+h2 { font-size: 1.35rem; margin-top: 2rem; margin-bottom: 0.5rem; border-bottom: 1px solid #e0e0e0; padding-bottom: 0.25rem; }
+h3 { font-size: 1.1rem; margin-top: 1.5rem; margin-bottom: 0.4rem; }
+p { margin-bottom: 1rem; }
+ul { margin: 0 0 1rem 1.5rem; }
+li { margin-bottom: 0.35rem; }
+a { color: #0969da; text-decoration: none; }
+a:hover { text-decoration: underline; }
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.9em;
+  background: #f0f0f0;
+  padding: 0.15em 0.35em;
+  border-radius: 3px;
+}
+pre {
+  background: #f6f8fa;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  margin-bottom: 1rem;
+}
+pre code { background: none; padding: 0; font-size: 0.85em; }
+hr { border: none; border-top: 1px solid #e0e0e0; margin: 2rem 0; }
+strong { font-weight: 600; }
+em { font-style: italic; }
+.meta { color: #666; font-size: 0.85rem; margin-bottom: 2rem; }
+`.trim();
+
+/**
+ * Convert a simple Markdown string to HTML.
+ *
+ * Handles the subset found in wp-trend-watcher reports: headings (h1–h3),
+ * paragraphs, unordered lists, links, bold, italic, inline code, horizontal
+ * rules, and HTML comments. Not a general-purpose parser.
+ */
+function markdownToHtml(md: string): string {
+  const lines = md.split("\n");
+  const out: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // HTML comment — pass through
+    if (/^\s*<!--/.test(line)) {
+      out.push(line);
+      i++;
+      continue;
+    }
+
+    // Horizontal rule
+    if (/^---+\s*$/.test(line)) {
+      out.push("<hr>");
+      i++;
+      continue;
+    }
+
+    // Headings
+    const headingMatch = line.match(/^(#{1,3})\s+(.*)/);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const text = inlineFormat(headingMatch[2]);
+      out.push(`<h${level}>${text}</h${level}>`);
+      i++;
+      continue;
+    }
+
+    // Unordered list
+    if (/^[*-]\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^[*-]\s+/.test(lines[i])) {
+        items.push(`<li>${inlineFormat(lines[i].replace(/^[-*]\s+/, ""))}</li>`);
+        i++;
+      }
+      out.push(`<ul>\n${items.join("\n")}\n</ul>`);
+      continue;
+    }
+
+    // Blank line — skip
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    // Paragraph — collect consecutive non-blank lines
+    const paraLines: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== "" &&
+      !/^(#{1,3})\s+/.test(lines[i]) &&
+      !/^[-*]\s+/.test(lines[i]) &&
+      !/^---+\s*$/.test(lines[i]) &&
+      !/^\s*<!--/.test(lines[i])
+    ) {
+      paraLines.push(lines[i]);
+      i++;
+    }
+    if (paraLines.length > 0) {
+      out.push(`<p>${inlineFormat(paraLines.join("\n"))}</p>`);
+    }
+  }
+
+  return out.join("\n");
+}
+
+/**
+ * Apply inline formatting: bold, italic, code, and links.
+ */
+function inlineFormat(text: string): string {
+  return (
+    text
+      // Inline code (must come before bold/italic to avoid conflicts)
+      .replace(/`([^`]+)`/g, "<code>$1</code>")
+      // Bold
+      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+      // Italic
+      .replace(/\*(.+?)\*/g, "<em>$1</em>")
+      // Links
+      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
+  );
+}
+
+/**
+ * Extract the report date from a Markdown filename like "2026-06-12.md".
+ */
+function dateFromFilename(filePath: string): string {
+  const name = basename(filePath, ".md");
+  return name;
+}
+
+/**
+ * Generate a styled HTML report from a Markdown report file.
+ *
+ * Reads the Markdown, converts to HTML with inline styles, and writes a
+ * self-contained HTML file alongside the original.
+ *
+ * @param mdPath - Absolute path to the Markdown report (e.g. reports/2026-06-12.md)
+ * @returns Absolute path to the generated HTML file
+ */
+export async function generateHtmlReport(mdPath: string): Promise<string> {
+  const md = await readFile(mdPath, "utf8");
+  const date = dateFromFilename(mdPath);
+  const htmlContent = markdownToHtml(md);
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>WordPress Trend Report — ${date}</title>
+  <style>${STYLESHEET}</style>
+</head>
+<body>
+  ${htmlContent}
+</body>
+</html>`;
+
+  const outPath = join(dirname(mdPath), `${date}.html`);
+  await writeFile(outPath, html, "utf8");
+  return outPath;
+}
+
+/**
+ * Generate the index.html listing page for all HTML reports in a directory.
+ *
+ * Scans for *.html files (skipping index.html itself) and produces a
+ * minimal listing page sorted by date descending.
+ *
+ * @param reportsDir - Absolute path to the reports directory
+ * @returns Absolute path to the generated index.html
+ */
+export async function generateIndexPage(reportsDir: string): Promise<string> {
+  const files = await readdir(reportsDir);
+  const htmlFiles = files
+    .filter((f) => f.endsWith(".html") && f !== "index.html")
+    .sort()
+    .reverse();
+
+  const links = htmlFiles
+    .map((f) => {
+      const date = f.replace(".html", "");
+      return `    <li><a href="${f}">${date}</a></li>`;
+    })
+    .join("\n");
+
+  const indexHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>WP Trend Watcher — Reports</title>
+  <style>${STYLESHEET}
+h1 { border-bottom: none; }
+  </style>
+</head>
+<body>
+  <h1>WP Trend Watcher — Reports</h1>
+  <p class="meta">Weekly WordPress ecosystem trend reports.</p>
+  <ul>
+${links}
+  </ul>
+</body>
+</html>`;
+
+  const outPath = join(reportsDir, "index.html");
+  await writeFile(outPath, indexHtml, "utf8");
+  return outPath;
+}

--- a/src/summarize/index-page.ts
+++ b/src/summarize/index-page.ts
@@ -1,0 +1,15 @@
+import { join } from "node:path";
+import { generateIndexPage } from "./html.js";
+
+/**
+ * Standalone script to regenerate reports/index.html.
+ *
+ * Scans the reports/ directory for *.html files and produces a listing page.
+ */
+async function main(): Promise<void> {
+  const reportsDir = join(process.cwd(), "reports");
+  const indexPath = await generateIndexPage(reportsDir);
+  console.log(`Index page written: ${indexPath}`);
+}
+
+await main();

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { createProvider, type SummarizeResult } from "../providers.js";
 import { fetchArticleContent } from "./content.js";
+import { generateHtmlReport, generateIndexPage } from "./html.js";
 
 // --- Types ---
 
@@ -411,6 +412,25 @@ async function main(): Promise<void> {
   await writeFile(outputPath, report, "utf8");
 
   console.log(`Report written: ${outputPath}`);
+
+  // 6. Generate HTML report (non-blocking — warn on failure)
+  try {
+    const htmlPath = await generateHtmlReport(outputPath);
+    console.log(`HTML report written: ${htmlPath}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`Warning: HTML report generation failed: ${message}`);
+  }
+
+  // 7. Regenerate index page (non-blocking)
+  try {
+    const reportsDir = join(process.cwd(), "reports");
+    const indexPath = await generateIndexPage(reportsDir);
+    console.log(`Index page written: ${indexPath}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`Warning: Index page generation failed: ${message}`);
+  }
 }
 
 await main();


### PR DESCRIPTION
## Phase 2 Complete

Closes #1

### What's included

**Collection & Sources (v0.1.3–v0.1.4)**
- 6 sources: 4 Tier 1 (Dev Blog, Make Core, WP News, ACF) + 2 Tier 2 (Gutenberg Times, ACF Chat Fridays)
- Clean collection summary with article counts, filtered counts, and source error reporting
- `sources.yaml` for user-customizable sources with fallback to TypeScript defaults

**HTML Reports & GitHub Pages (v0.1.5)**
- `src/summarize/html.ts` — self-contained MD→HTML converter with inline CSS (no deps)
- `src/summarize/index-page.ts` — auto-generated `reports/index.html` listing page
- `.github/workflows/pages.yml` — deploys `reports/` to GitHub Pages on push to main
- HTML generation is non-blocking in the summarize flow (try/catch with warnings)

**Release automation**
- `.github/workflows/release.yml` — auto-creates GitHub Releases on `v*` tag push with generated release notes

### Files changed
- `src/summarize/html.ts` (new) — MD→HTML converter + index generator
- `src/summarize/index-page.ts` (new) — standalone `pnpm index-page` script
- `src/summarize/index.ts` — hooks HTML generation into summarize flow
- `.github/workflows/pages.yml` (new) — GitHub Pages deploy
- `.github/workflows/release.yml` (new) — auto-release on tag push
- `README.md` — HTML Reports section, Phase 2 status, changelog entries
- `package.json` — `index-page` script, version → 0.1.5
- `reports/2026-06-12.html` (new) — first generated HTML report
- `reports/index.html` (new) — report listing page

### Verification
- `pnpm typecheck` — clean
- `pnpm test` — 2/2 pass
- HTML reports are self-contained (no external CSS/JS)
- Manually verified HTML rendering in browser

### Post-merge
- Configure GitHub Pages: Settings → Pages → Source: GitHub Actions
- Push a tag to trigger the release workflow: `git tag v0.2.0 && git push --tags`