### PR TITLE
feat: add app-level provider tuning for local OpenAI-compatible models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,12 +19,14 @@ WP_TREND_API_KEY=
 
 # Optional generation controls for local OpenAI-compatible providers.
 # Useful for LM Studio models that otherwise spend too long on final synthesis.
-WP_TREND_MAX_TOKENS=900
+# 2048 gives multi-section reports enough room without leaving output unbounded.
+WP_TREND_MAX_TOKENS=2048
 
 # Request timeout in milliseconds. Increase for slower local models.
 WP_TREND_REQUEST_TIMEOUT_MS=120000
 
 # Append /no_think to prompts for Qwen-style reasoning models.
+# Also disable thinking in LM Studio's model settings when available.
 WP_TREND_DISABLE_REASONING=true
 
 # Ollama settings (used when WP_TREND_PROVIDER=ollama)

--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,20 @@ WP_TREND_PROVIDER=openai-compatible
 WP_TREND_OPENAI_BASE_URL=http://localhost:1234/v1
 
 # Model name loaded by your local server (LM Studio shows this in the UI).
-WP_TREND_MODEL=local-model
+WP_TREND_MODEL=qwen/qwen3.5-9b
 
 # Optional API key for endpoints that require one. Leave blank for LM Studio.
 WP_TREND_API_KEY=
+
+# Optional generation controls for local OpenAI-compatible providers.
+# Useful for LM Studio models that otherwise spend too long on final synthesis.
+WP_TREND_MAX_TOKENS=900
+
+# Request timeout in milliseconds. Increase for slower local models.
+WP_TREND_REQUEST_TIMEOUT_MS=120000
+
+# Append /no_think to prompts for Qwen-style reasoning models.
+WP_TREND_DISABLE_REASONING=true
 
 # Ollama settings (used when WP_TREND_PROVIDER=ollama)
 WP_TREND_OLLAMA_URL=http://localhost:11434

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pnpm collect           # add -- --days 7 for recent articles
 pnpm summarize         # requires a local LLM endpoint for summarization
 ```
 
-Prerequisites: Node.js 22 and Corepack. Run `nvm use` to select the version pinned in `.nvmrc`, then `corepack enable` so the `packageManager` pin (`pnpm@11.5.0`) is used automatically. Summarization requires a local LLM provider such as LM Studio (OpenAI-compatible endpoint) or Ollama; collection does not. The CLI automatically loads `.env` from the project root when present.
+Prerequisites: Node.js 22 and Corepack. Run `nvm use` to select the version pinned in `.nvmrc`, then `corepack enable` so the `packageManager` pin (`pnpm@11.5.0`) is used automatically. Summarization requires a local LLM provider such as LM Studio (OpenAI-compatible endpoint) or Ollama; collection does not. LM Studio users should set a completion cap such as `WP_TREND_MAX_TOKENS=900` for predictable report generation. The CLI automatically loads `.env` from the project root when present.
 
 ## What This Does
 
@@ -111,6 +111,9 @@ See:
 Phase 2 complete. The repo collects from 6 sources, supports custom source configuration, produces styled HTML reports, and deploys to GitHub Pages. Ready for ongoing weekly use and community contributions.
 
 ## Changelog
+
+### 0.2.7
+Added local provider tuning for LM Studio and other OpenAI-compatible models. Users can now configure max tokens, request timeout, and optional Qwen `/no_think` prompting through environment variables.
 
 ### 0.2.6
 Fix missing Weekly Summary heading in report output and review check. The review checklist now looks for the h2 heading and falls back to the Article Inventory sub-section. Report assembly guarantees the heading is present even when the model omits it.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pnpm collect           # add -- --days 7 for recent articles
 pnpm summarize         # requires a local LLM endpoint for summarization
 ```
 
-Prerequisites: Node.js 22 and Corepack. Run `nvm use` to select the version pinned in `.nvmrc`, then `corepack enable` so the `packageManager` pin (`pnpm@11.5.0`) is used automatically. Summarization requires a local LLM provider such as LM Studio (OpenAI-compatible endpoint) or Ollama; collection does not. LM Studio users should set a completion cap such as `WP_TREND_MAX_TOKENS=900` for predictable report generation. The CLI automatically loads `.env` from the project root when present.
+Prerequisites: Node.js 22 and Corepack. Run `nvm use` to select the version pinned in `.nvmrc`, then `corepack enable` so the `packageManager` pin (`pnpm@11.5.0`) is used automatically. Summarization requires a local LLM provider such as LM Studio (OpenAI-compatible endpoint) or Ollama; collection does not. LM Studio users should set a completion cap such as `WP_TREND_MAX_TOKENS=2048` for predictable report generation. The CLI automatically loads `.env` from the project root when present.
 
 ## What This Does
 

--- a/docs/summarization.md
+++ b/docs/summarization.md
@@ -40,7 +40,7 @@ Example — LM Studio with the known-good local baseline:
 WP_TREND_PROVIDER=openai-compatible \
 WP_TREND_OPENAI_BASE_URL=http://localhost:1234/v1 \
 WP_TREND_MODEL=qwen/qwen3.5-9b \
-WP_TREND_MAX_TOKENS=900 \
+WP_TREND_MAX_TOKENS=2048 \
 WP_TREND_REQUEST_TIMEOUT_MS=120000 \
 WP_TREND_DISABLE_REASONING=true \
 pnpm summarize
@@ -53,9 +53,17 @@ cross-article synthesis step without re-fetching or re-summarizing articles.
 LM Studio users should keep an explicit completion cap. The cross-article
 synthesis step asks the model to cover every article, preserve links, and write
 multiple sections; without `WP_TREND_MAX_TOKENS`, some local models continue
-generating long enough to hit the request timeout. Qwen reasoning models may
-also spend extra time on hidden reasoning unless `WP_TREND_DISABLE_REASONING` is
-enabled or thinking is disabled in LM Studio.
+generating long enough to hit the request timeout. A cap around 2048 tokens has
+worked better than 900 for full multi-section reports. Qwen reasoning models may
+also spend extra time on hidden reasoning unless thinking is disabled in LM
+Studio; `WP_TREND_DISABLE_REASONING=true` adds `/no_think` as a prompt-level
+safeguard, but it is not a replacement for LM Studio's model setting.
+
+For local report quality, `qwen/qwen3.5-9b` tends to allocate more output to
+Emerging Trends, while `qwen/qwen3-14b` tends to spend more output on Article
+Inventory detail. Both can run locally with thinking disabled, max context, and
+`WP_TREND_MAX_TOKENS=2048`; choose based on whether speed or inventory detail is
+more important for the review pass.
 
 Example — Ollama with a larger local model:
 

--- a/docs/summarization.md
+++ b/docs/summarization.md
@@ -28,17 +28,34 @@ The provider is selected by environment variables:
 | `WP_TREND_OPENAI_BASE_URL` | `http://localhost:1234/v1` | OpenAI-compatible API base URL, without `/chat/completions` |
 | `WP_TREND_MODEL` | `local-model` | Model name for OpenAI-compatible providers; also works as the Ollama model fallback |
 | `WP_TREND_API_KEY` | unset | Optional bearer token for OpenAI-compatible endpoints that require one; leave blank for LM Studio |
+| `WP_TREND_MAX_TOKENS` | unset | Optional completion cap for OpenAI-compatible providers; useful for keeping local report synthesis bounded |
+| `WP_TREND_REQUEST_TIMEOUT_MS` | `60000` | Request timeout for LLM calls in milliseconds |
+| `WP_TREND_DISABLE_REASONING` | `false` | Appends `/no_think` to OpenAI-compatible prompts for Qwen-style reasoning models |
 | `WP_TREND_OLLAMA_URL` | `http://localhost:11434` | Ollama API endpoint |
 | `WP_TREND_OLLAMA_MODEL` | `llama3.2:3b` | Ollama model tag; overrides `WP_TREND_MODEL` for Ollama |
 
-Example — LM Studio or another local OpenAI-compatible server:
+Example — LM Studio with the known-good local baseline:
 
 ```bash
 WP_TREND_PROVIDER=openai-compatible \
 WP_TREND_OPENAI_BASE_URL=http://localhost:1234/v1 \
-WP_TREND_MODEL="your-loaded-model" \
+WP_TREND_MODEL=qwen/qwen3.5-9b \
+WP_TREND_MAX_TOKENS=900 \
+WP_TREND_REQUEST_TIMEOUT_MS=120000 \
+WP_TREND_DISABLE_REASONING=true \
 pnpm summarize
 ```
+
+Use `pnpm generate-report` with the same environment values when testing a
+model or prompt change against existing summaries. It isolates the final
+cross-article synthesis step without re-fetching or re-summarizing articles.
+
+LM Studio users should keep an explicit completion cap. The cross-article
+synthesis step asks the model to cover every article, preserve links, and write
+multiple sections; without `WP_TREND_MAX_TOKENS`, some local models continue
+generating long enough to hit the request timeout. Qwen reasoning models may
+also spend extra time on hidden reasoning unless `WP_TREND_DISABLE_REASONING` is
+enabled or thinking is disabled in LM Studio.
 
 Example — Ollama with a larger local model:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,

--- a/src/env.ts
+++ b/src/env.ts
@@ -59,13 +59,78 @@ export function parsePositiveIntegerEnv(key: string, fallback: number): number {
     return fallback;
   }
 
-  const value = Number.parseInt(raw, 10);
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    console.warn(`Invalid ${key} value, defaulting to ${fallback}`);
+    return fallback;
+  }
+
+  const value = Number.parseInt(trimmed, 10);
   if (Number.isNaN(value) || value < 1) {
     console.warn(`Invalid ${key} value, defaulting to ${fallback}`);
     return fallback;
   }
 
   return value;
+}
+
+/**
+ * Parse an optional positive integer environment variable.
+ *
+ * @param key - Environment variable name to read
+ * @returns Parsed positive integer, or undefined when unset or invalid
+ */
+export function parseOptionalPositiveIntegerEnv(
+  key: string,
+): number | undefined {
+  const raw = process.env[key];
+  if (raw === undefined || raw.trim() === "") {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    console.warn(`Invalid ${key} value, ignoring`);
+    return undefined;
+  }
+
+  const value = Number.parseInt(trimmed, 10);
+  if (Number.isNaN(value) || value < 1) {
+    console.warn(`Invalid ${key} value, ignoring`);
+    return undefined;
+  }
+
+  return value;
+}
+
+/**
+ * Parse a boolean environment variable with common truthy/falsy strings.
+ *
+ * @param key - Environment variable name to read
+ * @param fallback - Value to use when unset or invalid
+ * @returns Parsed boolean value
+ */
+export function parseBooleanEnv(key: string, fallback: boolean): boolean {
+  const raw = process.env[key];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+
+  switch (raw.trim().toLowerCase()) {
+    case "1":
+    case "true":
+    case "yes":
+    case "on":
+      return true;
+    case "0":
+    case "false":
+    case "no":
+    case "off":
+      return false;
+    default:
+      console.warn(`Invalid ${key} value, defaulting to ${fallback}`);
+      return fallback;
+  }
 }
 
 function parseEnvValue(value: string): string {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,8 +1,23 @@
+import {
+  parseBooleanEnv,
+  parseOptionalPositiveIntegerEnv,
+  parsePositiveIntegerEnv,
+} from "./env.js";
+
 export interface SummarizeResult {
   text: string;
   promptTokens: number;
   completionTokens: number;
 }
+
+type OpenAiChatRequestBody = {
+  model: string;
+  messages: Array<{ role: "system" | "user"; content: string }>;
+  temperature: number;
+  max_tokens?: number;
+};
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 
 export interface SummarizeProvider {
   name: string;
@@ -34,6 +49,10 @@ function createOllamaProvider(): SummarizeProvider {
     process.env.WP_TREND_OLLAMA_MODEL ??
     process.env.WP_TREND_MODEL ??
     "llama3.2:3b";
+  const requestTimeoutMs = parsePositiveIntegerEnv(
+    "WP_TREND_REQUEST_TIMEOUT_MS",
+    DEFAULT_REQUEST_TIMEOUT_MS,
+  );
 
   return {
     name: "ollama",
@@ -56,7 +75,7 @@ function createOllamaProvider(): SummarizeProvider {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body,
-          signal: AbortSignal.timeout(60_000),
+          signal: AbortSignal.timeout(requestTimeoutMs),
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -106,20 +125,40 @@ function createOpenAiCompatibleProvider(): SummarizeProvider {
   );
   const model = process.env.WP_TREND_MODEL ?? "local-model";
   const apiKey = process.env.WP_TREND_API_KEY;
+  const requestTimeoutMs = parsePositiveIntegerEnv(
+    "WP_TREND_REQUEST_TIMEOUT_MS",
+    DEFAULT_REQUEST_TIMEOUT_MS,
+  );
+  const maxTokens = parseOptionalPositiveIntegerEnv("WP_TREND_MAX_TOKENS");
+  const disableReasoning = parseBooleanEnv(
+    "WP_TREND_DISABLE_REASONING",
+    false,
+  );
 
   return {
     name: "openai-compatible",
     model,
 
     async summarize(systemPrompt, userPrompt) {
-      const body = JSON.stringify({
+      const requestBody: OpenAiChatRequestBody = {
         model,
         messages: [
           { role: "system", content: systemPrompt },
-          { role: "user", content: userPrompt },
+          {
+            role: "user",
+            content: disableReasoning
+              ? appendNoThinkDirective(userPrompt)
+              : userPrompt,
+          },
         ],
         temperature: 0.3,
-      });
+      };
+
+      if (maxTokens !== undefined) {
+        requestBody.max_tokens = maxTokens;
+      }
+
+      const body = JSON.stringify(requestBody);
 
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
@@ -134,7 +173,7 @@ function createOpenAiCompatibleProvider(): SummarizeProvider {
           method: "POST",
           headers,
           body,
-          signal: AbortSignal.timeout(60_000),
+          signal: AbortSignal.timeout(requestTimeoutMs),
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -178,4 +217,18 @@ function createOpenAiCompatibleProvider(): SummarizeProvider {
 
 function stripTrailingSlash(value: string): string {
   return value.replace(/\/+$/, "");
+}
+
+/**
+ * Add Qwen's non-thinking directive unless the prompt already includes it.
+ *
+ * @param prompt - User prompt sent to an OpenAI-compatible local model
+ * @returns Prompt with a trailing /no_think directive
+ */
+function appendNoThinkDirective(prompt: string): string {
+  if (/\/no_think\b/.test(prompt)) {
+    return prompt;
+  }
+
+  return `${prompt}\n\n/no_think`;
 }

--- a/tests/providers/index.test.ts
+++ b/tests/providers/index.test.ts
@@ -7,6 +7,9 @@ const ENV_KEYS = [
   "WP_TREND_OPENAI_BASE_URL",
   "WP_TREND_MODEL",
   "WP_TREND_API_KEY",
+  "WP_TREND_DISABLE_REASONING",
+  "WP_TREND_MAX_TOKENS",
+  "WP_TREND_REQUEST_TIMEOUT_MS",
   "WP_TREND_OLLAMA_MODEL",
   "WP_TREND_OLLAMA_URL",
 ] as const;
@@ -81,6 +84,123 @@ test("openai-compatible provider posts to chat completions with bearer token", a
       completionTokens: 5,
     });
   } finally {
+    globalThis.fetch = originalFetch;
+    restoreEnv();
+  }
+});
+
+test("openai-compatible provider applies local generation controls", async () => {
+  const restoreEnv = withCleanEnv();
+  const originalFetch = globalThis.fetch;
+
+  try {
+    process.env.WP_TREND_PROVIDER = "openai-compatible";
+    process.env.WP_TREND_MODEL = "qwen/qwen3.5-9b";
+    process.env.WP_TREND_MAX_TOKENS = "900";
+    process.env.WP_TREND_DISABLE_REASONING = "true";
+
+    let requestBody: unknown;
+
+    globalThis.fetch = async (_input, init) => {
+      requestBody = JSON.parse(String(init?.body));
+
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "report text" } }],
+          usage: { prompt_tokens: 120, completion_tokens: 90 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+
+    const provider = createProvider();
+    const result = await provider.summarize("system prompt", "user prompt");
+
+    assert.deepEqual(requestBody, {
+      model: "qwen/qwen3.5-9b",
+      messages: [
+        { role: "system", content: "system prompt" },
+        { role: "user", content: "user prompt\n\n/no_think" },
+      ],
+      temperature: 0.3,
+      max_tokens: 900,
+    });
+    assert.deepEqual(result, {
+      text: "report text",
+      promptTokens: 120,
+      completionTokens: 90,
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreEnv();
+  }
+});
+
+test("openai-compatible provider does not duplicate no_think directive", async () => {
+  const restoreEnv = withCleanEnv();
+  const originalFetch = globalThis.fetch;
+
+  try {
+    process.env.WP_TREND_PROVIDER = "openai-compatible";
+    process.env.WP_TREND_DISABLE_REASONING = "true";
+
+    let requestBody: { messages?: Array<{ content: string }> } = {};
+
+    globalThis.fetch = async (_input, init) => {
+      requestBody = JSON.parse(String(init?.body)) as {
+        messages?: Array<{ content: string }>;
+      };
+
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "summary text" } }],
+          usage: { prompt_tokens: 12, completion_tokens: 5 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+
+    const provider = createProvider();
+    await provider.summarize("system prompt", "user prompt\n\n/no_think");
+
+    assert.equal(requestBody.messages?.[1]?.content, "user prompt\n\n/no_think");
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreEnv();
+  }
+});
+
+test("openai-compatible provider uses configured request timeout", async () => {
+  const restoreEnv = withCleanEnv();
+  const originalFetch = globalThis.fetch;
+  const originalTimeout = AbortSignal.timeout;
+
+  try {
+    process.env.WP_TREND_PROVIDER = "openai-compatible";
+    process.env.WP_TREND_REQUEST_TIMEOUT_MS = "120000";
+
+    let timeoutMs = 0;
+    AbortSignal.timeout = (milliseconds: number): AbortSignal => {
+      timeoutMs = milliseconds;
+      return originalTimeout(60_000);
+    };
+
+    globalThis.fetch = async () => {
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "summary text" } }],
+          usage: { prompt_tokens: 12, completion_tokens: 5 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+
+    const provider = createProvider();
+    await provider.summarize("system prompt", "user prompt");
+
+    assert.equal(timeoutMs, 120000);
+  } finally {
+    AbortSignal.timeout = originalTimeout;
     globalThis.fetch = originalFetch;
     restoreEnv();
   }


### PR DESCRIPTION
- Adds app-level provider tuning for local OpenAI-compatible models:
  - `WP_TREND_MAX_TOKENS`
  - `WP_TREND_REQUEST_TIMEOUT_MS`
  - `WP_TREND_DISABLE_REASONING`
- Applies request timeout tuning to Ollama calls too, while keeping existing defaults when env vars are unset.
- Documents the LM Studio baseline with qwen/qwen3.5-9b, max tokens 900, and Qwen /no_think prompting.

Verification
- [x] pnpm run test
- [x] pnpm run typecheck
- [x] pnpm run doctor

Human testing before merge
- [x] In LM Studio, load qwen/qwen3.5-9b and start the local server.
- [x] Run:

```
WP_TREND_PROVIDER=openai-compatible
WP_TREND_OPENAI_BASE_URL=http://localhost:1234/v1
WP_TREND_MODEL=qwen/qwen3.5-9b WP_TREND_MAX_TOKENS=900
WP_TREND_REQUEST_TIMEOUT_MS=120000
WP_TREND_DISABLE_REASONING=true
pnpm generate-report
```

- [ ] Review the generated Markdown/HTML report quality before merging.

Notes
- Local generated report artifacts are intentionally excluded from this PR.