### PR TITLE
fix: fallback to reasoning_content for reasoning models

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -151,11 +151,14 @@ function createOpenAiCompatibleProvider(): SummarizeProvider {
       }
 
       const data = (await response.json()) as {
-        choices?: Array<{ message?: { content?: string } }>;
+        choices?: Array<{
+          message?: { content?: string; reasoning_content?: string };
+        }>;
         usage?: { prompt_tokens?: number; completion_tokens?: number };
       };
 
-      const text = data.choices?.[0]?.message?.content;
+      const message = data.choices?.[0]?.message;
+      const text = message?.content ?? message?.reasoning_content ?? "";
       if (!text) {
         throw new Error("OpenAI-compatible endpoint returned empty response");
       }


### PR DESCRIPTION
## Summary

Reasoning models like `qwen/qwen3.5-9b` return their response in the `reasoning_content` field while `content` is an empty string. The current OpenAI-compatible provider throws an "empty response" error in this case.

This fix adds a fallback: try `content` first, then `reasoning_content`, before erroring.

## Changes

- Updated type definition in `createOpenAiCompatibleProvider()` to include `reasoning_content`
- Changed text extraction to use nullish coalescing: `message?.content ?? message?.reasoning_content ?? ""`

## Testing

- 43/43 tests pass (`pnpm test`)
- Typecheck clean (`pnpm typecheck`)
- Doctor check passes (`pnpm doctor`)

## Issue

Fixes #9
