### PR TITLE
fix: add ordered lists, h1–h6; update template

### DIFF
--- a/src/summarize/html.ts
+++ b/src/summarize/html.ts
@@ -76,8 +76,8 @@ function markdownToHtml(md: string): string {
       continue;
     }
 
-    // Headings
-    const headingMatch = line.match(/^(#{1,3})\s+(.*)/);
+    // Headings (h1–h6)
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)/);
     if (headingMatch) {
       const level = headingMatch[1].length;
       const text = inlineFormat(headingMatch[2]);
@@ -97,6 +97,17 @@ function markdownToHtml(md: string): string {
       continue;
     }
 
+    // Ordered list
+    if (/^\d+\.\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\d+\.\s+/.test(lines[i])) {
+        items.push(`<li>${inlineFormat(lines[i].replace(/^\d+\.\s+/, ""))}</li>`);
+        i++;
+      }
+      out.push(`<ol>\n${items.join("\n")}\n</ol>`);
+      continue;
+    }
+
     // Blank line — skip
     if (line.trim() === "") {
       i++;
@@ -108,8 +119,9 @@ function markdownToHtml(md: string): string {
     while (
       i < lines.length &&
       lines[i].trim() !== "" &&
-      !/^(#{1,3})\s+/.test(lines[i]) &&
+      !/^(#{1,6})\s+/.test(lines[i]) &&
       !/^[-*]\s+/.test(lines[i]) &&
+      !/^\d+\.\s+/.test(lines[i]) &&
       !/^---+\s*$/.test(lines[i]) &&
       !/^\s*<!--/.test(lines[i])
     ) {

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -191,15 +191,17 @@ Every item below must appear in the Weekly Summary. If an item has no developer 
 
 ${inventory}
 
-Generate these three sections. Use Markdown headings.
-
 ## Weekly Summary
-Cover every article from the inventory above. Group related items. Reference articles by their inventory number.
 
-## Emerging Trends
+Include these three sub-sections using exactly the heading levels shown:
+
+### Article Inventory
+List every article from the inventory above with its number. Reference articles by title and source.
+
+### Emerging Trends
 Topics appearing across multiple sources — or note if there are none.
 
-## Developer Implications
+### Developer Implications
 What a freelance or agency WordPress developer should pay attention to. Be specific: name APIs, versions, deadlines, or decisions that affect real projects.`;
 }
 


### PR DESCRIPTION
Enhance markdown parser and adjust weekly-summary template.

- src/summarize/html.ts: Extend heading support to h1–h6, add parsing for ordered lists (<ol>) and update paragraph/ block termination checks to recognize headings and ordered-list lines. Improves Markdown coverage.
- src/summarize/index.ts: Revise the summary template to require three specific sub-sections (Article Inventory, Emerging Trends, Developer Implications), add an Article Inventory subsection with guidance to list articles by number/title/source, and clarify heading levels to use. This makes the output structure more explicit for downstream consumers.