### PR TITLE
feat: add GitHub issue template for report feedback

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/colorful-tones/wp-trend-watcher/blob/main/docs/sources.md
+    about: Review the current source list and selection criteria before suggesting

--- a/.github/ISSUE_TEMPLATE/report-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/report-feedback.yml
@@ -1,0 +1,91 @@
+name: Report Feedback
+description: Provide feedback on a generated weekly report
+title: "[Report Feedback] "
+labels: ["report-feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Feedback on Weekly Report
+
+        Thanks for reading the report and taking time to give feedback! Your input helps improve future reports.
+
+        **What kind of feedback is most useful?**
+        - Specific, actionable observations (e.g., "The Core section missed the latest REST API changes in 6.8")
+        - Context on what a section got wrong or right
+        - Suggestions for missing topics or sources
+        - Links to articles that should have been included
+
+        Feedback about report *formatting* or *accessibility* is also welcome here.
+
+  - type: input
+    id: report-date
+    attributes:
+      label: Report Date
+      description: Which weekly report is this feedback about? (e.g., "2025-W25" or "June 16, 2025")
+      placeholder: "e.g., 2025-W25"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: feedback-type
+    attributes:
+      label: Feedback Type
+      description: What kind of feedback are you providing?
+      options:
+        - Missing topic or source
+        - Incorrect or misleading summary
+        - Suggestion for improvement
+        - General positive feedback
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: section
+    attributes:
+      label: Which Section?
+      description: Which section of the report does this feedback relate to? Select "General" if it applies to the whole report.
+      options:
+        - Weekly Summary
+        - Emerging Trends
+        - Developer Implications
+        - What I'm Watching
+        - Build Notes
+        - General (multiple sections or whole report)
+    validations:
+      required: true
+
+  - type: textarea
+    id: feedback-description
+    attributes:
+      label: Detailed Feedback
+      description: |
+        Describe your feedback in detail. Include:
+        - What the report said vs. what you think is accurate
+        - Missing topics, sources, or context
+        - Suggestions for how the report could be improved
+      placeholder: |
+        "The Emerging Trends section covered the block binding proposal but missed the
+        recent discussion about improving block patterns API stability, which directly
+        impacts how I structure client sites."
+    validations:
+      required: true
+
+  - type: input
+    id: source-link
+    attributes:
+      label: Source Article Link
+      description: If your feedback references a specific article or source, paste the URL here
+      placeholder: "https://developer.wordpress.org/news/..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Anything else you'd like to share (e.g., your role, what you're building, why this section matters to you)
+      placeholder: "Optional additional context about your feedback"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/source-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/source-suggestion.yml
@@ -1,0 +1,73 @@
+name: Source Suggestion
+description: Suggest a new RSS source for WP Trend Watcher to track
+title: "[Source] "
+labels: ["source-suggestion"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Suggest a Source
+
+        Thanks for suggesting a new source! Please provide the details below.
+
+        **What makes a good source?** Sources should:
+        - Publish WordPress developer-relevant updates
+        - Have an RSS feed or predictable public URL
+        - Produce information that can affect real development decisions
+        - Be citeable in a public report
+
+        Sources are generally **excluded** if they are mostly marketing, rumors, drama, duplicate commentary, too broad to be useful, or contain unsupported claims.
+
+        See [docs/sources.md](../docs/sources.md) for full criteria and current source list.
+
+  - type: input
+    id: source-name
+    attributes:
+      label: Source Name
+      description: The display name of the source (e.g., "WordPress Developer Blog")
+      placeholder: e.g., "Developer Blog"
+    validations:
+      required: true
+
+  - type: input
+    id: homepage-url
+    attributes:
+      label: Homepage URL
+      description: The main URL of the source
+      placeholder: "https://example.com"
+    validations:
+      required: true
+
+  - type: input
+    id: feed-url
+    attributes:
+      label: RSS Feed URL
+      description: The RSS or Atom feed URL for the source
+      placeholder: "https://example.com/feed/"
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why does this source belong?
+      description: |
+        Explain how this source meets the inclusion criteria. Reference specific aspects of the source that make it valuable for WordPress developers.
+      placeholder: |
+        This source publishes weekly deep-dives on block editor internals and
+        core performance work that directly impact plugin development decisions.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Suggested Tier
+      description: |
+        **Tier 1** — Official or primary sources (WordPress.org, Make Core, ACF Blog).
+        **Tier 2** — Community-curated sources with consistent developer value (Gutenberg Times, ACF Chat Fridays).
+      options:
+        - Tier 2 (default)
+        - Tier 1
+    validations:
+      required: false


### PR DESCRIPTION
Adds a structured YAML issue template for users to provide feedback on generated weekly reports.

**Template fields:**
- Report date (required) — which weekly report
- Feedback type (required dropdown) — missing topic, incorrect summary, suggestion, positive, other
- Section reference (required dropdown) — Weekly Summary, Emerging Trends, Developer Implications, What I'm Watching, Build Notes, General
- Detailed feedback description (required textarea)
- Source article link (optional input)
- Additional context (optional textarea)

**Design choices:**
- Follows the existing  pattern for consistency
- Help text in the markdown header explains what kind of feedback is most useful
- All triage-critical fields are required to reduce empty/triage-heavy issues
- Section dropdown uses exact heading names from the report template

Closes nothing — this is an infrastructure improvement. All tests pass (58/58), typecheck clean.