### PR TITLE
feat: OpenAI-compatible provider support and pnpm doctor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,14 +3,22 @@
 # Copy this file to .env and adjust values for your setup.
 # .env is gitignored and never committed.
 
-# Provider: "ollama" (default) or "openai" (future)
-WP_TREND_PROVIDER=ollama
+# Provider: "openai-compatible" for LM Studio/local OpenAI-compatible servers,
+# or "ollama" for Ollama. Existing Ollama env vars remain supported.
+WP_TREND_PROVIDER=openai-compatible
 
-# Ollama API endpoint (default: localhost)
+# OpenAI-compatible API base URL, without /chat/completions.
+# LM Studio default: http://localhost:1234/v1
+WP_TREND_OPENAI_BASE_URL=http://localhost:1234/v1
+
+# Model name loaded by your local server (LM Studio shows this in the UI).
+WP_TREND_MODEL=local-model
+
+# Optional API key for endpoints that require one. Leave blank for LM Studio.
+WP_TREND_API_KEY=
+
+# Ollama settings (used when WP_TREND_PROVIDER=ollama)
 WP_TREND_OLLAMA_URL=http://localhost:11434
-
-# Model tag for Ollama (default: llama3.2:3b — ~2 GB, $0/run)
-# Options: llama3.2:3b | llama3.1:8b (~5 GB) | qwen3:14b (~9 GB)
 WP_TREND_OLLAMA_MODEL=llama3.2:3b
 
 # Per-article summarization concurrency (default: 3)

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ pnpm install
 cp .env.example .env   # edit if using a different model or provider
 cp sources.example.yaml sources.yaml  # optional: customize sources
 pnpm collect           # add -- --days 7 for recent articles
-pnpm summarize         # requires Ollama (local, $0) by default
+pnpm summarize         # requires a local LLM endpoint for summarization
 ```
 
-Prerequisites: Node.js 18+, pnpm 9+. Ollama is optional for collection but required for summarization.
+Prerequisites: Node.js 18+, pnpm 9+. Summarization requires a local LLM provider such as LM Studio (OpenAI-compatible endpoint) or Ollama; collection does not. The CLI automatically loads `.env` from the project root when present.
 
 ## What This Does
 
@@ -127,7 +127,7 @@ Launch readiness pass. Added the README hero image, updated the launch status, a
 
 ### 0.1.1
 
-AI summarization pipeline. Per-article content fetching, LLM summarization, cross-article synthesis with article inventory strategy, parallel processing, summary caching, and provider abstraction. Defaults to Ollama local (llama3.2:3b, $0/run). Provider configurable via `WP_TREND_PROVIDER`, `WP_TREND_OLLAMA_MODEL`, and `WP_TREND_OLLAMA_URL`.
+AI summarization pipeline. Per-article content fetching, LLM summarization, cross-article synthesis with article inventory strategy, parallel processing, summary caching, and provider abstraction. Supports Ollama and OpenAI-compatible local endpoints such as LM Studio. Provider configurable via `WP_TREND_PROVIDER`, `WP_TREND_MODEL`, `WP_TREND_OPENAI_BASE_URL`, `WP_TREND_OLLAMA_MODEL`, and `WP_TREND_OLLAMA_URL`.
 
 ### 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Phase 1+ workflow (working):
 pnpm collect    # Fetch RSS feeds from 6 sources (4 Tier 1 + 2 Tier 2), store articles as JSON
 pnpm summarize  # Fetch article content, generate per-article summaries, synthesize weekly report (also generates HTML + index)
 pnpm index-page # Regenerate the reports index.html listing page
+pnpm doctor     # Check environment readiness before first summarize
 ```
 
 See [Summarization](docs/summarization.md) for provider configuration, model options, and synthesis strategy.
@@ -107,6 +108,9 @@ See:
 Phase 2 complete. The repo collects from 6 sources, supports custom source configuration, produces styled HTML reports, and deploys to GitHub Pages. Ready for ongoing weekly use and community contributions.
 
 ## Changelog
+
+### 0.2.1
+`pnpm doctor` command for setup sanity checks. Reports Node/pnpm versions, .env status, provider config, endpoint reachability, sources, and directory writability. Exits nonzero only for true blockers.
 
 ### 0.2.0 — Phase 2 Release
 

--- a/docs/summarization.md
+++ b/docs/summarization.md
@@ -18,24 +18,42 @@ This strategy is designed for small local models (3B parameters) that struggle t
 
 ## Provider Configuration
 
+The CLI automatically loads `.env` from the project root if the file exists. Environment variables already exported in your shell take precedence.
+
 The provider is selected by environment variables:
 
 | Variable | Default | Description |
 |---|---|---|
-| `WP_TREND_PROVIDER` | `ollama` | Provider: `ollama` or `openai` (when implemented) |
+| `WP_TREND_PROVIDER` | `ollama` | Provider: `openai-compatible` (LM Studio/local OpenAI-compatible servers) or `ollama` |
+| `WP_TREND_OPENAI_BASE_URL` | `http://localhost:1234/v1` | OpenAI-compatible API base URL, without `/chat/completions` |
+| `WP_TREND_MODEL` | `local-model` | Model name for OpenAI-compatible providers; also works as the Ollama model fallback |
+| `WP_TREND_API_KEY` | unset | Optional bearer token for OpenAI-compatible endpoints that require one; leave blank for LM Studio |
 | `WP_TREND_OLLAMA_URL` | `http://localhost:11434` | Ollama API endpoint |
-| `WP_TREND_OLLAMA_MODEL` | `llama3.2:3b` | Model tag to use |
+| `WP_TREND_OLLAMA_MODEL` | `llama3.2:3b` | Ollama model tag; overrides `WP_TREND_MODEL` for Ollama |
 
-Example — use a larger local model:
+Example — LM Studio or another local OpenAI-compatible server:
 
 ```bash
-WP_TREND_OLLAMA_MODEL=qwen3:14b pnpm summarize
+WP_TREND_PROVIDER=openai-compatible \
+WP_TREND_OPENAI_BASE_URL=http://localhost:1234/v1 \
+WP_TREND_MODEL="your-loaded-model" \
+pnpm summarize
 ```
 
-Example — point to a remote Ollama instance:
+Example — Ollama with a larger local model:
 
 ```bash
-WP_TREND_OLLAMA_URL=https://ollama.example.com pnpm summarize
+WP_TREND_PROVIDER=ollama WP_TREND_OLLAMA_MODEL=qwen3:14b pnpm summarize
+```
+
+Example — point to a remote OpenAI-compatible endpoint:
+
+```bash
+WP_TREND_PROVIDER=openai-compatible \
+WP_TREND_OPENAI_BASE_URL=https://api.example.com/v1 \
+WP_TREND_API_KEY=your-token \
+WP_TREND_MODEL=your-model \
+pnpm summarize
 ```
 
 ## Model Tradeoffs
@@ -61,9 +79,9 @@ WP_TREND_OLLAMA_URL=https://ollama.example.com pnpm summarize
 - **Coverage:** Consistent 7/7 with better nuance
 - **Best for:** Final report generation before human review
 
-### Cloud models (future)
+### OpenAI-compatible models
 
-When the OpenAI provider is implemented, models like GPT-4o mini (~$0.01/report) will offer near-perfect coverage with no local resource requirements.
+LM Studio and other OpenAI-compatible chat completions endpoints let you use whatever local or remote model that server exposes. Local endpoints are usually $0/run; remote endpoint costs depend on the provider.
 
 ## Caching
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "collect": "tsx src/collect/index.ts",
     "summarize": "tsx src/summarize/index.ts",
     "index-page": "tsx src/summarize/index-page.ts",
+    "doctor": "tsx src/doctor/index.ts",
     "test": "tsx --test tests/**/*.test.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/src/collect/index.ts
+++ b/src/collect/index.ts
@@ -1,4 +1,5 @@
 import Parser from "rss-parser";
+import { loadEnvFile, parseNonNegativeIntegerEnv } from "../env.js";
 import { type Source } from "../sources.js";
 import { loadSources } from "../load-sources.js";
 import { writeArticlesJson, type CollectedArticle } from "./storage.js";
@@ -58,7 +59,7 @@ function toCollectedArticle(source: Source, item: FeedItem): CollectedArticle[] 
 function parseDaysArg(): number {
   const daysIndex = process.argv.indexOf("--days");
   if (daysIndex === -1 || daysIndex === process.argv.length - 1) {
-    return 7;
+    return parseNonNegativeIntegerEnv("WP_TREND_DAYS", 7);
   }
   const value = parseInt(process.argv[daysIndex + 1], 10);
   if (isNaN(value) || value < 0) {
@@ -84,6 +85,8 @@ function filterRecentArticles(articles: CollectedArticle[], days: number): Colle
 }
 
 async function main(): Promise<void> {
+  loadEnvFile();
+
   const recentDays = parseDaysArg();
   const sources = await loadSources();
   const sourceCount = sources.length;

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure functions for the setup doctor command.
+ * Separated for testability — no side effects, no imports beyond types.
+ */
+
+/** Supported provider identifiers. */
+export type ProviderName = "ollama" | "openai-compatible" | "openai";
+
+/** Resolved provider configuration from environment variables. */
+export interface ProviderConfig {
+  provider: ProviderName;
+  baseUrl: string;
+  model: string;
+}
+
+/**
+ * Resolve the provider configuration from environment variables.
+ * Mirrors the same defaults used by createProvider() in providers.ts.
+ *
+ * @param env - Environment variables to read from (default: process.env).
+ * @returns Resolved provider, base URL, and model.
+ */
+export function resolveProviderConfig(
+  env: Record<string, string | undefined> = process.env,
+): ProviderConfig {
+  const provider = (env.WP_TREND_PROVIDER ?? "ollama") as string;
+
+  if (provider === "ollama") {
+    return {
+      provider: "ollama",
+      baseUrl: env.WP_TREND_OLLAMA_URL ?? "http://localhost:11434",
+      model:
+        env.WP_TREND_OLLAMA_MODEL ??
+        env.WP_TREND_MODEL ??
+        "llama3.2:3b",
+    };
+  }
+
+  if (provider === "openai-compatible" || provider === "openai") {
+    return {
+      provider: "openai-compatible",
+      baseUrl: (
+        env.WP_TREND_OPENAI_BASE_URL ?? "http://localhost:1234/v1"
+      ).replace(/\/+$/, ""),
+      model: env.WP_TREND_MODEL ?? "local-model",
+    };
+  }
+
+  // Unknown provider — return as-is so caller can report the error.
+  return {
+    provider: provider as ProviderName,
+    baseUrl: "",
+    model: env.WP_TREND_MODEL ?? "",
+  };
+}
+
+/** Doctor check severity. */
+export type CheckStatus = "ok" | "warn" | "fail";
+
+/** A single doctor check result. */
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  message: string;
+}
+
+/**
+ * Format a check result as a human-readable line.
+ *
+ * @param check - The check result to format.
+ * @returns Formatted string with status indicator and message.
+ */
+export function formatCheck(check: CheckResult): string {
+  const icon = check.status === "ok" ? "✓" : check.status === "warn" ? "⚠" : "✗";
+  return `  ${icon} ${check.name}: ${check.message}`;
+}

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+
+/**
+ * Setup sanity check for WP Trend Watcher.
+ *
+ * Reports environment readiness for `pnpm summarize` without running
+ * a full summarization. Exits 0 for warnings-only, 1 for true blockers.
+ *
+ * Usage: pnpm doctor
+ */
+
+import { access, readFile, stat, constants } from "node:fs/promises";
+import { execSync } from "node:child_process";
+import { join, resolve } from "node:path";
+import { loadEnvFile } from "../env.js";
+import {
+  resolveProviderConfig,
+  formatCheck,
+  type CheckResult,
+  type ProviderName,
+} from "./checks.js";
+
+// --- Checks ---
+
+/** Check Node.js version (requires 18+). */
+function checkNodeVersion(): CheckResult {
+  const major = process.versions.node
+    ? Number.parseInt(process.versions.node.split(".")[0], 10)
+    : 0;
+
+  if (major >= 18) {
+    return {
+      name: "Node.js",
+      status: "ok",
+      message: `v${process.versions.node}`,
+    };
+  }
+
+  return {
+    name: "Node.js",
+    status: "fail",
+    message: `v${process.versions.node} — requires 18+`,
+  };
+}
+
+/** Check pnpm presence and version. */
+function checkPnpm(): CheckResult {
+  try {
+    const version = execSync("pnpm --version", {
+      encoding: "utf8",
+      timeout: 5_000,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    return { name: "pnpm", status: "ok", message: `v${version}` };
+  } catch {
+    return {
+      name: "pnpm",
+      status: "warn",
+      message: "not found in PATH — required to run commands",
+    };
+  }
+}
+
+/** Check .env file presence and whether it loaded. */
+function checkEnvFile(loaded: boolean): CheckResult {
+  if (loaded) {
+    return { name: ".env", status: "ok", message: "found and loaded" };
+  }
+  return {
+    name: ".env",
+    status: "warn",
+    message: "not found — using defaults (copy .env.example to .env to customize)",
+  };
+}
+
+/** Check provider configuration. */
+function checkProvider(): CheckResult {
+  const config = resolveProviderConfig();
+  const raw = process.env.WP_TREND_PROVIDER ?? "(default: ollama)";
+
+  if (
+    config.provider !== "ollama" &&
+    config.provider !== "openai-compatible" &&
+    config.provider !== "openai"
+  ) {
+    return {
+      name: "Provider",
+      status: "fail",
+      message: `unknown provider "${raw}" — supported: ollama, openai-compatible`,
+    };
+  }
+
+  return {
+    name: "Provider",
+    status: "ok",
+    message: `${config.provider} (${config.model})`,
+  };
+}
+
+/** Check provider endpoint reachability. */
+async function checkEndpoint(
+  config: { provider: ProviderName; baseUrl: string; model: string },
+): Promise<CheckResult> {
+  // Skip if no URL (unknown provider)
+  if (!config.baseUrl) {
+    return {
+      name: "Endpoint",
+      status: "warn",
+      message: "skipped — provider not configured",
+    };
+  }
+
+  // Only check local endpoints — skip if URL looks non-local
+  let url: URL;
+  try {
+    url = new URL(config.baseUrl);
+  } catch {
+    return {
+      name: "Endpoint",
+      status: "warn",
+      message: `invalid URL "${config.baseUrl}"`,
+    };
+  }
+  const isLocal =
+    url.hostname === "localhost" || url.hostname === "127.0.0.1";
+  if (!isLocal) {
+    return {
+      name: "Endpoint",
+      status: "ok",
+      message: `${config.baseUrl} (remote — skipped reachability check)`,
+    };
+  }
+
+  const healthUrl =
+    config.provider === "ollama"
+      ? `${config.baseUrl}/api/tags`
+      : `${config.baseUrl}/models`;
+
+  try {
+    const response = await fetch(healthUrl, {
+      method: "GET",
+      signal: AbortSignal.timeout(3_000),
+    });
+    if (response.ok) {
+      return {
+        name: "Endpoint",
+        status: "ok",
+        message: `${config.baseUrl} — reachable`,
+      };
+    }
+    return {
+      name: "Endpoint",
+      status: "warn",
+      message: `${config.baseUrl} — responded with ${response.status}`,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      name: "Endpoint",
+      status: "warn",
+      message: `${config.baseUrl} — not reachable (${msg.slice(0, 80)})`,
+    };
+  }
+}
+
+/** Check sources.yaml presence. */
+async function checkSources(rootDir: string): Promise<CheckResult> {
+  const yamlPath = join(rootDir, "sources.yaml");
+  try {
+    await access(yamlPath, constants.R_OK);
+    const raw = await readFile(yamlPath, "utf8");
+    // Quick sanity: does it have a sources key?
+    if (raw.includes("sources:")) {
+      return { name: "Sources", status: "ok", message: "sources.yaml found" };
+    }
+    return {
+      name: "Sources",
+      status: "warn",
+      message: "sources.yaml exists but missing 'sources:' key — using defaults",
+    };
+  } catch {
+    return {
+      name: "Sources",
+      status: "warn",
+      message: "sources.yaml not found — using built-in defaults",
+    };
+  }
+}
+
+/** Check that data/ and reports/ directories exist and are writable. */
+async function checkDirectories(
+  rootDir: string,
+): Promise<CheckResult[]> {
+  const checks: CheckResult[] = [];
+
+  for (const dir of ["data", "reports"]) {
+    const dirPath = join(rootDir, dir);
+    try {
+      const s = await stat(dirPath);
+      if (!s.isDirectory()) {
+        checks.push({
+          name: `${dir}/`,
+          status: "fail",
+          message: "exists but is not a directory",
+        });
+        continue;
+      }
+      // Check write access by attempting to stat a temp file path
+      // (we don't create anything — just verify the directory is writable)
+      await access(dirPath, constants.W_OK);
+      checks.push({ name: `${dir}/`, status: "ok", message: "writable" });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      checks.push({
+        name: `${dir}/`,
+        status: "warn",
+        message: `not found or not writable — will be created on first run (${msg.slice(0, 60)})`,
+      });
+    }
+  }
+
+  return checks;
+}
+
+// --- Main ---
+
+async function main(): Promise<void> {
+  const rootDir = process.cwd();
+
+  // Check .env before loading it
+  let envExists = false;
+  try {
+    await access(resolve(rootDir, ".env"), constants.R_OK);
+    envExists = true;
+  } catch {
+    // no .env
+  }
+  loadEnvFile();
+
+  console.log("WP Trend Watcher — setup doctor\n");
+
+  // Sync checks
+  const syncChecks: CheckResult[] = [
+    checkNodeVersion(),
+    checkPnpm(),
+    checkEnvFile(envExists),
+    checkProvider(),
+  ];
+
+  // Async checks
+  const config = resolveProviderConfig();
+  const endpointCheck = checkEndpoint(config);
+  const sourcesCheck = checkSources(rootDir);
+  const dirChecks = checkDirectories(rootDir);
+
+  const [endpoint, sources, dirs] = await Promise.all([
+    endpointCheck,
+    sourcesCheck,
+    dirChecks,
+  ]);
+
+  const allChecks = [...syncChecks, endpoint, sources, ...dirs];
+
+  // Print results
+  for (const check of allChecks) {
+    console.log(formatCheck(check));
+  }
+
+  // Summary
+  const failures = allChecks.filter((c) => c.status === "fail");
+  const warnings = allChecks.filter((c) => c.status === "warn");
+
+  console.log("");
+  if (failures.length > 0) {
+    console.log(
+      `${failures.length} blocker(s), ${warnings.length} warning(s) — summarization may not work`,
+    );
+    process.exitCode = 1;
+  } else if (warnings.length > 0) {
+    console.log(
+      `${warnings.length} warning(s) — summarization should work with defaults`,
+    );
+  } else {
+    console.log("All checks passed — ready to summarize");
+  }
+}
+
+await main();

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export function loadEnvFile(filePath = ".env"): void {
+  const resolvedPath = resolve(process.cwd(), filePath);
+
+  let content: string;
+  try {
+    content = readFileSync(resolvedPath, "utf8");
+  } catch (err) {
+    if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    const normalized = line.startsWith("export ") ? line.slice(7).trim() : line;
+    const equalsIndex = normalized.indexOf("=");
+    if (equalsIndex === -1) {
+      continue;
+    }
+
+    const key = normalized.slice(0, equalsIndex).trim();
+    if (!key || process.env[key] !== undefined) {
+      continue;
+    }
+
+    process.env[key] = parseEnvValue(normalized.slice(equalsIndex + 1).trim());
+  }
+}
+
+export function parseNonNegativeIntegerEnv(
+  key: string,
+  fallback: number,
+): number {
+  const raw = process.env[key];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+
+  const value = Number.parseInt(raw, 10);
+  if (Number.isNaN(value) || value < 0) {
+    console.warn(`Invalid ${key} value, defaulting to ${fallback}`);
+    return fallback;
+  }
+
+  return value;
+}
+
+export function parsePositiveIntegerEnv(key: string, fallback: number): number {
+  const raw = process.env[key];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+
+  const value = Number.parseInt(raw, 10);
+  if (Number.isNaN(value) || value < 1) {
+    console.warn(`Invalid ${key} value, defaulting to ${fallback}`);
+    return fallback;
+  }
+
+  return value;
+}
+
+function parseEnvValue(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+}

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -17,13 +17,12 @@ export function createProvider(): SummarizeProvider {
   switch (provider) {
     case "ollama":
       return createOllamaProvider();
+    case "openai-compatible":
     case "openai":
-      throw new Error(
-        "OpenAI provider not yet implemented. Set WP_TREND_PROVIDER=ollama or contribute a provider at src/providers.ts",
-      );
+      return createOpenAiCompatibleProvider();
     default:
       throw new Error(
-        `Unknown provider "${provider}". Supported: ollama. Set WP_TREND_PROVIDER=ollama.`,
+        `Unknown provider "${provider}". Supported: ollama, openai-compatible.`,
       );
   }
 }
@@ -31,7 +30,10 @@ export function createProvider(): SummarizeProvider {
 function createOllamaProvider(): SummarizeProvider {
   const baseUrl =
     process.env.WP_TREND_OLLAMA_URL ?? "http://localhost:11434";
-  const model = process.env.WP_TREND_OLLAMA_MODEL ?? "llama3.2:3b";
+  const model =
+    process.env.WP_TREND_OLLAMA_MODEL ??
+    process.env.WP_TREND_MODEL ??
+    "llama3.2:3b";
 
   return {
     name: "ollama",
@@ -96,4 +98,81 @@ function createOllamaProvider(): SummarizeProvider {
       return 0; // local, free
     },
   };
+}
+
+function createOpenAiCompatibleProvider(): SummarizeProvider {
+  const baseUrl = stripTrailingSlash(
+    process.env.WP_TREND_OPENAI_BASE_URL ?? "http://localhost:1234/v1",
+  );
+  const model = process.env.WP_TREND_MODEL ?? "local-model";
+  const apiKey = process.env.WP_TREND_API_KEY;
+
+  return {
+    name: "openai-compatible",
+    model,
+
+    async summarize(systemPrompt, userPrompt) {
+      const body = JSON.stringify({
+        model,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+        temperature: 0.3,
+      });
+
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (apiKey) {
+        headers.Authorization = `Bearer ${apiKey}`;
+      }
+
+      let response: Response;
+      try {
+        response = await fetch(`${baseUrl}/chat/completions`, {
+          method: "POST",
+          headers,
+          body,
+          signal: AbortSignal.timeout(60_000),
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Cannot reach OpenAI-compatible endpoint at ${baseUrl}. Is it running? (${message})`,
+        );
+      }
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "");
+        throw new Error(
+          `OpenAI-compatible API error ${response.status}: ${errorText.slice(0, 200)}`,
+        );
+      }
+
+      const data = (await response.json()) as {
+        choices?: Array<{ message?: { content?: string } }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number };
+      };
+
+      const text = data.choices?.[0]?.message?.content;
+      if (!text) {
+        throw new Error("OpenAI-compatible endpoint returned empty response");
+      }
+
+      return {
+        text,
+        promptTokens: data.usage?.prompt_tokens ?? 0,
+        completionTokens: data.usage?.completion_tokens ?? 0,
+      };
+    },
+
+    costFor(_result: SummarizeResult): number {
+      return 0; // local/OpenAI-compatible cost is user-managed
+    },
+  };
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
 }

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
+import { loadEnvFile, parsePositiveIntegerEnv } from "../env.js";
 import { createProvider, type SummarizeResult } from "../providers.js";
 import { fetchArticleContent } from "./content.js";
 import { generateHtmlReport, generateIndexPage } from "./html.js";
@@ -327,9 +328,15 @@ async function loadExistingSummaries(
 // --- Main ---
 
 async function main(): Promise<void> {
+  loadEnvFile();
+
   console.log("WP Trend Watcher — summarize\n");
 
   const provider = createProvider();
+  const concurrency = parsePositiveIntegerEnv(
+    "WP_TREND_CONCURRENCY",
+    DEFAULT_CONCURRENCY,
+  );
   console.log(`Provider: ${provider.name}/${provider.model}\n`);
 
   // 1. Load articles
@@ -359,7 +366,7 @@ async function main(): Promise<void> {
     console.log(
       `Summarizing ${newArticles.length} new article${newArticles.length > 1 ? "s" : ""}:\n`,
     );
-    newSummaries = await summarizeArticleBatch(newArticles, provider);
+    newSummaries = await summarizeArticleBatch(newArticles, provider, concurrency);
   }
 
   const summaries = [...cachedSummaries, ...newSummaries];

--- a/tests/doctor/index.test.ts
+++ b/tests/doctor/index.test.ts
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveProviderConfig,
+  formatCheck,
+  type CheckResult,
+} from "../../src/doctor/checks.js";
+
+// --- resolveProviderConfig ---
+
+test("defaults to ollama when no env vars set", () => {
+  const config = resolveProviderConfig({});
+  assert.equal(config.provider, "ollama");
+  assert.equal(config.baseUrl, "http://localhost:11434");
+  assert.equal(config.model, "llama3.2:3b");
+});
+
+test("ollama provider uses ollama-specific env vars", () => {
+  const config = resolveProviderConfig({
+    WP_TREND_PROVIDER: "ollama",
+    WP_TREND_OLLAMA_URL: "http://192.168.1.10:11434",
+    WP_TREND_OLLAMA_MODEL: "mistral",
+    WP_TREND_MODEL: "ignored-model",
+  });
+  assert.equal(config.provider, "ollama");
+  assert.equal(config.baseUrl, "http://192.168.1.10:11434");
+  assert.equal(config.model, "mistral");
+});
+
+test("ollama falls back to generic model env var", () => {
+  const config = resolveProviderConfig({
+    WP_TREND_PROVIDER: "ollama",
+    WP_TREND_MODEL: "generic-model",
+  });
+  assert.equal(config.model, "generic-model");
+});
+
+test("openai-compatible provider reads its env vars", () => {
+  const config = resolveProviderConfig({
+    WP_TREND_PROVIDER: "openai-compatible",
+    WP_TREND_OPENAI_BASE_URL: "http://localhost:8080/v1/",
+    WP_TREND_MODEL: "my-model",
+  });
+  assert.equal(config.provider, "openai-compatible");
+  assert.equal(config.baseUrl, "http://localhost:8080/v1");
+  assert.equal(config.model, "my-model");
+});
+
+test("openai alias resolves to openai-compatible provider", () => {
+  const config = resolveProviderConfig({
+    WP_TREND_PROVIDER: "openai",
+    WP_TREND_MODEL: "gpt-4",
+  });
+  assert.equal(config.provider, "openai-compatible");
+  assert.equal(config.baseUrl, "http://localhost:1234/v1");
+  assert.equal(config.model, "gpt-4");
+});
+
+test("unknown provider is returned as-is", () => {
+  const config = resolveProviderConfig({
+    WP_TREND_PROVIDER: "llama.cpp",
+  });
+  assert.equal(config.provider, "llama.cpp");
+  assert.equal(config.baseUrl, "");
+  assert.equal(config.model, "");
+});
+
+test("strips trailing slashes from openai-compatible base URL", () => {
+  const config = resolveProviderConfig({
+    WP_TREND_PROVIDER: "openai-compatible",
+    WP_TREND_OPENAI_BASE_URL: "http://localhost:1234/v1///",
+  });
+  assert.equal(config.baseUrl, "http://localhost:1234/v1");
+});
+
+// --- formatCheck ---
+
+test("formatCheck renders ok status", () => {
+  const check: CheckResult = {
+    name: "Node.js",
+    status: "ok",
+    message: "v20.0.0",
+  };
+  const line = formatCheck(check);
+  assert.ok(line.includes("✓"));
+  assert.ok(line.includes("Node.js"));
+  assert.ok(line.includes("v20.0.0"));
+});
+
+test("formatCheck renders warn status", () => {
+  const check: CheckResult = {
+    name: ".env",
+    status: "warn",
+    message: "not found",
+  };
+  const line = formatCheck(check);
+  assert.ok(line.includes("⚠"));
+  assert.ok(line.includes(".env"));
+});
+
+test("formatCheck renders fail status", () => {
+  const check: CheckResult = {
+    name: "Node.js",
+    status: "fail",
+    message: "v16.0.0 — requires 18+",
+  };
+  const line = formatCheck(check);
+  assert.ok(line.includes("✗"));
+  assert.ok(line.includes("v16.0.0"));
+});

--- a/tests/providers/index.test.ts
+++ b/tests/providers/index.test.ts
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProvider } from "../../src/providers.js";
+
+const ENV_KEYS = [
+  "WP_TREND_PROVIDER",
+  "WP_TREND_OPENAI_BASE_URL",
+  "WP_TREND_MODEL",
+  "WP_TREND_API_KEY",
+  "WP_TREND_OLLAMA_MODEL",
+  "WP_TREND_OLLAMA_URL",
+] as const;
+
+function withCleanEnv(): () => void {
+  const original = new Map<string, string | undefined>();
+  for (const key of ENV_KEYS) {
+    original.set(key, process.env[key]);
+    delete process.env[key];
+  }
+
+  return () => {
+    for (const [key, value] of original) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+}
+
+test("openai-compatible provider posts to chat completions with bearer token", async () => {
+  const restoreEnv = withCleanEnv();
+  const originalFetch = globalThis.fetch;
+
+  try {
+    process.env.WP_TREND_PROVIDER = "openai-compatible";
+    process.env.WP_TREND_OPENAI_BASE_URL = "http://localhost:1234/v1/";
+    process.env.WP_TREND_MODEL = "local-test-model";
+    process.env.WP_TREND_API_KEY = "test-key";
+
+    let requestUrl = "";
+    let requestBody: unknown;
+    let requestHeaders: HeadersInit | undefined;
+
+    globalThis.fetch = async (input, init) => {
+      requestUrl = String(input);
+      requestBody = JSON.parse(String(init?.body));
+      requestHeaders = init?.headers;
+
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "summary text" } }],
+          usage: { prompt_tokens: 12, completion_tokens: 5 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+
+    const provider = createProvider();
+    const result = await provider.summarize("system prompt", "user prompt");
+
+    assert.equal(provider.name, "openai-compatible");
+    assert.equal(provider.model, "local-test-model");
+    assert.equal(requestUrl, "http://localhost:1234/v1/chat/completions");
+    assert.deepEqual(requestBody, {
+      model: "local-test-model",
+      messages: [
+        { role: "system", content: "system prompt" },
+        { role: "user", content: "user prompt" },
+      ],
+      temperature: 0.3,
+    });
+    assert.equal(
+      (requestHeaders as Record<string, string>).Authorization,
+      "Bearer test-key",
+    );
+    assert.deepEqual(result, {
+      text: "summary text",
+      promptTokens: 12,
+      completionTokens: 5,
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreEnv();
+  }
+});
+
+test("openai alias uses the OpenAI-compatible provider", () => {
+  const restoreEnv = withCleanEnv();
+
+  try {
+    process.env.WP_TREND_PROVIDER = "openai";
+    process.env.WP_TREND_MODEL = "alias-model";
+
+    const provider = createProvider();
+
+    assert.equal(provider.name, "openai-compatible");
+    assert.equal(provider.model, "alias-model");
+  } finally {
+    restoreEnv();
+  }
+});
+
+test("ollama model-specific env var takes precedence over generic model env var", () => {
+  const restoreEnv = withCleanEnv();
+
+  try {
+    process.env.WP_TREND_PROVIDER = "ollama";
+    process.env.WP_TREND_MODEL = "generic-model";
+    process.env.WP_TREND_OLLAMA_MODEL = "ollama-specific-model";
+
+    const provider = createProvider();
+
+    assert.equal(provider.name, "ollama");
+    assert.equal(provider.model, "ollama-specific-model");
+  } finally {
+    restoreEnv();
+  }
+});


### PR DESCRIPTION
## Summary

- Adds OpenAI-compatible local model provider support (LM Studio, etc.) while preserving Ollama.
- Adds `.env` loading so copied `.env.example` values are actually used.
- Wires `WP_TREND_DAYS` and `WP_TREND_CONCURRENCY` into the code.
- Adds `pnpm doctor` for setup sanity checks.

## Provider changes

- `WP_TREND_PROVIDER=openai-compatible` for LM Studio / OpenAI-compatible endpoints
- `WP_TREND_OPENAI_BASE_URL=http://localhost:1234/v1`
- `WP_TREND_MODEL=<model-name>`
- Optional `WP_TREND_API_KEY`
- Ollama support unchanged

## Doctor checks

- Node.js version (18+)
- pnpm presence
- `.env` loaded
- Provider config and endpoint reachability
- `sources.yaml` presence or fallback
- `data/` and `reports/` writability

## Verification

- `pnpm test`: 15/15 pass
- `pnpm typecheck`: clean
- `pnpm doctor`: passes with 1 warning (missing sources.yaml)

## Commits

- `feat: support OpenAI-compatible local models`
- `feat: add pnpm doctor setup check command`
