### PR TITLE
feat: add previous report discovery helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,18 @@ The goal is to collect useful WordPress ecosystem updates, summarize them effici
 
 ## Status
 
-Phase 3 is underway. The repo now has:
+Phase 4 is complete. The repo now has:
 
 - **6 sources** (4 Tier 1 + 2 Tier 2) with clean collection summaries
 - **sources.yaml** for user-customizable sources
-- **HTML reports** with self-contained styling, generated alongside Markdown
+- **HTML reports** with table-of-contents navigation, stable heading IDs, and polished styling
+- **Reports index page** with card-style listing, friendly dates, and latest-report badge
 - **GitHub Pages** deployment via GitHub Actions on push to main
 - **Doctor and review commands** for setup checks and report review
 - **Report regeneration** from saved article summaries
 - **OpenAI-compatible and LM Studio tuning** for local model runs
 - **Deterministic Article Inventory** with linked titles and takeaways
+- **Previous-report comparison** with automatically generated `## Since Last Report` section
 - **Published weekly reports** for ongoing use
 
 ## Intended Audience
@@ -59,13 +61,16 @@ See [Summarization](docs/summarization.md) for provider configuration, model opt
 
 ### HTML Reports & GitHub Pages
 
-`pnpm summarize` now produces a self-contained HTML version of each report alongside the Markdown file. An `index.html` listing page is also generated automatically in `reports/`.
+`pnpm summarize` produces a self-contained HTML version of each report alongside the Markdown file. Reports now include:
+
+- A styled report header card with left-border accent
+- A table-of-contents navigation block (auto-generated when 2+ sections exist)
+- Stable heading IDs for deep linking to report sections
+- Polished Article Inventory and Build Notes styling
+
+An `index.html` listing page is automatically generated in `reports/`, displaying reports as styled cards with friendly date formatting and a "Latest report" badge on the newest entry.
 
 Reports are deployed to GitHub Pages on every push to `main` via the `pages.yml` workflow. Configure GitHub Pages to deploy from the `github-pages` environment (Settings → Pages → Source: GitHub Actions).
-
-### 0.1.3
-Tier 2 sources (Gutenberg Times, ACF Chat Fridays) added to the default collection. Collection now prints a clean summary with article counts, filtered counts, and source error reporting.
-
 
 ## What This Does Not Do Yet
 
@@ -82,6 +87,7 @@ Each weekly report should include:
 
 - Weekly Summary
 - Article Inventory
+- Since Last Report (auto-generated when a previous report exists — compares topics across weeks)
 - Emerging Trends
 - Developer Implications
 - What I'm Watching
@@ -113,6 +119,33 @@ See:
 - [Contributing](CONTRIBUTING.md)
 
 ## Changelog
+
+### 0.4.0 — Phase 4 Release
+
+**Previous-report comparison:**
+- Reports now include an optional `## Since Last Report` section comparing topics to the previous week
+- Auto-generated from existing report files — no LLM call or database required
+- Up to 3 bullets per report (Continued topic, New topic, Dropped topic), prioritized by signal
+
+**HTML report polish:**
+- Added stable heading IDs (`id="weekly-summary"`, etc.) for deep linking
+- Added auto-generated table of contents on reports with 2+ sections
+- Added styled report header card with left-border accent
+- Added Article Inventory list item styling for better scannability
+- Added muted Build Notes metadata panel
+- HTML entity escaping for XSS prevention
+
+**Reports index page polish:**
+- Card-style report listing with border, rounded corners, and hover effect
+- Friendly date formatting ("June 21, 2026") via `toLocaleDateString`
+- "Latest report" badge on the newest entry
+- Dynamic report count with singular/plural support
+
+**Under the hood:**
+- New `src/summarize/report-comparison.ts` module with topic parsing and comparison helpers
+- `findPreviousReportPath()` helper for deterministic previous-report discovery
+- Both `pnpm summarize` and `pnpm generate-report` support the comparison pipeline
+- 114 tests across all modules, 0 failures, typecheck clean
 
 ### 0.2.8
 Article Inventory is now assembled deterministically from saved article summaries, giving every source a linked title and one-sentence takeaway while reserving model output for trends and implications.

--- a/docs/summarization.md
+++ b/docs/summarization.md
@@ -122,3 +122,12 @@ To force re-summarization of all articles, delete the summaries.json file:
 rm data/articles/YYYY-MM-DD/summaries.json
 pnpm summarize
 ```
+
+## Previous-Report Comparison
+
+When a previous report exists in `reports/`, the assembly step automatically generates a `## Since Last Report` section comparing topics across weeks. This comparison:
+
+- Parses `### Emerging Trends`, `### Developer Implications`, and `### Article Inventory` sections from both reports
+- Classifies topics as Continued, New, or Dropped using normalized label matching
+- Outputs at most 3 bullets per report, prioritizing continued topics first
+- Requires no LLM call, database, or historical store — purely file-based and deterministic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.2.8",
+  "version": "0.4.0",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,

--- a/reports/index.html
+++ b/reports/index.html
@@ -60,15 +60,44 @@ em { font-style: italic; }
 /* Build Notes panel */
 #build-notes ~ * { font-size: 0.9rem; color: #555; }
 #build-notes { font-size: 1rem; color: #666; margin-top: 2rem; border-top: 1px solid #e0e0e0; padding-top: 1rem; }
+
+/* Report index page */
+.report-card-grid { display: flex; flex-direction: column; gap: 0.75rem; }
+.report-card {
+  display: block;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.15s;
+}
+.report-card:hover { background: #f6f8fa; border-color: #d0d0d0; }
+.report-card-date { display: block; font-size: 1.05rem; font-weight: 500; margin-bottom: 0.15rem; }
+.report-card-label {
+  display: inline-block;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #888;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  padding: 0.1em 0.5em;
+}
 h1 { border-bottom: none; }
   </style>
 </head>
 <body>
   <h1>WP Trend Watcher — Reports</h1>
-  <p class="meta">Weekly WordPress ecosystem trend reports.</p>
-  <ul>
-    <li><a href="2026-06-21.html">2026-06-21</a></li>
-    <li><a href="2026-06-12.html">2026-06-12</a></li>
-  </ul>
+  <p class="meta">2 weekly WordPress ecosystem trend reports.</p>
+  <div class="report-card-grid">
+    <a href="2026-06-21.html" class="report-card">
+      <span class="report-card-date">June 21, 2026</span>
+    <span class="report-card-label">Latest report</span>
+    </a>
+    <a href="2026-06-12.html" class="report-card">
+      <span class="report-card-date">June 12, 2026</span>
+    </a>
+  </div>
 </body>
 </html>

--- a/reports/index.html
+++ b/reports/index.html
@@ -42,6 +42,24 @@ hr { border: none; border-top: 1px solid #e0e0e0; margin: 2rem 0; }
 strong { font-weight: 600; }
 em { font-style: italic; }
 .meta { color: #666; font-size: 0.85rem; margin-bottom: 2rem; }
+
+/* Report header */
+.report-header { border-left: 4px solid #0969da; padding-left: 1rem; margin-bottom: 1.5rem; }
+.report-header h1 { margin-bottom: 0.25rem; border-bottom: none; }
+
+/* Table of contents */
+.toc { background: #f6f8fa; border: 1px solid #e0e0e0; border-radius: 6px; padding: 1rem 1.5rem; margin-bottom: 2rem; }
+.toc h2 { margin-top: 0; border-bottom: none; font-size: 1rem; }
+.toc ul { margin-bottom: 0; }
+.toc a { font-size: 0.9rem; }
+
+/* Article Inventory list */
+#article-inventory + ol li { padding: 0.25rem 0; border-bottom: 1px solid #f0f0f0; }
+#article-inventory + ol li:last-child { border-bottom: none; }
+
+/* Build Notes panel */
+#build-notes ~ * { font-size: 0.9rem; color: #555; }
+#build-notes { font-size: 1rem; color: #666; margin-top: 2rem; border-top: 1px solid #e0e0e0; padding-top: 1rem; }
 h1 { border-bottom: none; }
   </style>
 </head>

--- a/src/generate-report/index.ts
+++ b/src/generate-report/index.ts
@@ -8,6 +8,7 @@ import {
   type ArticleSummary,
   type SummariesJson,
   findLatestArticlesJson,
+  findPreviousReportPath,
   REPORT_SYSTEM_PROMPT,
   buildReportPrompt,
   assembleReport,
@@ -91,6 +92,21 @@ async function main(): Promise<void> {
   const synthesisPromptTokens = synthesisResult.promptTokens;
   const synthesisCompletionTokens = synthesisResult.completionTokens;
 
+  // 4. Load previous report for comparison (non-blocking)
+  let previousReportMd: string | null = null;
+  try {
+    const reportsDir = join(process.cwd(), "reports");
+    const previousReportPath = await findPreviousReportPath(
+      reportsDir,
+      articlesData.date,
+    );
+    if (previousReportPath) {
+      previousReportMd = await readFile(previousReportPath, "utf8");
+    }
+  } catch {
+    // No previous report available — comparison section will be omitted
+  }
+
   // 4. Assemble and write report
   const report = assembleReport(
     articlesData.date,
@@ -100,6 +116,7 @@ async function main(): Promise<void> {
     provider,
     cachedPromptTokens + synthesisPromptTokens,
     cachedCompletionTokens + synthesisCompletionTokens,
+    previousReportMd,
   );
 
   const outputPath = join(process.cwd(), "reports", `${articlesData.date}.md`);

--- a/src/summarize/html.ts
+++ b/src/summarize/html.ts
@@ -45,7 +45,35 @@ hr { border: none; border-top: 1px solid #e0e0e0; margin: 2rem 0; }
 strong { font-weight: 600; }
 em { font-style: italic; }
 .meta { color: #666; font-size: 0.85rem; margin-bottom: 2rem; }
+
+/* Report header */
+.report-header { border-left: 4px solid #0969da; padding-left: 1rem; margin-bottom: 1.5rem; }
+.report-header h1 { margin-bottom: 0.25rem; border-bottom: none; }
+
+/* Table of contents */
+.toc { background: #f6f8fa; border: 1px solid #e0e0e0; border-radius: 6px; padding: 1rem 1.5rem; margin-bottom: 2rem; }
+.toc h2 { margin-top: 0; border-bottom: none; font-size: 1rem; }
+.toc ul { margin-bottom: 0; }
+.toc a { font-size: 0.9rem; }
+
+/* Article Inventory list */
+#article-inventory + ol li { padding: 0.25rem 0; border-bottom: 1px solid #f0f0f0; }
+#article-inventory + ol li:last-child { border-bottom: none; }
+
+/* Build Notes panel */
+#build-notes ~ * { font-size: 0.9rem; color: #555; }
+#build-notes { font-size: 1rem; color: #666; margin-top: 2rem; border-top: 1px solid #e0e0e0; padding-top: 1rem; }
 `.trim();
+
+/**
+ * Convert a URL-friendly slug from plain text.
+ *
+ * Strips non-alphanumeric characters, lowercases, and collapses whitespace
+ * into hyphens. Used to generate stable heading ids.
+ */
+function slugify(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
 
 /**
  * Convert a simple Markdown string to HTML.
@@ -76,12 +104,13 @@ function markdownToHtml(md: string): string {
       continue;
     }
 
-    // Headings (h1–h6)
+    // Headings (h1–h6) — add stable id attribute
     const headingMatch = line.match(/^(#{1,6})\s+(.*)/);
     if (headingMatch) {
       const level = headingMatch[1].length;
       const text = inlineFormat(headingMatch[2]);
-      out.push(`<h${level}>${text}</h${level}>`);
+      const id = slugify(headingMatch[2]);
+      out.push(`<h${level} id="${id}">${text}</h${level}>`);
       i++;
       continue;
     }
@@ -166,6 +195,10 @@ function markdownToHtml(md: string): string {
 function inlineFormat(text: string): string {
   return (
     text
+      // HTML-escape angle brackets for XSS prevention (before other transforms)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
       // Inline code (must come before bold/italic to avoid conflicts)
       .replace(/`([^`]+)`/g, "<code>$1</code>")
       // Bold
@@ -199,6 +232,33 @@ export async function generateHtmlReport(mdPath: string): Promise<string> {
   const date = dateFromFilename(mdPath);
   const htmlContent = markdownToHtml(md);
 
+  // Extract the h1 heading for the report header
+  const h1Match = htmlContent.match(/<h1[^>]*>.*?<\/h1>/);
+  let headerHtml = "";
+  let bodyHtml = htmlContent;
+  if (h1Match) {
+    headerHtml = `<header class="report-header">\n  ${h1Match[0]}\n</header>`;
+    bodyHtml = htmlContent.slice(h1Match.index! + h1Match[0].length).trim();
+  } else {
+    headerHtml = `<header class="report-header">\n  <h1>WordPress Trend Report — ${date}</h1>\n</header>`;
+  }
+
+  // Build table of contents from h2 headings (if 2 or more exist)
+  const h2Regex = /<h2[^>]*id="([^"]*)"[^>]*>(.*?)<\/h2>/g;
+  const tocEntries: { id: string; text: string }[] = [];
+  let tocMatch: RegExpExecArray | null;
+  while ((tocMatch = h2Regex.exec(htmlContent)) !== null) {
+    tocEntries.push({ id: tocMatch[1], text: tocMatch[2] });
+  }
+
+  let tocHtml = "";
+  if (tocEntries.length >= 2) {
+    const links = tocEntries
+      .map((entry) => `    <li><a href="#${entry.id}">${entry.text}</a></li>`)
+      .join("\n");
+    tocHtml = `<nav class="toc">\n  <h2>Contents</h2>\n  <ul>\n${links}\n  </ul>\n</nav>`;
+  }
+
   const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -208,7 +268,11 @@ export async function generateHtmlReport(mdPath: string): Promise<string> {
   <style>${STYLESHEET}</style>
 </head>
 <body>
-  ${htmlContent}
+  ${headerHtml}
+  ${tocHtml}
+  <div class="report-body">
+  ${bodyHtml}
+</div>
 </body>
 </html>`;
 

--- a/src/summarize/html.ts
+++ b/src/summarize/html.ts
@@ -63,6 +63,30 @@ em { font-style: italic; }
 /* Build Notes panel */
 #build-notes ~ * { font-size: 0.9rem; color: #555; }
 #build-notes { font-size: 1rem; color: #666; margin-top: 2rem; border-top: 1px solid #e0e0e0; padding-top: 1rem; }
+
+/* Report index page */
+.report-card-grid { display: flex; flex-direction: column; gap: 0.75rem; }
+.report-card {
+  display: block;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.15s;
+}
+.report-card:hover { background: #f6f8fa; border-color: #d0d0d0; }
+.report-card-date { display: block; font-size: 1.05rem; font-weight: 500; margin-bottom: 0.15rem; }
+.report-card-label {
+  display: inline-block;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #888;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  padding: 0.1em 0.5em;
+}
 `.trim();
 
 /**
@@ -297,10 +321,30 @@ export async function generateIndexPage(reportsDir: string): Promise<string> {
     .sort()
     .reverse();
 
-  const links = htmlFiles
-    .map((f) => {
-      const date = f.replace(".html", "");
-      return `    <li><a href="${f}">${date}</a></li>`;
+  const reportCount = htmlFiles.length;
+  const reportLabel =
+    reportCount === 1
+      ? "1 weekly WordPress ecosystem trend report."
+      : `${reportCount} weekly WordPress ecosystem trend reports.`;
+
+  const cards = htmlFiles
+    .map((f, i) => {
+      const dateStr = f.replace(".html", "");
+      // Parse YYYY-MM-DD into a Date object for locale formatting
+      const [year, month, day] = dateStr.split("-").map(Number);
+      const dateObj = new Date(year, month - 1, day);
+      const formattedDate = dateObj.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+      const labelHtml =
+        i === 0
+          ? `\n    <span class="report-card-label">Latest report</span>`
+          : "";
+      return `    <a href="${f}" class="report-card">
+      <span class="report-card-date">${formattedDate}</span>${labelHtml}
+    </a>`;
     })
     .join("\n");
 
@@ -316,10 +360,10 @@ h1 { border-bottom: none; }
 </head>
 <body>
   <h1>WP Trend Watcher — Reports</h1>
-  <p class="meta">Weekly WordPress ecosystem trend reports.</p>
-  <ul>
-${links}
-  </ul>
+  <p class="meta">${reportLabel}</p>
+  <div class="report-card-grid">
+${cards}
+  </div>
 </body>
 </html>`;
 

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -9,6 +9,7 @@ import {
   type ArticlesJson,
   type ArticleSummary,
   findLatestArticlesJson,
+  findPreviousReportPath,
   loadExistingSummaries,
   writeSummariesJson,
   REPORT_SYSTEM_PROMPT,
@@ -192,6 +193,21 @@ async function main(): Promise<void> {
   const synthesisPromptTokens = synthesisResult.promptTokens;
   const synthesisCompletionTokens = synthesisResult.completionTokens;
 
+  // 6. Load previous report for comparison (non-blocking)
+  let previousReportMd: string | null = null;
+  try {
+    const reportsDir = join(process.cwd(), "reports");
+    const previousReportPath = await findPreviousReportPath(
+      reportsDir,
+      articlesData.date,
+    );
+    if (previousReportPath) {
+      previousReportMd = await readFile(previousReportPath, "utf8");
+    }
+  } catch {
+    // No previous report available — comparison section will be omitted
+  }
+
   // 6. Assemble and write report
   const report = assembleReport(
     articlesData.date,
@@ -201,6 +217,7 @@ async function main(): Promise<void> {
     provider,
     totalPromptTokens + synthesisPromptTokens,
     totalCompletionTokens + synthesisCompletionTokens,
+    previousReportMd,
   );
 
   const outputPath = join(process.cwd(), "reports", `${articlesData.date}.md`);

--- a/src/summarize/report-comparison.ts
+++ b/src/summarize/report-comparison.ts
@@ -150,3 +150,103 @@ export function normalizeLabel(label: string): string {
 
   return result;
 }
+
+// --- Comparison ---
+
+/**
+ * Build a "## Since Last Report" section comparing current report topics to
+ * previous report topics.
+ *
+ * For each topic, the label is normalized via {@link normalizeLabel} before
+ * comparison. Topics are classified as:
+ *
+ * - **Continued**: normalized label present in both current and previous
+ * - **New**: normalized label present in current but not in previous
+ * - **Dropped**: normalized label present in previous but not in current
+ *
+ * The output is at most 3 bullets, prioritising continued, then new, then
+ * dropped. The original (non-normalized) label from the current report is
+ * used for continued and new topics; the original label from the previous
+ * report is used for dropped topics.
+ *
+ * @param currentTopics - Topics parsed from the current report
+ * @param previousTopics - Topics parsed from the previous report
+ * @returns Markdown bullet list string, or null when there is nothing to report
+ */
+export function buildSinceLastReportSection(
+  currentTopics: ReportTopic[],
+  previousTopics: ReportTopic[],
+): string | null {
+  // No topics at all — nothing to compare
+  if (currentTopics.length === 0 && previousTopics.length === 0) {
+    return null;
+  }
+
+  // No previous topics — no meaningful "since last report" story
+  if (previousTopics.length === 0) {
+    return null;
+  }
+
+  // Build normalized → original label maps (first occurrence wins for original)
+  const currentMap = new Map<string, string>();
+  for (const t of currentTopics) {
+    const key = normalizeLabel(t.label);
+    if (!currentMap.has(key)) {
+      currentMap.set(key, t.label);
+    }
+  }
+
+  const previousMap = new Map<string, string>();
+  for (const t of previousTopics) {
+    const key = normalizeLabel(t.label);
+    if (!previousMap.has(key)) {
+      previousMap.set(key, t.label);
+    }
+  }
+
+  // Classify topics
+  const continued: string[] = [];
+  const newLabels: string[] = [];
+  const dropped: string[] = [];
+
+  for (const [key, label] of currentMap) {
+    if (previousMap.has(key)) {
+      continued.push(label);
+    } else {
+      newLabels.push(label);
+    }
+  }
+
+  for (const [key, label] of previousMap) {
+    if (!currentMap.has(key)) {
+      dropped.push(label);
+    }
+  }
+
+  // If there is nothing new or dropped, the sets are effectively identical
+  if (newLabels.length === 0 && dropped.length === 0) {
+    return null;
+  }
+
+  // Build bullets: at most 3, prioritising continued → new → dropped
+  const bullets: string[] = [];
+
+  for (const label of continued) {
+    if (bullets.length >= 3) break;
+    bullets.push(`* **Continued topic:** ${label}`);
+  }
+
+  for (const label of newLabels) {
+    if (bullets.length >= 3) break;
+    bullets.push(`* **New topic:** ${label}`);
+  }
+
+  for (const label of dropped) {
+    if (bullets.length >= 3) break;
+    bullets.push(`* **Dropped topic:** ${label}`);
+  }
+
+  if (bullets.length === 0) return null;
+
+  return bullets.join("\n");
+}

--- a/src/summarize/report-comparison.ts
+++ b/src/summarize/report-comparison.ts
@@ -1,0 +1,152 @@
+/**
+ * Shallow parsing of report sections to extract topic candidates
+ * for comparison between previous and current reports.
+ *
+ * Intentionally dumb — identifies repeated phrases and section items,
+ * not semantic similarity. No LLM call or historical store involved.
+ */
+
+// --- Types ---
+
+/** A topic candidate extracted from a report section. */
+export type ReportTopic = {
+  label: string;
+  source: "emerging-trends" | "developer-implications" | "article-inventory";
+};
+
+// --- Internal helpers ---
+
+const SECTION_PATTERNS: Array<{
+  heading: string;
+  source: ReportTopic["source"];
+}> = [
+  { heading: "### Emerging Trends", source: "emerging-trends" },
+  { heading: "### Developer Implications", source: "developer-implications" },
+  { heading: "### Article Inventory", source: "article-inventory" },
+];
+
+/**
+ * Build a RegExp that matches one of the known section headings.
+ * The `m` flag lets `^` match at line boundaries.
+ */
+function buildSectionPattern(): RegExp {
+  const names = SECTION_PATTERNS.map(
+    (s) => s.heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), // escape regex metacharacters
+  ).join("|");
+  return new RegExp(`^(${names})$`, "gm");
+}
+
+// --- Public API ---
+
+/**
+ * Parse a Markdown report and extract topic candidates from known sections.
+ *
+ * Looks for `### Emerging Trends`, `### Developer Implications`, and
+ * `### Article Inventory` sections. For each found section, extracts:
+ *   - Lines starting with `* ` (bullet list items)
+ *   - Lines starting with `N. ` (numbered list items)
+ *   - Heading-adjacent paragraph text (non-empty, non-list lines between
+ *     the heading and the first list item)
+ *
+ * Each extracted candidate is tagged with its section source.
+ *
+ * @param markdown - Full Markdown text of a trend report
+ * @returns Array of extracted topic candidates (empty if none found)
+ */
+export function parseReportTopics(markdown: string): ReportTopic[] {
+  if (!markdown) return [];
+
+  const topics: ReportTopic[] = [];
+  const sectionRe = buildSectionPattern();
+  let match: RegExpExecArray | null;
+
+  while ((match = sectionRe.exec(markdown)) !== null) {
+    const headingLine = match[1];
+    const source = SECTION_PATTERNS.find(
+      (s) => s.heading === headingLine,
+    )!.source;
+
+    // Slice from the end of the heading line to the end of the markdown
+    const afterHeading = markdown.slice(match.index + headingLine.length);
+
+    // Find the next heading at any level (h1–h6) to delimit the section
+    const nextHeading = afterHeading.match(/^#{1,6}\s/m);
+    const sectionContent = nextHeading
+      ? afterHeading.slice(0, nextHeading.index)
+      : afterHeading;
+
+    // Parse lines in the section content
+    const lines = sectionContent.split("\n");
+    let headingAdjacentText: string | null = null;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      // Bullet list item: * content
+      const bulletMatch = trimmed.match(/^\*\s+(.+)$/);
+      if (bulletMatch) {
+        // If we've been accumulating heading-adjacent text, emit it first
+        if (headingAdjacentText !== null) {
+          topics.push({ label: headingAdjacentText, source });
+          headingAdjacentText = null;
+        }
+        topics.push({ label: bulletMatch[1], source });
+        continue;
+      }
+
+      // Numbered list item: N. content
+      const numberedMatch = trimmed.match(/^\d+\.\s+(.+)$/);
+      if (numberedMatch) {
+        if (headingAdjacentText !== null) {
+          topics.push({ label: headingAdjacentText, source });
+          headingAdjacentText = null;
+        }
+        topics.push({ label: numberedMatch[1], source });
+        continue;
+      }
+
+      // Non-list, non-empty, non-heading text — accumulate as heading-adjacent
+      // paragraph (only the first contiguous block before list items)
+      if (headingAdjacentText === null) {
+        headingAdjacentText = trimmed;
+      }
+    }
+
+    // Emit leftover heading-adjacent text if section had no list items
+    if (headingAdjacentText !== null) {
+      topics.push({ label: headingAdjacentText, source });
+    }
+  }
+
+  return topics;
+}
+
+/**
+ * Normalize a topic label for shallow comparison.
+ *
+ * Steps:
+ * 1. Strip markdown links (`[text](url)` → `text`)
+ * 2. Lowercase
+ * 3. Remove punctuation characters except hyphens (`-`) and apostrophes (`'`)
+ * 4. Trim leading and trailing whitespace
+ *
+ * @param label - Raw label string to normalize
+ * @returns Normalized label
+ */
+export function normalizeLabel(label: string): string {
+  // Strip markdown links — replace [text](url) with just text
+  let result = label.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+
+  // Lowercase
+  result = result.toLowerCase();
+
+  // Remove punctuation except hyphens and apostrophes
+  // Keep: whitespace, a-z, 0-9, hyphens, apostrophes
+  result = result.replace(/[^\sa-z0-9'-]/g, "");
+
+  // Trim whitespace
+  result = result.trim();
+
+  return result;
+}

--- a/src/summarize/report.ts
+++ b/src/summarize/report.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir, readdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import type { SummarizeProvider } from "../providers.js";
 import { ensureSourceReferences } from "./source-refs.js";
@@ -54,7 +54,6 @@ export type SummariesJson = {
  * @throws If no articles.json files are found
  */
 export async function findLatestArticlesJson(): Promise<string> {
-  const { readdir } = await import("node:fs/promises");
   const articlesRoot = join(process.cwd(), "data/articles");
   const dateDirs = await readdir(articlesRoot);
   const sorted = dateDirs.sort().reverse();
@@ -70,6 +69,33 @@ export async function findLatestArticlesJson(): Promise<string> {
   }
 
   throw new Error("No articles.json files found. Run `pnpm collect` first.");
+}
+
+/**
+ * Find the Markdown report immediately before the current report date.
+ *
+ * Scans date-named Markdown files in the given reports directory, excluding
+ * index.md and the current report, then returns the newest report dated before
+ * the current date.
+ *
+ * @param reportsDir - Directory containing Markdown reports
+ * @param currentDate - Current report date in YYYY-MM-DD format
+ * @returns Absolute or relative path to the previous report, or null when none exists
+ */
+export async function findPreviousReportPath(
+  reportsDir: string,
+  currentDate: string,
+): Promise<string | null> {
+  const reportDatePattern = /^(\d{4}-\d{2}-\d{2})\.md$/;
+  const files = await readdir(reportsDir);
+  const previousReport = files
+    .map((file) => ({ file, match: file.match(reportDatePattern) }))
+    .filter((entry): entry is { file: string; match: RegExpMatchArray } =>
+      entry.match !== null && entry.match[1] < currentDate,
+    )
+    .sort((a, b) => b.match[1].localeCompare(a.match[1]))[0];
+
+  return previousReport ? join(reportsDir, previousReport.file) : null;
 }
 
 // --- Summary persistence ---

--- a/src/summarize/report.ts
+++ b/src/summarize/report.ts
@@ -2,6 +2,10 @@ import { readFile, writeFile, mkdir, readdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import type { SummarizeProvider } from "../providers.js";
 import { ensureSourceReferences } from "./source-refs.js";
+import {
+  parseReportTopics,
+  buildSinceLastReportSection,
+} from "./report-comparison.js";
 
 // --- Types ---
 
@@ -289,6 +293,9 @@ function stripGeneratedArticleInventory(synthesis: string): string {
  * sections for human review. Runs source-reference enforcement to catch any
  * articles the LLM omitted.
  *
+ * When a previous report is provided, a "## Since Last Report" section is
+ * inserted highlighting continued, new, and dropped topics.
+ *
  * @param date - Report date in YYYY-MM-DD format
  * @param articles - All collected articles
  * @param synthesis - LLM-generated synthesis text
@@ -296,6 +303,7 @@ function stripGeneratedArticleInventory(synthesis: string): string {
  * @param provider - The LLM provider (for build notes)
  * @param totalPromptTokens - Cumulative prompt tokens across all LLM calls
  * @param totalCompletionTokens - Cumulative completion tokens across all LLM calls
+ * @param previousReportMd - Full Markdown of the previous report (if any)
  * @returns Assembled Markdown report string
  */
 export function assembleReport(
@@ -306,6 +314,7 @@ export function assembleReport(
   provider: SummarizeProvider,
   totalPromptTokens: number,
   totalCompletionTokens: number,
+  previousReportMd?: string | null,
 ): string {
   const articleInventory = buildArticleInventorySection(summaries);
   const synthesisWithoutInventory = stripGeneratedArticleInventory(synthesis);
@@ -346,9 +355,20 @@ export function assembleReport(
       ? "$0.00 (local model)"
       : `$${cost.toFixed(4)}`;
 
+  // Build "Since Last Report" section if previous report is available
+  let sinceLastReportBlock = "";
+  if (previousReportMd) {
+    const currentTopics = parseReportTopics(weeklySummary);
+    const previousTopics = parseReportTopics(previousReportMd);
+    const slr = buildSinceLastReportSection(currentTopics, previousTopics);
+    if (slr !== null) {
+      sinceLastReportBlock = `\n\n## Since Last Report\n\n${slr}\n`;
+    }
+  }
+
   return `# WordPress Trend Report — ${date}
 
-${weeklySummary}
+${weeklySummary}${sinceLastReportBlock}
 
 ---
 

--- a/tests/summarize/html.test.ts
+++ b/tests/summarize/html.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { writeFile, mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { generateHtmlReport } from "../../src/summarize/html.js";
+import { generateHtmlReport, generateIndexPage } from "../../src/summarize/html.js";
 
 test("slugify produces stable lowercase-hyphenated strings", async () => {
   // We can test slugify indirectly by creating a .md with a heading
@@ -128,4 +128,92 @@ test("generateHtmlReport wraps report header with h1 inside .report-header", asy
   );
 
   assert.ok(html.includes('<h1 id="my-report-title">My Report Title</h1>'));
+});
+
+test("generateIndexPage renders report cards sorted by date descending", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "index-test-"));
+  // Create 3 HTML files with different dates
+  await writeFile(join(tmpDir, "2026-06-21.html"), "<html></html>", "utf8");
+  await writeFile(join(tmpDir, "2026-06-14.html"), "<html></html>", "utf8");
+  await writeFile(join(tmpDir, "2026-07-01.html"), "<html></html>", "utf8");
+
+  const indexPath = await generateIndexPage(tmpDir);
+  const html = await readFile(indexPath, "utf8");
+
+  // Extract report-card hrefs in order
+  const cardRegex = /<a\s+href="([^"]+\.html)"[^>]*class="report-card"/g;
+  const matches = [];
+  let m;
+  while ((m = cardRegex.exec(html)) !== null) {
+    matches.push(m[1]);
+  }
+
+  assert.equal(matches.length, 3);
+  assert.equal(matches[0], "2026-07-01.html");
+  assert.equal(matches[1], "2026-06-21.html");
+  assert.equal(matches[2], "2026-06-14.html");
+});
+
+test("generateIndexPage marks the newest report as Latest report", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "index-test-"));
+  await writeFile(join(tmpDir, "2026-01-01.html"), "<html></html>", "utf8");
+  await writeFile(join(tmpDir, "2026-06-15.html"), "<html></html>", "utf8");
+
+  const indexPath = await generateIndexPage(tmpDir);
+  const html = await readFile(indexPath, "utf8");
+
+  // Only the first card (newest) should have the "Latest report" label
+  const cards = html.match(/<a\s+href="([^"]+\.html)"[^>]*class="report-card"/g);
+  assert.ok(cards, "should have at least one report card");
+  assert.equal(cards.length, 2);
+
+  // The first card in the HTML should be the newest and have the label
+  const firstCardStart = html.indexOf('<a href="2026-06-15.html"');
+  const secondCardStart = html.indexOf('<a href="2026-01-01.html"');
+  assert.ok(firstCardStart >= 0, "newest report link should exist");
+  assert.ok(secondCardStart >= 0, "oldest report link should exist");
+  assert.ok(firstCardStart < secondCardStart, "newest should appear first");
+
+  // The Latest report label should appear once, after the first card's href
+  // but before the second card starts
+  const labelCount = (html.match(/Latest report/g) || []).length;
+  assert.equal(labelCount, 1);
+
+  const betweenCards = html.slice(firstCardStart, secondCardStart);
+  assert.ok(
+    betweenCards.includes("Latest report"),
+    "newest card should contain the Latest report label",
+  );
+});
+
+test("generateIndexPage shows correct report count", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "index-test-"));
+  await writeFile(join(tmpDir, "2026-06-21.html"), "<html></html>", "utf8");
+  await writeFile(join(tmpDir, "2026-06-14.html"), "<html></html>", "utf8");
+  await writeFile(join(tmpDir, "2026-06-07.html"), "<html></html>", "utf8");
+
+  const indexPath = await generateIndexPage(tmpDir);
+  const html = await readFile(indexPath, "utf8");
+
+  assert.ok(
+    html.includes("3 weekly WordPress ecosystem trend reports"),
+    `Expected "3 weekly WordPress ecosystem trend reports" in output`,
+  );
+});
+
+test("generateIndexPage skips index.html itself", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "index-test-"));
+  await writeFile(join(tmpDir, "2026-06-21.html"), "<html></html>", "utf8");
+  await writeFile(join(tmpDir, "2026-06-14.html"), "<html></html>", "utf8");
+  // index.html should already exist or we create one to ensure it's skipped
+  const indexPath = await generateIndexPage(tmpDir);
+  // Read the generated index to verify count
+  const html = await readFile(indexPath, "utf8");
+
+  // Count report cards
+  const cardCount = (html.match(/class="report-card"/g) || []).length;
+  assert.equal(cardCount, 2, "index.html should not be counted as a report card");
+
+  // Also verify no card links to index.html
+  assert.ok(!html.includes('href="index.html"'), "no card should link to index.html");
 });

--- a/tests/summarize/html.test.ts
+++ b/tests/summarize/html.test.ts
@@ -1,0 +1,131 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { writeFile, mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateHtmlReport } from "../../src/summarize/html.js";
+
+test("slugify produces stable lowercase-hyphenated strings", async () => {
+  // We can test slugify indirectly by creating a .md with a heading
+  // and checking the generated HTML for the correct id attribute.
+  const tmpDir = await mkdtemp(join(tmpdir(), "html-test-"));
+  const mdPath = join(tmpDir, "2026-06-21.md");
+  await writeFile(
+    mdPath,
+    "# Weekly Summary\n\nSome content.\n\n## Build Notes\n\nFine.",
+    "utf8",
+  );
+  const htmlPath = await generateHtmlReport(mdPath);
+  const html = await import("node:fs/promises").then((fs) =>
+    fs.readFile(htmlPath, "utf8"),
+  );
+
+  // h1 id should be "weekly-summary"
+  assert.ok(html.includes('<h1 id="weekly-summary">'));
+  // h2 id should be "build-notes"
+  assert.ok(html.includes('<h2 id="build-notes">'));
+});
+
+test("markdownToHtml adds heading ids to h1, h2, h3", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "html-test-"));
+  const mdPath = join(tmpDir, "2026-06-21.md");
+  await writeFile(
+    mdPath,
+    "# Top Level\n\n## Second Level\n\n### Third Level\n\nSome content.",
+    "utf8",
+  );
+  const htmlPath = await generateHtmlReport(mdPath);
+  const html = await import("node:fs/promises").then((fs) =>
+    fs.readFile(htmlPath, "utf8"),
+  );
+
+  assert.ok(html.includes('<h1 id="top-level">'));
+  assert.ok(html.includes('<h2 id="second-level">'));
+  assert.ok(html.includes('<h3 id="third-level">'));
+});
+
+test("markdownToHtml escapes text properly in heading ids — brackets/angles become hyphens", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "html-test-"));
+  const mdPath = join(tmpDir, "2026-06-21.md");
+  await writeFile(
+    mdPath,
+    "# Release v2.0 [beta]\n\n## What's <new>?\n\nSome content.",
+    "utf8",
+  );
+  const htmlPath = await generateHtmlReport(mdPath);
+  const html = await import("node:fs/promises").then((fs) =>
+    fs.readFile(htmlPath, "utf8"),
+  );
+
+  // h1 id should slugify brackets into hyphens: "release-v2-0-beta"
+  assert.ok(html.includes('<h1 id="release-v2-0-beta">'));
+  // Heading text renders brackets literally (they are not markdown links without parens)
+  assert.ok(html.includes("[beta]"));
+  // h2 id should slugify angle brackets and apostrophes: "whats-new" → "what-s-new"
+  assert.ok(html.includes('<h2 id="what-s-new">'));
+  // Angle brackets in text should be HTML-escaped for XSS prevention
+  assert.ok(html.includes("&lt;new&gt;"));
+  // Ensure the XSS angle brackets are NOT raw in the HTML
+  assert.ok(!html.includes("<new>"));
+});
+
+test("generateHtmlReport produces valid HTML with .report-header and .toc when enough headings exist", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "html-test-"));
+  const mdPath = join(tmpDir, "2026-06-21.md");
+  await writeFile(
+    mdPath,
+    "# WordPress Trend Report — 2026-06-21\n\n" +
+      "## Weekly Summary\n\nSummary here.\n\n" +
+      "## Since Last Report\n\nNothing new.\n\n" +
+      "## What I'm Watching\n\nWatching stuff.\n\n" +
+      "## Source Articles\n\nArticles here.\n\n" +
+      "## Build Notes\n\nBuilt with love.\n",
+    "utf8",
+  );
+  const htmlPath = await generateHtmlReport(mdPath);
+  const html = await import("node:fs/promises").then((fs) =>
+    fs.readFile(htmlPath, "utf8"),
+  );
+
+  assert.ok(html.includes('<header class="report-header">'));
+  assert.ok(html.includes('<nav class="toc">'));
+  assert.ok(html.includes("Contents"));
+  assert.ok(html.includes('<div class="report-body">'));
+  // TOC should have links to the h2 sections
+  assert.ok(html.includes('<a href="#weekly-summary">'));
+  assert.ok(html.includes('<a href="#build-notes">'));
+});
+
+test("generateHtmlReport does not produce TOC when only 1 heading exists", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "html-test-"));
+  const mdPath = join(tmpDir, "2026-06-21.md");
+  await writeFile(
+    mdPath,
+    "# WordPress Trend Report — 2026-06-21\n\nJust a single heading.\n",
+    "utf8",
+  );
+  const htmlPath = await generateHtmlReport(mdPath);
+  const html = await import("node:fs/promises").then((fs) =>
+    fs.readFile(htmlPath, "utf8"),
+  );
+
+  assert.ok(!html.includes('<nav class="toc">'));
+  assert.ok(html.includes('<header class="report-header">'));
+  assert.ok(html.includes('<div class="report-body">'));
+});
+
+test("generateHtmlReport wraps report header with h1 inside .report-header", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "html-test-"));
+  const mdPath = join(tmpDir, "2026-06-21.md");
+  await writeFile(
+    mdPath,
+    "# My Report Title\n\nJust content.\n",
+    "utf8",
+  );
+  const htmlPath = await generateHtmlReport(mdPath);
+  const html = await import("node:fs/promises").then((fs) =>
+    fs.readFile(htmlPath, "utf8"),
+  );
+
+  assert.ok(html.includes('<h1 id="my-report-title">My Report Title</h1>'));
+});

--- a/tests/summarize/report-comparison.test.ts
+++ b/tests/summarize/report-comparison.test.ts
@@ -1,0 +1,185 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseReportTopics,
+  normalizeLabel,
+  type ReportTopic,
+} from "../../src/summarize/report-comparison.js";
+
+// --- parseReportTopics ---
+
+test("parseReportTopics extracts topics from ### Emerging Trends with * items", () => {
+  const md =
+    [
+      "### Emerging Trends",
+      "",
+      "* WordPress 7.1 Release Planning",
+      "* Gutenberg 23.4 React 19 Integration",
+      "* Template Part Dynamic Loading",
+    ].join("\n") + "\n";
+
+  const topics = parseReportTopics(md);
+
+  assert.equal(topics.length, 3);
+  assert.equal(topics[0].source, "emerging-trends");
+  assert.equal(topics[0].label, "WordPress 7.1 Release Planning");
+  assert.equal(topics[1].source, "emerging-trends");
+  assert.equal(topics[1].label, "Gutenberg 23.4 React 19 Integration");
+  assert.equal(topics[2].source, "emerging-trends");
+  assert.equal(topics[2].label, "Template Part Dynamic Loading");
+});
+
+test("parseReportTopics extracts topics from ### Emerging Trends with mixed * and numbered items", () => {
+  const md =
+    [
+      "## Weekly Summary",
+      "",
+      "### Emerging Trends",
+      "",
+      "* WordCamp Europe 2026 Recap",
+      "* WordPress 7.1 Release Planning",
+      "1. Gutenberg 23.4 React 19 Integration",
+    ].join("\n") + "\n";
+
+  const topics = parseReportTopics(md);
+
+  assert.equal(topics.length, 3);
+  assert.equal(topics[0].source, "emerging-trends");
+  assert.equal(topics[0].label, "WordCamp Europe 2026 Recap");
+  assert.equal(topics[1].source, "emerging-trends");
+  assert.equal(topics[1].label, "WordPress 7.1 Release Planning");
+  assert.equal(topics[2].source, "emerging-trends");
+  assert.equal(topics[2].label, "Gutenberg 23.4 React 19 Integration");
+});
+
+test("parseReportTopics extracts topics from ### Developer Implications with numbered items", () => {
+  const md =
+    [
+      "### Developer Implications",
+      "",
+      "1. Prepare for WordPress 7.1 (August 19, 2026)",
+      "2. Monitor WordPress 7.0.1 (July 9, 2026)",
+      "3. Update Build Pipelines for React 19",
+      "",
+      "### Other Section",
+      "",
+      "* Not a developer implication",
+    ].join("\n") + "\n";
+
+  const topics = parseReportTopics(md);
+
+  assert.equal(topics.length, 3);
+  assert.equal(topics[0].source, "developer-implications");
+  assert.equal(
+    topics[0].label,
+    "Prepare for WordPress 7.1 (August 19, 2026)",
+  );
+  assert.equal(topics[1].source, "developer-implications");
+  assert.equal(topics[1].label, "Monitor WordPress 7.0.1 (July 9, 2026)");
+  assert.equal(topics[2].source, "developer-implications");
+  assert.equal(topics[2].label, "Update Build Pipelines for React 19");
+});
+
+test("parseReportTopics extracts topics from ### Article Inventory with numbered items + markdown links", () => {
+  const md =
+    [
+      "### Article Inventory",
+      "",
+      "1. [Roadmap to 7.1](https://make.wordpress.org/core/2026/06/19/roadmap-to-7-1/) (Make Core)",
+      "2. [WordPress 7.0.1 Release Schedule](https://make.wordpress.org/core/2026/06/18/wordpress-7-0-1-release-schedule/) (Make Core)",
+    ].join("\n") + "\n";
+
+  const topics = parseReportTopics(md);
+
+  assert.equal(topics.length, 2);
+  assert.equal(topics[0].source, "article-inventory");
+  assert.ok(
+    topics[0].label.includes("[Roadmap to 7.1]"),
+    `Expected label to contain markdown link, got: ${topics[0].label}`,
+  );
+  assert.equal(topics[1].source, "article-inventory");
+  assert.ok(
+    topics[1].label.includes("[WordPress 7.0.1 Release Schedule]"),
+    `Expected label to contain markdown link, got: ${topics[1].label}`,
+  );
+});
+
+test("parseReportTopics returns empty array for missing sections", () => {
+  const md =
+    [
+      "### Some Other Section",
+      "",
+      "* Item one",
+      "* Item two",
+    ].join("\n") + "\n";
+
+  assert.deepEqual(parseReportTopics(md), []);
+});
+
+test("parseReportTopics returns empty array for empty markdown", () => {
+  assert.deepEqual(parseReportTopics(""), []);
+});
+
+test("parseReportTopics extracts heading-adjacent paragraph as topic from ### Developer Implications", () => {
+  const md =
+    [
+      "### Developer Implications",
+      "",
+      "For freelance or agency WordPress developers:",
+      "",
+      "* Prepare for WordPress 7.1 (August 19, 2026)",
+      "* Monitor WordPress 7.0.1 (July 9, 2026)",
+    ].join("\n") + "\n";
+
+  const topics = parseReportTopics(md);
+
+  // Should include the heading-adjacent paragraph + the 2 list items
+  assert.equal(topics.length, 3);
+  assert.equal(topics[0].source, "developer-implications");
+  assert.equal(
+    topics[0].label,
+    "For freelance or agency WordPress developers:",
+  );
+  assert.equal(topics[1].source, "developer-implications");
+  assert.equal(
+    topics[1].label,
+    "Prepare for WordPress 7.1 (August 19, 2026)",
+  );
+  assert.equal(topics[2].source, "developer-implications");
+  assert.equal(topics[2].label, "Monitor WordPress 7.0.1 (July 9, 2026)");
+});
+
+// --- normalizeLabel ---
+
+test("normalizeLabel strips markdown links, lowercases, removes punctuation", () => {
+  const input = "[Hello World](https://example.com) — Test!";
+  const result = normalizeLabel(input);
+
+  // Strip link:  "Hello World — Test!"
+  // Lowercase:   "hello world — test!"
+  // Remove punct: "hello world  test"
+  // Trim:        "hello world  test"
+  assert.equal(result, "hello world  test");
+});
+
+test("normalizeLabel preserves hyphens and apostrophes", () => {
+  const result = normalizeLabel(
+    "WordPress 7.1 Release Planning - It's great!",
+  );
+
+  // No links:     "WordPress 7.1 Release Planning - It's great!"
+  // Lowercase:    "wordpress 7.1 release planning - it's great!"
+  // Remove punct: "wordpress 71 release planning - it's great"
+  // Trim:         "wordpress 71 release planning - it's great"
+  assert.equal(result, "wordpress 71 release planning - it's great");
+});
+
+test("normalizeLabel trims leading and trailing whitespace", () => {
+  const result = normalizeLabel("  [Hello](https://example.com)  ");
+  assert.equal(result, "hello");
+});
+
+test("normalizeLabel handles string with no markdown or punctuation", () => {
+  const result = normalizeLabel("Hello World");
+  assert.equal(result, "hello world");
+});

--- a/tests/summarize/report-comparison.test.ts
+++ b/tests/summarize/report-comparison.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   parseReportTopics,
   normalizeLabel,
+  buildSinceLastReportSection,
   type ReportTopic,
 } from "../../src/summarize/report-comparison.js";
 
@@ -182,4 +183,157 @@ test("normalizeLabel trims leading and trailing whitespace", () => {
 test("normalizeLabel handles string with no markdown or punctuation", () => {
   const result = normalizeLabel("Hello World");
   assert.equal(result, "hello world");
+});
+
+// --- buildSinceLastReportSection ---
+
+/**
+ * Helper to create a ReportTopic with the given label.
+ * Source is irrelevant for comparison tests.
+ */
+function topic(label: string, source: ReportTopic["source"] = "emerging-trends"): ReportTopic {
+  return { label, source };
+}
+
+test("buildSinceLastReportSection returns null when both topic arrays are empty", () => {
+  const result = buildSinceLastReportSection([], []);
+  assert.equal(result, null);
+});
+
+test("buildSinceLastReportSection returns null when previous topics array is empty", () => {
+  const result = buildSinceLastReportSection(
+    [topic("WordPress 7.1 Release Planning")],
+    [],
+  );
+  assert.equal(result, null);
+});
+
+test("buildSinceLastReportSection returns null when topic sets are identical", () => {
+  const current = [
+    topic("WordPress 7.1 Release Planning"),
+    topic("Gutenberg 23.4 React 19 Integration"),
+  ];
+  const previous = [
+    topic("WordPress 7.1 Release Planning"),
+    topic("Gutenberg 23.4 React 19 Integration"),
+  ];
+  const result = buildSinceLastReportSection(current, previous);
+  assert.equal(result, null);
+});
+
+test("buildSinceLastReportSection returns single continued bullet when one topic continued and one is new", () => {
+  // current has [A, B], previous has [A] → A is continued, B is new
+  const current = [
+    topic("WordPress 7.1 Release Planning"),
+    topic("Gutenberg 23.4 React 19 Integration"),
+  ];
+  const previous = [
+    topic("WordPress 7.1 Release Planning"),
+  ];
+  const result = buildSinceLastReportSection(current, previous);
+  assert.ok(result !== null);
+  assert.ok(result.includes("**Continued topic:**"));
+  assert.ok(result.includes("WordPress 7.1 Release Planning"));
+  // Should include both the continued and new bullets
+  assert.ok(result.includes("**New topic:**"));
+  assert.ok(result.includes("Gutenberg 23.4 React 19 Integration"));
+});
+
+test("buildSinceLastReportSection returns bullets prioritizing continued, then new, then dropped", () => {
+  const current = [
+    topic("Continued A"),
+    topic("New C"),
+  ];
+  const previous = [
+    topic("Continued A"),
+    topic("Dropped B"),
+  ];
+  const result = buildSinceLastReportSection(current, previous);
+  assert.ok(result !== null);
+
+  const lines = result.split("\n");
+  // First bullet should be continued, second should be new, third should be dropped
+  assert.ok(lines[0].includes("**Continued topic:**"));
+  assert.ok(lines[0].includes("Continued A"));
+  assert.ok(lines[1].includes("**New topic:**"));
+  assert.ok(lines[1].includes("New C"));
+  assert.ok(lines[2].includes("**Dropped topic:**"));
+  assert.ok(lines[2].includes("Dropped B"));
+});
+
+test("buildSinceLastReportSection caps at 3 bullets when there are more than 3 changes", () => {
+  const current = [
+    topic("C1"),
+    topic("C2"),
+    topic("C3"),
+    topic("N1"),
+    topic("N2"),
+  ];
+  const previous = [
+    topic("C1"),
+    topic("C2"),
+    topic("C3"),
+    topic("D1"),
+    topic("D2"),
+    topic("D3"),
+  ];
+  const result = buildSinceLastReportSection(current, previous);
+  assert.ok(result !== null);
+
+  const lines = result.split("\n");
+  assert.equal(lines.length, 3);
+  // All three should be continued (highest priority)
+  assert.ok(lines[0].includes("**Continued topic:**"));
+  assert.ok(lines[1].includes("**Continued topic:**"));
+  assert.ok(lines[2].includes("**Continued topic:**"));
+});
+
+test("buildSinceLastReportSection uses normalized matching for continued topics", () => {
+  // Labels that differ only in punctuation should match as continued.
+  // Include a second new topic so the comparison is not empty (no new/dropped).
+  const current = [
+    topic("WordPress 7.1 Release Planning!"),
+    topic("Brand New Topic"),
+  ];
+  const previous = [
+    topic("WordPress 7.1 Release Planning"),
+  ];
+  const result = buildSinceLastReportSection(current, previous);
+  assert.ok(result !== null);
+  assert.ok(result.includes("**Continued topic:**"));
+  // Should use the current label (with the exclamation) in the output
+  assert.ok(result.includes("WordPress 7.1 Release Planning!"));
+  // Should use current label for new topic
+  assert.ok(result.includes("Brand New Topic"));
+});
+
+test("buildSinceLastReportSection includes both continued and dropped when no new topics", () => {
+  const current = [
+    topic("WordPress 7.1 Release Planning"),
+  ];
+  const previous = [
+    topic("WordPress 7.1 Release Planning"),
+    topic("Gutenberg 23.4"),
+  ];
+  const result = buildSinceLastReportSection(current, previous);
+  assert.ok(result !== null);
+  assert.ok(result.includes("**Continued topic:**"));
+  assert.ok(result.includes("WordPress 7.1 Release Planning"));
+  assert.ok(result.includes("**Dropped topic:**"));
+  assert.ok(result.includes("Gutenberg 23.4"));
+});
+
+test("buildSinceLastReportSection uses current label for continued and new, previous label for dropped", () => {
+  // Labels may differ slightly due to normalization, but output uses original labels
+  const current = [
+    topic("WordPress 7.1!"),
+  ];
+  const previous = [
+    topic("WordPress 7.1!"),
+    topic("Dropped Item (old)"),
+  ];
+  const result = buildSinceLastReportSection(current, previous);
+  assert.ok(result !== null);
+  assert.ok(result.includes("WordPress 7.1!"));
+  assert.ok(result.includes("Dropped Item (old)"));
 });

--- a/tests/summarize/report.test.ts
+++ b/tests/summarize/report.test.ts
@@ -1,10 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   buildReportPrompt,
   buildArticleInventorySection,
   assembleReport,
   isHighSignalReleasePlanningArticle,
+  findPreviousReportPath,
 } from "../../src/summarize/report.js";
 import type {
   ArticleSummary,
@@ -49,6 +53,64 @@ function makeSummary(
     completionTokens: overrides.completionTokens ?? 50,
   };
 }
+
+async function makeReportsDir(files: string[]): Promise<string> {
+  const reportsDir = await mkdtemp(join(tmpdir(), "wp-trend-reports-"));
+  await Promise.all(
+    files.map((file) => writeFile(join(reportsDir, file), "# Report\n", "utf8")),
+  );
+  return reportsDir;
+}
+
+// --- findPreviousReportPath ---
+
+test("findPreviousReportPath finds the immediate previous date", async () => {
+  const reportsDir = await makeReportsDir([
+    "2026-06-06.md",
+    "2026-06-13.md",
+    "2026-06-20.md",
+  ]);
+
+  const previous = await findPreviousReportPath(reportsDir, "2026-06-20");
+
+  assert.equal(previous, join(reportsDir, "2026-06-13.md"));
+});
+
+test("findPreviousReportPath ignores future reports", async () => {
+  const reportsDir = await makeReportsDir([
+    "2026-06-13.md",
+    "2026-06-20.md",
+    "2026-06-27.md",
+  ]);
+
+  const previous = await findPreviousReportPath(reportsDir, "2026-06-20");
+
+  assert.equal(previous, join(reportsDir, "2026-06-13.md"));
+});
+
+test("findPreviousReportPath ignores index.md", async () => {
+  const reportsDir = await makeReportsDir([
+    "index.md",
+    "2026-06-13.md",
+    "2026-06-20.md",
+  ]);
+
+  const previous = await findPreviousReportPath(reportsDir, "2026-06-20");
+
+  assert.equal(previous, join(reportsDir, "2026-06-13.md"));
+});
+
+test("findPreviousReportPath returns null with no previous report", async () => {
+  const reportsDir = await makeReportsDir([
+    "index.md",
+    "2026-06-20.md",
+    "2026-06-27.md",
+  ]);
+
+  const previous = await findPreviousReportPath(reportsDir, "2026-06-20");
+
+  assert.equal(previous, null);
+});
 
 // --- buildReportPrompt ---
 


### PR DESCRIPTION
## Summary
- Add `findPreviousReportPath(reportsDir, currentDate)` for Phase 4 previous-report discovery.
- Scan date-named Markdown reports and return the newest report before the current date.
- Cover immediate previous report, future report filtering, `index.md` filtering, and no previous report cases.

## Verification
- `corepack pnpm exec tsx --test tests/summarize/report.test.ts` — 22 passed
- `corepack pnpm run test` — 84 passed
- `corepack pnpm run typecheck` — passed

## Review
- Independent code-review pass: APPROVED, no required fixes

## Notes
- This is Phase 4 Task 1 only. It does not wire the helper into report generation yet.
