### PR TITLE
fix: missing Weekly Summary heading in reports and review check

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ Phase 2 complete. The repo collects from 6 sources, supports custom source confi
 
 ## Changelog
 
+### 0.2.6
+Fix missing Weekly Summary heading in report output and review check. The review checklist now looks for the h2 heading and falls back to the Article Inventory sub-section. Report assembly guarantees the heading is present even when the model omits it.
+
 ### 0.2.5
 Cross-article report prompts now include inline Markdown links for source article titles and ask the model to preserve them when referencing specific articles. Release-planning prompts now preserve high-signal roadmap, schedule, proposal, and testing details for trend and developer-impact synthesis.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,

--- a/src/review/checks.ts
+++ b/src/review/checks.ts
@@ -63,12 +63,21 @@ export function parseSourceArticles(report: string): SourceArticle[] {
  * @returns Review check result.
  */
 export function checkWeeklySummary(body: string): ReviewCheck {
-  const marker = "### Weekly Summary";
-  const idx = body.indexOf(marker);
+  const h2Marker = "## Weekly Summary";
+  const inventoryMarker = "### Article Inventory";
+
+  const h2Idx = body.indexOf(h2Marker);
+  const inventoryIdx = body.indexOf(inventoryMarker);
+
+  // Accept either the expected h2 parent heading or the first sub-section
+  // as evidence the weekly summary content is present.  Some models omit the
+  // parent heading and emit sub-sections directly.
+  const idx = h2Idx >= 0 ? h2Idx : inventoryIdx;
   if (idx < 0) {
     return { name: "Weekly Summary", status: "fail", message: "section not found" };
   }
 
+  const marker = h2Idx >= 0 ? h2Marker : inventoryMarker;
   const afterMarker = body.slice(idx + marker.length).trim();
   if (!afterMarker) {
     return { name: "Weekly Summary", status: "fail", message: "section is empty" };

--- a/src/summarize/report.ts
+++ b/src/summarize/report.ts
@@ -238,6 +238,13 @@ export function assembleReport(
 ): string {
   const ensuredSynthesis = ensureSourceReferences(synthesis, articles);
 
+  // Guarantee the Weekly Summary heading is present. Some models skip the
+  // parent h2 and emit sub-sections (### Article Inventory, etc.) directly.
+  const hasWeeklySummary = /^## Weekly Summary\b/m.test(ensuredSynthesis);
+  const synthesisWithHeading = hasWeeklySummary
+    ? ensuredSynthesis
+    : `## Weekly Summary\n\n${ensuredSynthesis}`;
+
   const bySource = new Map<string, CollectedArticle[]>();
   for (const a of articles) {
     const existing = bySource.get(a.sourceName) ?? [];
@@ -272,7 +279,7 @@ export function assembleReport(
 
   return `# WordPress Trend Report — ${date}
 
-${ensuredSynthesis}
+${synthesisWithHeading}
 
 ---
 

--- a/tests/review/checks.test.ts
+++ b/tests/review/checks.test.ts
@@ -18,7 +18,7 @@ import {
 test("extractReportBody returns everything before Source Articles", () => {
   const report = `# Title
 
-### Weekly Summary
+## Weekly Summary
 Hello world.
 
 ## Source Articles
@@ -61,7 +61,7 @@ test("parseSourceArticles returns empty array for empty section", () => {
 // --- checkWeeklySummary ---
 
 test("checkWeeklySummary passes when section has content", () => {
-  const body = "### Weekly Summary\nHere is the summary.";
+  const body = "## Weekly Summary\nHere is the summary.";
   const result = checkWeeklySummary(body);
   assert.equal(result.status, "pass");
 });
@@ -73,9 +73,15 @@ test("checkWeeklySummary fails when section is missing", () => {
 });
 
 test("checkWeeklySummary fails when section is empty", () => {
-  const result = checkWeeklySummary("### Weekly Summary");
+  const result = checkWeeklySummary("## Weekly Summary");
   assert.equal(result.status, "fail");
   assert.ok(result.message.includes("empty"));
+});
+
+test("checkWeeklySummary passes when h2 missing but Article Inventory sub-section present", () => {
+  const body = "### Article Inventory\n1. [Title](https://example.com) — summary.";
+  const result = checkWeeklySummary(body);
+  assert.equal(result.status, "pass");
 });
 
 // --- checkSourceReferences ---

--- a/tests/summarize/ensure-source-refs.test.ts
+++ b/tests/summarize/ensure-source-refs.test.ts
@@ -175,7 +175,7 @@ test("integration: ensureSourceReferences makes checkSourceReferences pass", () 
   const ensured = ensureSourceReferences(synthesis, articles);
 
   // Simulate a report body
-  const reportBody = `### Weekly Summary\n${ensured}`;
+  const reportBody = `## Weekly Summary\n${ensured}`;
   const parsedArticles = articles.map((a) => ({
     title: a.title,
     url: a.url,
@@ -211,7 +211,7 @@ test("integration: paraphrased titles pass review check", () => {
   // Paraphrased synthesis
   const synthesis =
     "WordPress is seeking release managers for the 7.0.x maintenance releases. WordCamp Europe 2026 took place in Kraków.";
-  const reportBody = `### Weekly Summary\n${synthesis}`;
+  const reportBody = `## Weekly Summary\n${synthesis}`;
   const parsedArticles = articles.map((a) => ({
     title: a.title,
     url: a.url,

--- a/tests/summarize/report.test.ts
+++ b/tests/summarize/report.test.ts
@@ -189,6 +189,7 @@ test("assembleReport produces a complete Markdown report", () => {
   );
 
   assert.ok(report.includes("# WordPress Trend Report — 2026-06-20"));
+  assert.ok(report.includes("## Weekly Summary"));
   assert.ok(report.includes("### Article Inventory"));
   assert.ok(report.includes("### Emerging Trends"));
   assert.ok(report.includes("### Developer Implications"));
@@ -314,4 +315,25 @@ test("assembleReport includes human placeholders", () => {
 
   assert.ok(report.includes("Human-authored: add your observations here"));
   assert.ok(report.includes("Review time: (add after human review)"));
+});
+
+test("assembleReport does not duplicate Weekly Summary heading when model includes it", () => {
+  const articles = [makeArticle()];
+  const summaries = [makeSummary()];
+  const synthesis =
+    "## Weekly Summary\n\n### Article Inventory\n\n1. Test.\n\n### Emerging Trends\n\nNone.\n\n### Developer Implications\n\nNone.";
+
+  const report = assembleReport(
+    "2026-06-20",
+    articles,
+    synthesis,
+    summaries,
+    stubProvider,
+    200,
+    100,
+  );
+
+  const matches = report.match(/## Weekly Summary/g);
+  assert.ok(matches, "expected ## Weekly Summary in report");
+  assert.equal(matches!.length, 1, "heading should appear exactly once");
 });


### PR DESCRIPTION
## Problem

The report template was updated in #13 to use `## Weekly Summary` (h2) with `### Article Inventory`, `### Emerging Trends`, `### Developer Implications` as h3 sub-sections. Two issues remained:

1. **Review check mismatch**: `checkWeeklySummary` still looked for `### Weekly Summary` (h3), causing `pnpm review` to fail on newly generated reports.
2. **Missing heading in output**: `assembleReport` inserts the LLM synthesis raw. If the model skips the `## Weekly Summary` parent heading, it is missing from both .md and .html output entirely.

## Changes

### Commit 1: fix: align review check with updated Weekly Summary heading hierarchy
- `src/review/checks.ts` — Look for `## Weekly Summary` first, fall back to `### Article Inventory` for models that skip the parent h2
- `tests/review/checks.test.ts` — Update fixtures from `###` to `##`, add fallback test
- `tests/summarize/ensure-source-refs.test.ts` — Update fixtures for consistency

### Commit 2: fix: guarantee ## Weekly Summary heading in assembled report output
- `src/summarize/report.ts` — `assembleReport` now checks if the synthesis contains `## Weekly Summary` and prepends it if missing (no duplication when present)
- `tests/summarize/report.test.ts` — Add assertion for heading presence + deduplication test

## Verification

- `pnpm test` — 74 tests pass
- `pnpm typecheck` — clean
- `pnpm review` — all checks pass