### PR TITLE
feat: add back-to-index and feedback navigation to HTML output

### DIFF
--- a/src/summarize/html.ts
+++ b/src/summarize/html.ts
@@ -87,6 +87,16 @@ em { font-style: italic; }
   border-radius: 3px;
   padding: 0.1em 0.5em;
 }
+
+/* Navigation footer */
+.nav-footer {
+  margin-top: 3rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e0e0e0;
+  font-size: 0.9rem;
+  color: #666;
+}
+.nav-footer a { color: #0969da; }
 `.trim();
 
 /**
@@ -297,6 +307,9 @@ export async function generateHtmlReport(mdPath: string): Promise<string> {
   <div class="report-body">
   ${bodyHtml}
 </div>
+  <footer class="nav-footer">
+    <a href="index.html">← Back to Reports</a>
+  </footer>
 </body>
 </html>`;
 
@@ -364,6 +377,13 @@ h1 { border-bottom: none; }
   <div class="report-card-grid">
 ${cards}
   </div>
+  <footer class="nav-footer">
+    <p>
+      <a href="https://github.com/colorful-tones/wp-trend-watcher/issues/new?template=source-suggestion.yml">Suggest a source</a>
+      &nbsp;·&nbsp;
+      <a href="https://github.com/colorful-tones/wp-trend-watcher/issues/new?template=report-feedback.yml">Send feedback</a>
+    </p>
+  </footer>
 </body>
 </html>`;
 

--- a/tests/summarize/html.test.ts
+++ b/tests/summarize/html.test.ts
@@ -217,3 +217,53 @@ test("generateIndexPage skips index.html itself", async () => {
   // Also verify no card links to index.html
   assert.ok(!html.includes('href="index.html"'), "no card should link to index.html");
 });
+
+test("generateHtmlReport includes back-to-index footer link", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "html-test-"));
+  const mdPath = join(tmpDir, "2026-06-21.md");
+  await writeFile(
+    mdPath,
+    "# My Report\n\n## Section One\n\nSome content.\n",
+    "utf8",
+  );
+  const htmlPath = await generateHtmlReport(mdPath);
+  const html = await readFile(htmlPath, "utf8");
+
+  assert.ok(
+    html.includes('<footer class="nav-footer">'),
+    "report should include nav-footer",
+  );
+  assert.ok(
+    html.includes('<a href="index.html">← Back to Reports</a>'),
+    "report should include back-to-index link",
+  );
+});
+
+test("generateIndexPage includes feedback and source suggestion links", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "index-test-"));
+  await writeFile(join(tmpDir, "2026-06-21.html"), "<html></html>", "utf8");
+
+  const indexPath = await generateIndexPage(tmpDir);
+  const html = await readFile(indexPath, "utf8");
+
+  assert.ok(
+    html.includes("Suggest a source"),
+    "index page should include source suggestion link",
+  );
+  assert.ok(
+    html.includes("source-suggestion.yml"),
+    "source suggestion link should point to the issue template",
+  );
+  assert.ok(
+    html.includes("Send feedback"),
+    "index page should include feedback link",
+  );
+  assert.ok(
+    html.includes("report-feedback.yml"),
+    "feedback link should point to the issue template",
+  );
+  assert.ok(
+    html.includes('<footer class="nav-footer">'),
+    "index page should include nav-footer",
+  );
+});


### PR DESCRIPTION
## Summary

Adds navigation footers to HTML output: individual report pages get a "Back to Reports" link, and the reports index page gets feedback and source suggestion links pointing to the existing GitHub issue templates.

**Individual reports:**
- Footer with "← Back to Reports" link pointing to `index.html`

**Reports index page:**
- Footer with "Suggest a source" → `source-suggestion.yml` template
- "Send feedback" → `report-feedback.yml` template
- Separated with a dot, styled with the same `.nav-footer` class

**CSS:**
- New `.nav-footer` style: top border, muted text, spacing from content

## Verification

- 116 tests pass (2 new), typecheck clean
