### PR TITLE
feat: add pnpm review checklist command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ pnpm collect    # Fetch RSS feeds from 6 sources (4 Tier 1 + 2 Tier 2), store ar
 pnpm summarize  # Fetch article content, generate per-article summaries, synthesize weekly report (also generates HTML + index)
 pnpm index-page # Regenerate the reports index.html listing page
 pnpm doctor     # Check environment readiness before first summarize
+pnpm review     # Review checklist for the latest report
 ```
 
 See [Summarization](docs/summarization.md) for provider configuration, model options, and synthesis strategy.
@@ -108,6 +109,9 @@ See:
 Phase 2 complete. The repo collects from 6 sources, supports custom source configuration, produces styled HTML reports, and deploys to GitHub Pages. Ready for ongoing weekly use and community contributions.
 
 ## Changelog
+
+### 0.2.2
+`pnpm review` command for report review checklists. Checks Weekly Summary, source article references, weasel words, Build Notes, What I'm Watching, markdown link validity, and HTML report presence. Exits nonzero only for true blockers.
 
 ### 0.2.1
 `pnpm doctor` command for setup sanity checks. Reports Node/pnpm versions, .env status, provider config, endpoint reachability, sources, and directory writability. Exits nonzero only for true blockers.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.1.5",
+  "version": "0.2.2",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,
@@ -9,6 +9,7 @@
     "summarize": "tsx src/summarize/index.ts",
     "index-page": "tsx src/summarize/index-page.ts",
     "doctor": "tsx src/doctor/index.ts",
+    "review": "tsx src/review/index.ts",
     "test": "tsx --test tests/**/*.test.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/src/review/checks.ts
+++ b/src/review/checks.ts
@@ -1,0 +1,279 @@
+/**
+ * Pure functions for the report review checklist.
+ * Separated for testability — no side effects, no filesystem imports.
+ */
+
+/** Check severity for the review checklist. */
+export type ReviewStatus = "pass" | "warn" | "fail";
+
+/** A single review checklist result. */
+export interface ReviewCheck {
+  name: string;
+  status: ReviewStatus;
+  message: string;
+}
+
+/** A parsed source article from the Source Articles section. */
+export interface SourceArticle {
+  title: string;
+  url: string;
+}
+
+/**
+ * Extract the body of a markdown report (everything before ## Source Articles).
+ *
+ * @param report - Full markdown content of the report.
+ * @returns The body text (before Source Articles section), or the full text if the marker is absent.
+ */
+export function extractReportBody(report: string): string {
+  const marker = "## Source Articles";
+  const idx = report.indexOf(marker);
+  return idx >= 0 ? report.slice(0, idx) : report;
+}
+
+/**
+ * Parse source articles from the ## Source Articles section of a report.
+ *
+ * @param report - Full markdown content of the report.
+ * @returns Array of parsed source articles with title and URL.
+ */
+export function parseSourceArticles(report: string): SourceArticle[] {
+  const marker = "## Source Articles";
+  const idx = report.indexOf(marker);
+  if (idx < 0) return [];
+
+  const section = report.slice(idx);
+  const articles: SourceArticle[] = [];
+  const linkPattern = /\[([^\]]+)\]\(([^)]+)\)/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = linkPattern.exec(section)) !== null) {
+    articles.push({ title: match[1], url: match[2] });
+  }
+
+  return articles;
+}
+
+/**
+ * Check that the Weekly Summary section exists and is non-empty.
+ *
+ * @param body - The report body (before Source Articles).
+ * @returns Review check result.
+ */
+export function checkWeeklySummary(body: string): ReviewCheck {
+  const marker = "### Weekly Summary";
+  const idx = body.indexOf(marker);
+  if (idx < 0) {
+    return { name: "Weekly Summary", status: "fail", message: "section not found" };
+  }
+
+  const afterMarker = body.slice(idx + marker.length).trim();
+  if (!afterMarker) {
+    return { name: "Weekly Summary", status: "fail", message: "section is empty" };
+  }
+
+  return { name: "Weekly Summary", status: "pass", message: "present" };
+}
+
+/**
+ * Check that every source article is referenced in the report body.
+ *
+ * @param articles - Parsed source articles from the Source Articles section.
+ * @param body - The report body (before Source Articles).
+ * @returns Review check result. Warns for unreferenced articles.
+ */
+export function checkSourceReferences(
+  articles: SourceArticle[],
+  body: string,
+): ReviewCheck {
+  if (articles.length === 0) {
+    return { name: "Source references", status: "warn", message: "no source articles found" };
+  }
+
+  const unreferenced: string[] = [];
+  for (const article of articles) {
+    const titlePresent = body.includes(article.title);
+    const urlPresent = body.includes(article.url);
+    if (!titlePresent && !urlPresent) {
+      unreferenced.push(article.title);
+    }
+  }
+
+  if (unreferenced.length > 0) {
+    const list = unreferenced.slice(0, 3).join(", ");
+    const suffix = unreferenced.length > 3 ? ` (+${unreferenced.length - 3} more)` : "";
+    return {
+      name: "Source references",
+      status: "warn",
+      message: `${unreferenced.length} unreferenced: ${list}${suffix}`,
+    };
+  }
+
+  return {
+    name: "Source references",
+    status: "pass",
+    message: `all ${articles.length} articles referenced`,
+  };
+}
+
+/** Weasel words that signal unsupported or marketing-style claims. */
+const WEASEL_WORDS = [
+  "seamlessly",
+  "robust",
+  "game-changer",
+  "best practices",
+  "cutting-edge",
+  "state-of-the-art",
+  "revolutionary",
+  "unparalleled",
+];
+
+/**
+ * Scan the report body for weasel words that suggest unsupported claims.
+ *
+ * @param body - The report body text.
+ * @returns Review check result. Warns if weasel words are found.
+ */
+export function checkWeaselWords(body: string): ReviewCheck {
+  const lower = body.toLowerCase();
+  const found = WEASEL_WORDS.filter((w) => lower.includes(w));
+
+  if (found.length > 0) {
+    return {
+      name: "Weasel words",
+      status: "warn",
+      message: `found: ${found.join(", ")}`,
+    };
+  }
+
+  return { name: "Weasel words", status: "pass", message: "none detected" };
+}
+
+/**
+ * Check that Build Notes section exists and contains provider/model/cost info.
+ *
+ * @param report - Full markdown content of the report.
+ * @returns Review check result.
+ */
+export function checkBuildNotes(report: string): ReviewCheck {
+  const marker = "## Build Notes";
+  const idx = report.indexOf(marker);
+  if (idx < 0) {
+    return { name: "Build Notes", status: "fail", message: "section not found" };
+  }
+
+  const section = report.slice(idx, idx + 1000);
+  const lower = section.toLowerCase();
+
+  const hasProvider = lower.includes("model:") || lower.includes("provider:");
+  const hasCost = lower.includes("cost") || lower.includes("token");
+
+  if (!hasProvider && !hasCost) {
+    return {
+      name: "Build Notes",
+      status: "warn",
+      message: "present but missing provider/model/cost info",
+    };
+  }
+
+  return { name: "Build Notes", status: "pass", message: "present with metadata" };
+}
+
+/** Placeholder comment that indicates the human hasn't written their note yet. */
+const PLACEHOLDER_PATTERNS = [
+  "TODO",
+  "FIXME",
+  "PLACEHOLDER",
+  "ADD YOUR NOTE",
+  "YOUR OBSERVATION HERE",
+];
+
+/**
+ * Check that the What I'm Watching section exists and has a human-authored note.
+ *
+ * @param report - Full markdown content of the report.
+ * @returns Review check result.
+ */
+export function checkWatchingSection(report: string): ReviewCheck {
+  const marker = "## What I'm Watching";
+  const idx = report.indexOf(marker);
+  if (idx < 0) {
+    return { name: "What I'm Watching", status: "fail", message: "section not found" };
+  }
+
+  const afterMarker = report.slice(idx + marker.length).trim();
+  if (!afterMarker) {
+    return {
+      name: "What I'm Watching",
+      status: "fail",
+      message: "section is empty",
+    };
+  }
+
+  const upper = afterMarker.toUpperCase();
+  for (const pattern of PLACEHOLDER_PATTERNS) {
+    if (upper.includes(pattern)) {
+      return {
+        name: "What I'm Watching",
+        status: "warn",
+        message: "contains placeholder text — needs human note",
+      };
+    }
+  }
+
+  return { name: "What I'm Watching", status: "pass", message: "has human note" };
+}
+
+/**
+ * Check that markdown links are well-formed (no empty []() patterns).
+ *
+ * @param report - Full markdown content of the report.
+ * @returns Review check result.
+ */
+export function checkMarkdownLinks(report: string): ReviewCheck {
+  // Match [](url) — empty text
+  const emptyText = /\[\s*\]\([^)]+\)/g;
+  // Match [text]() — empty url
+  const emptyUrl = /\[[^\]]+\]\(\s*\)/g;
+
+  const issues: string[] = [];
+
+  if (emptyText.test(report)) {
+    issues.push("empty link text []()");
+  }
+  if (emptyUrl.test(report)) {
+    issues.push("empty link URL [text]()");
+  }
+
+  if (issues.length > 0) {
+    return {
+      name: "Markdown links",
+      status: "warn",
+      message: issues.join("; "),
+    };
+  }
+
+  return { name: "Markdown links", status: "pass", message: "well-formed" };
+}
+
+/**
+ * Check that an HTML report file exists alongside the Markdown report.
+ *
+ * @param htmlExists - Whether the HTML file was found on disk.
+ * @param htmlPath - Path to the expected HTML file.
+ * @returns Review check result.
+ */
+export function checkHtmlReport(
+  htmlExists: boolean,
+  htmlPath: string,
+): ReviewCheck {
+  if (htmlExists) {
+    return { name: "HTML report", status: "pass", message: htmlPath };
+  }
+
+  return {
+    name: "HTML report",
+    status: "warn",
+    message: `not found at ${htmlPath}`,
+  };
+}

--- a/src/review/index.ts
+++ b/src/review/index.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+/**
+ * Report review checklist for WP Trend Watcher.
+ *
+ * Prints pass/warn/fail checks for the latest report. Exits 0 for
+ * warnings-only, 1 for true blockers.
+ *
+ * Usage: pnpm review
+ */
+
+import { access, readdir, readFile, stat, constants } from "node:fs/promises";
+import { join, basename } from "node:path";
+
+import {
+  extractReportBody,
+  parseSourceArticles,
+  checkWeeklySummary,
+  checkSourceReferences,
+  checkWeaselWords,
+  checkBuildNotes,
+  checkWatchingSection,
+  checkMarkdownLinks,
+  checkHtmlReport,
+  type ReviewCheck,
+  type ReviewStatus,
+} from "./checks.js";
+
+const REPORTS_DIR = "reports";
+
+/**
+ * Format a check result as a human-readable line.
+ *
+ * @param check - The review check result.
+ * @returns Formatted string with status indicator.
+ */
+function formatCheck(check: ReviewCheck): string {
+  const icon =
+    check.status === "pass" ? "✓" : check.status === "warn" ? "⚠" : "✗";
+  return `  ${icon} ${check.name}: ${check.message}`;
+}
+
+/**
+ * Find the latest markdown report in the reports directory.
+ *
+ * @param reportsDir - Path to the reports directory.
+ * @returns The full path to the latest report, or null if none found.
+ */
+async function findLatestReport(reportsDir: string): Promise<string | null> {
+  let files: string[];
+  try {
+    files = await readdir(reportsDir);
+  } catch {
+    return null;
+  }
+
+  const mdFiles = files
+    .filter((f) => f.endsWith(".md") && f !== "index.md")
+    .sort()
+    .reverse();
+
+  return mdFiles.length > 0 ? join(reportsDir, mdFiles[0]) : null;
+}
+
+async function main(): Promise<void> {
+  const reportsDir = join(process.cwd(), REPORTS_DIR);
+
+  const reportPath = await findLatestReport(reportsDir);
+  if (!reportPath) {
+    console.log("No reports found in reports/");
+    process.exitCode = 1;
+    return;
+  }
+
+  const report = await readFile(reportPath, "utf8");
+  const date = basename(reportPath, ".md");
+
+  console.log(`WP Trend Watcher — review checklist for ${date}\n`);
+
+  const body = extractReportBody(report);
+  const articles = parseSourceArticles(report);
+
+  // Check if HTML report exists
+  const htmlPath = join(reportsDir, `${date}.html`);
+  let htmlExists = false;
+  try {
+    await access(htmlPath, constants.R_OK);
+    htmlExists = true;
+  } catch {
+    // not found
+  }
+
+  // Run all checks
+  const checks: ReviewCheck[] = [
+    checkWeeklySummary(body),
+    checkSourceReferences(articles, body),
+    checkWeaselWords(body),
+    checkBuildNotes(report),
+    checkWatchingSection(report),
+    checkMarkdownLinks(report),
+    checkHtmlReport(htmlExists, htmlPath),
+  ];
+
+  // Print results
+  for (const check of checks) {
+    console.log(formatCheck(check));
+  }
+
+  // Summary
+  const failures = checks.filter((c) => c.status === "fail");
+  const warnings = checks.filter((c) => c.status === "warn");
+
+  console.log("");
+  if (failures.length > 0) {
+    console.log(
+      `${failures.length} blocker(s), ${warnings.length} warning(s) — review before publishing`,
+    );
+    process.exitCode = 1;
+  } else if (warnings.length > 0) {
+    console.log(`${warnings.length} warning(s) — review recommended`);
+  } else {
+    console.log("All checks passed — ready for human review");
+  }
+}
+
+await main();

--- a/tests/review/checks.test.ts
+++ b/tests/review/checks.test.ts
@@ -1,0 +1,232 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  extractReportBody,
+  parseSourceArticles,
+  checkWeeklySummary,
+  checkSourceReferences,
+  checkWeaselWords,
+  checkBuildNotes,
+  checkWatchingSection,
+  checkMarkdownLinks,
+  checkHtmlReport,
+  type SourceArticle,
+} from "../../src/review/checks.js";
+
+// --- extractReportBody ---
+
+test("extractReportBody returns everything before Source Articles", () => {
+  const report = `# Title
+
+### Weekly Summary
+Hello world.
+
+## Source Articles
+### Source
+* [Link](https://example.com)`;
+  const body = extractReportBody(report);
+  assert.ok(body.includes("Weekly Summary"));
+  assert.ok(!body.includes("Source Articles"));
+  assert.ok(!body.includes("Link"));
+});
+
+test("extractReportBody returns full text when no Source Articles marker", () => {
+  const report = "# Title\n\nHello world.";
+  assert.equal(extractReportBody(report), report);
+});
+
+// --- parseSourceArticles ---
+
+test("parseSourceArticles extracts title and URL from markdown links", () => {
+  const report = `## Source Articles
+### WordPress Developer Blog
+* [What's new for developers](https://developer.wordpress.org/news/2026/06/) — 6/10/2026
+### Make Core
+* [Dev Chat Agenda](https://make.wordpress.org/core/2026/06/) — 6/9/2026`;
+  const articles = parseSourceArticles(report);
+  assert.equal(articles.length, 2);
+  assert.equal(articles[0].title, "What's new for developers");
+  assert.equal(articles[0].url, "https://developer.wordpress.org/news/2026/06/");
+  assert.equal(articles[1].title, "Dev Chat Agenda");
+});
+
+test("parseSourceArticles returns empty array when no Source Articles section", () => {
+  assert.deepEqual(parseSourceArticles("# Just a title"), []);
+});
+
+test("parseSourceArticles returns empty array for empty section", () => {
+  assert.deepEqual(parseSourceArticles("## Source Articles\n"), []);
+});
+
+// --- checkWeeklySummary ---
+
+test("checkWeeklySummary passes when section has content", () => {
+  const body = "### Weekly Summary\nHere is the summary.";
+  const result = checkWeeklySummary(body);
+  assert.equal(result.status, "pass");
+});
+
+test("checkWeeklySummary fails when section is missing", () => {
+  const result = checkWeeklySummary("### Something else");
+  assert.equal(result.status, "fail");
+  assert.ok(result.message.includes("not found"));
+});
+
+test("checkWeeklySummary fails when section is empty", () => {
+  const result = checkWeeklySummary("### Weekly Summary");
+  assert.equal(result.status, "fail");
+  assert.ok(result.message.includes("empty"));
+});
+
+// --- checkSourceReferences ---
+
+test("checkSourceReferences passes when all articles are referenced by title", () => {
+  const articles: SourceArticle[] = [
+    { title: "Gutenberg Update", url: "https://example.com/1" },
+    { title: "ACF Release", url: "https://example.com/2" },
+  ];
+  const body = "The Gutenberg Update brings new features. ACF Release is out.";
+  const result = checkSourceReferences(articles, body);
+  assert.equal(result.status, "pass");
+});
+
+test("checkSourceReferences passes when articles referenced by URL", () => {
+  const articles: SourceArticle[] = [
+    { title: "Some Article", url: "https://example.com/special" },
+  ];
+  const body = "See https://example.com/special for details.";
+  const result = checkSourceReferences(articles, body);
+  assert.equal(result.status, "pass");
+});
+
+test("checkSourceReferences warns when articles are not referenced", () => {
+  const articles: SourceArticle[] = [
+    { title: "Referenced Article", url: "https://example.com/1" },
+    { title: "Missing Article", url: "https://example.com/2" },
+  ];
+  const body = "Referenced Article is great.";
+  const result = checkSourceReferences(articles, body);
+  assert.equal(result.status, "warn");
+  assert.ok(result.message.includes("1 unreferenced"));
+  assert.ok(result.message.includes("Missing Article"));
+});
+
+test("checkSourceReferences warns when no articles found", () => {
+  const result = checkSourceReferences([], "body text");
+  assert.equal(result.status, "warn");
+  assert.ok(result.message.includes("no source articles"));
+});
+
+test("checkSourceReferences truncates long lists", () => {
+  const articles: SourceArticle[] = [
+    { title: "A", url: "https://a.com" },
+    { title: "B", url: "https://b.com" },
+    { title: "C", url: "https://c.com" },
+    { title: "D", url: "https://d.com" },
+  ];
+  const result = checkSourceReferences(articles, "no references here");
+  assert.equal(result.status, "warn");
+  assert.ok(result.message.includes("+1 more"));
+});
+
+// --- checkWeaselWords ---
+
+test("checkWeaselWords passes when no weasel words found", () => {
+  const result = checkWeaselWords("This is a straightforward update.");
+  assert.equal(result.status, "pass");
+});
+
+test("checkWeaselWords warns when weasel words are found", () => {
+  const result = checkWeaselWords("This seamlessly integrates with the robust system.");
+  assert.equal(result.status, "warn");
+  assert.ok(result.message.includes("seamlessly"));
+  assert.ok(result.message.includes("robust"));
+});
+
+test("checkWeaselWords is case-insensitive", () => {
+  const result = checkWeaselWords("A GAME-CHANGER for developers.");
+  assert.equal(result.status, "warn");
+  assert.ok(result.message.includes("game-changer"));
+});
+
+// --- checkBuildNotes ---
+
+test("checkBuildNotes passes when section has provider and cost info", () => {
+  const report = `## Build Notes
+* Model: ollama/llama3.2:3b
+* Estimated cost: $0.00`;
+  const result = checkBuildNotes(report);
+  assert.equal(result.status, "pass");
+});
+
+test("checkBuildNotes fails when section is missing", () => {
+  const result = checkBuildNotes("# Just a title");
+  assert.equal(result.status, "fail");
+});
+
+test("checkBuildNotes warns when section lacks metadata", () => {
+  const report = "## Build Notes\nSome notes here.";
+  const result = checkBuildNotes(report);
+  assert.equal(result.status, "warn");
+});
+
+// --- checkWatchingSection ---
+
+test("checkWatchingSection passes when section has human note", () => {
+  const report = `## What I'm Watching
+- Collaborative editing is the biggest shift.`;
+  const result = checkWatchingSection(report);
+  assert.equal(result.status, "pass");
+});
+
+test("checkWatchingSection fails when section is missing", () => {
+  const result = checkWatchingSection("# Title");
+  assert.equal(result.status, "fail");
+});
+
+test("checkWatchingSection fails when section is empty", () => {
+  const result = checkWatchingSection("## What I'm Watching");
+  assert.equal(result.status, "fail");
+});
+
+test("checkWatchingSection warns on placeholder text", () => {
+  const report = "## What I'm Watching\nTODO: add notes";
+  const result = checkWatchingSection(report);
+  assert.equal(result.status, "warn");
+  assert.ok(result.message.includes("placeholder"));
+});
+
+// --- checkMarkdownLinks ---
+
+test("checkMarkdownLinks passes for well-formed links", () => {
+  const report = "* [Title](https://example.com)\n* [Another](https://other.com)";
+  const result = checkMarkdownLinks(report);
+  assert.equal(result.status, "pass");
+});
+
+test("checkMarkdownLinks warns on empty link text", () => {
+  const report = "[](https://example.com)";
+  const result = checkMarkdownLinks(report);
+  assert.equal(result.status, "warn");
+  assert.ok(result.message.includes("empty link text"));
+});
+
+test("checkMarkdownLinks warns on empty URL", () => {
+  const report = "[Title]()";
+  const result = checkMarkdownLinks(report);
+  assert.equal(result.status, "warn");
+  assert.ok(result.message.includes("empty link URL"));
+});
+
+// --- checkHtmlReport ---
+
+test("checkHtmlReport passes when file exists", () => {
+  const result = checkHtmlReport(true, "reports/2026-06-12.html");
+  assert.equal(result.status, "pass");
+});
+
+test("checkHtmlReport warns when file is missing", () => {
+  const result = checkHtmlReport(false, "reports/2026-06-12.html");
+  assert.equal(result.status, "warn");
+  assert.ok(result.message.includes("not found"));
+});


### PR DESCRIPTION
## Summary

Adds `pnpm review` command — a lightweight checklist for human review of the weekly report.

## What it checks

- Weekly Summary section exists and is non-empty.
- Every source article appears to be referenced in the report (title or URL substring).
- No weasel words (seamlessly, robust, game-changer, best practices, etc.).
- Build Notes section exists and contains provider/model/cost info.
- What I'm Watching section has a human-authored note (not just placeholder).
- Markdown links are well-formed.
- HTML report exists alongside Markdown report.

## Verification

- `pnpm test`: 43/43 pass
- `pnpm typecheck`: clean
- `pnpm review` against `reports/2026-06-12.md`: 1 warning (source articles not all cited in summary — expected for current format), exit 0

## Commits

- `feat: add pnpm review checklist command`

## Human Testing Instructions

Before merging, please run:

```bash
git checkout feature/report-review-checklist
pnpm install
pnpm review
```

Expected output:

```
WP Trend Watcher — review checklist for 2026-06-12

  ✓ Weekly Summary: present
  ⚠ Source references: 6 unreferenced: What's new for developers? (June 2026), ...
  ✓ Weasel words: none detected
  ✓ Build Notes: present with metadata
  ✓ What I'm Watching: has human note
  ✓ Markdown links: well-formed
  ✓ HTML report: reports/2026-06-12.html

1 warning(s) — review recommended
```

The warning about source references is **expected** for the current report format (it summarizes topics rather than citing every article by title). This is a real finding for human reviewers to evaluate.

If the output matches, merge is good.