### PR TITLE
feat: improve report source emphasis

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Phase 2 complete. The repo collects from 6 sources, supports custom source confi
 
 ## Changelog
 
-### Unreleased
+### 0.2.5
 Cross-article report prompts now include inline Markdown links for source article titles and ask the model to preserve them when referencing specific articles. Release-planning prompts now preserve high-signal roadmap, schedule, proposal, and testing details for trend and developer-impact synthesis.
 
 ### 0.2.4

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ Phase 2 complete. The repo collects from 6 sources, supports custom source confi
 
 ## Changelog
 
+### Unreleased
+Cross-article report prompts now include inline Markdown links for source article titles and ask the model to preserve them when referencing specific articles. Release-planning prompts now preserve high-signal roadmap, schedule, proposal, and testing details for trend and developer-impact synthesis.
+
 ### 0.2.4
 Pinned local tooling to Node.js 22 and pnpm 11 via `.nvmrc`, `packageManager`, `engines`, and npm strictness settings. Quick Start now documents `nvm use` and Corepack setup for contributors and local agents.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,

--- a/src/summarize/html.ts
+++ b/src/summarize/html.ts
@@ -97,12 +97,36 @@ function markdownToHtml(md: string): string {
       continue;
     }
 
-    // Ordered list
+    // Ordered list — handles both tight (no blank lines between items) and
+    // loose (blank lines between items) formats. Collects indented continuation
+    // lines that follow a numbered item as part of that item's content.
     if (/^\d+\.\s+/.test(line)) {
       const items: string[] = [];
       while (i < lines.length && /^\d+\.\s+/.test(lines[i])) {
-        items.push(`<li>${inlineFormat(lines[i].replace(/^\d+\.\s+/, ""))}</li>`);
+        let itemText = lines[i].replace(/^\d+\.\s+/, "");
         i++;
+        // Collect indented continuation lines (part of this list item)
+        while (
+          i < lines.length &&
+          /^\s{2,}\S/.test(lines[i]) &&
+          !/^\d+\.\s+/.test(lines[i]) &&
+          !/^(#{1,6})\s+/.test(lines[i]) &&
+          !/^[-*]\s+/.test(lines[i]) &&
+          !/^---+\s*$/.test(lines[i])
+        ) {
+          itemText += " " + lines[i].trim();
+          i++;
+        }
+        // Skip blank line between loose list items (next line is another item)
+        if (
+          i < lines.length &&
+          lines[i].trim() === "" &&
+          i + 1 < lines.length &&
+          /^\d+\.\s+/.test(lines[i + 1])
+        ) {
+          i++;
+        }
+        items.push(`<li>${inlineFormat(itemText)}</li>`);
       }
       out.push(`<ol>\n${items.join("\n")}\n</ol>`);
       continue;

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -24,6 +24,7 @@ Rules:
 - Include the key technical takeaway if there is one.
 - Be specific, not generic.
 - Do not use marketing phrases like "dive deep into" or "in this article we explore."
+- For release roadmap, schedule, proposal, or call-for-testing posts, include dates, proposed focus areas, decisions under discussion, and developer-facing implications.
 - Do not evaluate or review the article — just summarize what it says.
 - Respond with the summary only. No prefixes like "Here is the summary" or "Summary:".`;
 

--- a/src/summarize/report.ts
+++ b/src/summarize/report.ts
@@ -166,9 +166,9 @@ export function buildReportPrompt(
   const inventory = summaries
     .map((s, i) => {
       const firstSentence = s.summary.split(". ")[0] + ".";
-      return `${i + 1}. **${s.title}** (${s.sourceName})\n   ${firstSentence}`;
+      return `${i + 1}. **${s.title}** (${s.sourceName}) — ${firstSentence}`;
     })
-    .join("\n\n");
+    .join("\n");
 
   return `Week ending ${date}. ${summaries.length} articles from WordPress developer sources.
 

--- a/src/summarize/report.ts
+++ b/src/summarize/report.ts
@@ -149,6 +149,19 @@ Rules:
 - If there is no real trend or implication, say so rather than inventing one.`;
 
 /**
+ * Detect whether an article title is likely to be a high-signal WordPress
+ * release-planning post that should retain more summary detail in synthesis.
+ *
+ * @param title - Article title to classify
+ * @returns True when the title contains release-planning signals
+ */
+export function isHighSignalReleasePlanningArticle(title: string): boolean {
+  return /\b(?:roadmap|release schedule|release squad|proposal|call for testing|beta|release candidate)\b/i.test(
+    title,
+  ) || /\bWordPress\s+\d+\.\d+(?:\.\d+)?\b/i.test(title);
+}
+
+/**
  * Build the user prompt for cross-article synthesis.
  *
  * Produces a structured prompt containing an inventory of all article
@@ -165,8 +178,10 @@ export function buildReportPrompt(
 ): string {
   const inventory = summaries
     .map((s, i) => {
-      const firstSentence = s.summary.split(". ")[0] + ".";
-      return `${i + 1}. **${s.title}** (${s.sourceName}) — ${firstSentence}`;
+      const highSignal = isHighSignalReleasePlanningArticle(s.title);
+      const summary = highSignal ? s.summary : s.summary.split(". ")[0] + ".";
+      const signal = highSignal ? " Signal: release planning." : "";
+      return `${i + 1}. [${s.title}](${s.url}) (${s.sourceName}) —${signal} ${summary}`;
     })
     .join("\n");
 
@@ -183,13 +198,15 @@ ${inventory}
 Include these three sub-sections using exactly the heading levels shown:
 
 ### Article Inventory
-List every article from the inventory above with its number. Reference articles by title and source.
+List every article from the inventory above with its number. Reference articles by title and source. Preserve the Markdown links when mentioning specific article titles.
 
 ### Emerging Trends
-Topics appearing across multiple sources — or note if there are none.
+Topics appearing across multiple sources — or note if there are none. Link specific article mentions where useful, without over-linking or inventing links.
+Release roadmaps, release schedules, major proposals, and calls for testing need explicit attention here when present. Include concrete dates, proposed changes, and decisions under discussion.
 
 ### Developer Implications
-What a freelance or agency WordPress developer should pay attention to. Be specific: name APIs, versions, deadlines, or decisions that affect real projects.`;
+What a freelance or agency WordPress developer should pay attention to. Be specific: name APIs, versions, deadlines, or decisions that affect real projects. Link specific article mentions where useful, without over-linking or inventing links.
+For release-planning items, explain what freelance and agency developers should monitor, including compatibility risks, testing windows, proposed focus areas, and upcoming decision points.`;
 }
 
 // --- Report assembly ---

--- a/tests/summarize/report.test.ts
+++ b/tests/summarize/report.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   buildReportPrompt,
   assembleReport,
+  isHighSignalReleasePlanningArticle,
 } from "../../src/summarize/report.js";
 import type {
   ArticleSummary,
@@ -50,17 +51,45 @@ function makeSummary(
 
 // --- buildReportPrompt ---
 
-test("buildReportPrompt includes all summaries in the inventory", () => {
+test("isHighSignalReleasePlanningArticle detects release-planning titles", () => {
+  assert.equal(isHighSignalReleasePlanningArticle("Roadmap to 7.1"), true);
+  assert.equal(
+    isHighSignalReleasePlanningArticle("WordPress 7.0.1 Release Schedule"),
+    true,
+  );
+  assert.equal(
+    isHighSignalReleasePlanningArticle(
+      "Call for Testing: Unicode email addresses",
+    ),
+    true,
+  );
+  assert.equal(
+    isHighSignalReleasePlanningArticle("Building layouts with container queries"),
+    false,
+  );
+});
+
+test("buildReportPrompt includes all summaries as linked titles in the inventory", () => {
   const summaries = [
-    makeSummary({ title: "Article A", sourceName: "Source A", summary: "Summary A text goes here. More text." }),
-    makeSummary({ title: "Article B", sourceName: "Source B", summary: "Summary B text goes here. More text." }),
+    makeSummary({
+      title: "Article A",
+      sourceName: "Source A",
+      url: "https://example.com/a",
+      summary: "Summary A text goes here. More text.",
+    }),
+    makeSummary({
+      title: "Article B",
+      sourceName: "Source B",
+      url: "https://example.com/b",
+      summary: "Summary B text goes here. More text.",
+    }),
   ];
   const prompt = buildReportPrompt(summaries, "2026-06-20");
   assert.ok(prompt.includes("Week ending 2026-06-20"));
   assert.ok(prompt.includes("2 articles"));
-  assert.ok(prompt.includes("**Article A**"));
+  assert.ok(prompt.includes("[Article A](https://example.com/a)"));
   assert.ok(prompt.includes("(Source A)"));
-  assert.ok(prompt.includes("**Article B**"));
+  assert.ok(prompt.includes("[Article B](https://example.com/b)"));
   assert.ok(prompt.includes("(Source B)"));
   assert.ok(prompt.includes("Summary A text goes here."));
   assert.ok(prompt.includes("Summary B text goes here."));
@@ -87,17 +116,55 @@ test("buildReportPrompt truncates summaries to first sentence", () => {
   assert.ok(!prompt.includes("Second sentence continues"));
 });
 
+test("buildReportPrompt keeps full summaries for high-signal release-planning articles", () => {
+  const summaries = [
+    makeSummary({
+      title: "WordPress 7.0.1 Release Schedule",
+      summary:
+        "The post outlines release timing for WordPress 7.0.1. It names the planned beta and release candidate windows. Freelance developers should monitor final dates and compatibility issues.",
+    }),
+  ];
+  const prompt = buildReportPrompt(summaries, "2026-06-20");
+  assert.ok(prompt.includes("Signal: release planning."));
+  assert.ok(prompt.includes("It names the planned beta and release candidate windows."));
+  assert.ok(
+    prompt.includes(
+      "Freelance developers should monitor final dates and compatibility issues.",
+    ),
+  );
+});
+
+test("buildReportPrompt includes release-planning instructions", () => {
+  const prompt = buildReportPrompt([makeSummary()], "2026-06-20");
+  assert.ok(
+    prompt.includes(
+      "Release roadmaps, release schedules, major proposals, and calls for testing need explicit attention",
+    ),
+  );
+  assert.ok(prompt.includes("concrete dates"));
+  assert.ok(prompt.includes("freelance and agency developers should monitor"));
+});
+
 test("buildReportPrompt numbers summaries sequentially", () => {
   const summaries = [
-    makeSummary({ title: "A", sourceName: "S1" }),
-    makeSummary({ title: "B", sourceName: "S2" }),
-    makeSummary({ title: "C", sourceName: "S3" }),
+    makeSummary({ title: "A", sourceName: "S1", url: "https://example.com/a" }),
+    makeSummary({ title: "B", sourceName: "S2", url: "https://example.com/b" }),
+    makeSummary({ title: "C", sourceName: "S3", url: "https://example.com/c" }),
   ];
   const prompt = buildReportPrompt(summaries, "2026-06-20");
   // Check sequential numbering
-  assert.ok(prompt.includes("1. **A**"));
-  assert.ok(prompt.includes("2. **B**"));
-  assert.ok(prompt.includes("3. **C**"));
+  assert.ok(prompt.includes("1. [A](https://example.com/a)"));
+  assert.ok(prompt.includes("2. [B](https://example.com/b)"));
+  assert.ok(prompt.includes("3. [C](https://example.com/c)"));
+});
+
+test("buildReportPrompt instructs the model to preserve Markdown article links", () => {
+  const prompt = buildReportPrompt([makeSummary()], "2026-06-20");
+  assert.ok(
+    prompt.includes(
+      "Preserve the Markdown links when mentioning specific article titles",
+    ),
+  );
 });
 
 // --- assembleReport ---


### PR DESCRIPTION
## Summary
- Add inline Markdown links to article titles in the cross-article report prompt inventory.
- Preserve full summaries for high-signal release-planning posts such as roadmaps, release schedules, proposals, calls for testing, betas, and release candidates.
- Add prompt guidance so release-planning items receive explicit attention in trends and developer implications.

## Verification
- [x] `pnpm exec tsx --test tests/summarize/report.test.ts`
- [x] `pnpm run test`
- [x] `pnpm run typecheck`
- [x] Code review profile approved

## Human testing
- Generate the latest report locally after this PR lands.
- Confirm a post like `Roadmap to 7.1` keeps more than the first sentence in the synthesis prompt and receives attention in Emerging Trends and Developer Implications.
- Confirm generated report files are reviewed separately before publishing.

## Notes
- This PR intentionally excludes generated latest report files.
- `pnpm run review` was run against the local untracked 2026-06-20 report and failed because that generated draft does not contain `### Weekly Summary`; that draft is not included in this PR.