### PR TITLE
feat: auto-calculate --days from last report date

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,25 @@ Both templates walk you through what's needed — takes about a minute.
 
 ## Changelog
 
+### 0.4.1
+
+**README and documentation overhaul:**
+- Added Requirements section with Node/pnpm/Corepack/LLM prerequisites
+- Added Latest Reports section linking to the GitHub Pages index
+- Added Feedback & Sources section linking to the GitHub issue templates (report feedback and source suggestion)
+- Removed stale Status snapshot, What This Does Not Do Yet, Report Format, and Data Snapshot Policy (all covered by docs/ or Project Principles)
+- New `docs/weekly-workflow.md` — 7-step command sequence quick reference with scannable table
+
+**HTML navigation polish:**
+- Individual report pages now include a "← Back to Reports" footer link
+- Reports index page now includes "Suggest a source" and "Send feedback" footer links pointing to the issue templates
+- New `.nav-footer` CSS class for consistent navigation styling
+
+**Smarter default collection window:**
+- `pnpm collect` now auto-calculates `--days` from the most recent report date instead of defaulting to 7
+- Priority: explicit `--days N` flag → `WP_TREND_DAYS` env var → auto-calculated from last report → 7 day fallback
+- New `findDaysSinceLastReport` helper scans `reports/` for date-named `.md` files
+
 ### 0.4.0 — Phase 4 Release
 
 **Previous-report comparison:**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,

--- a/src/collect/index.ts
+++ b/src/collect/index.ts
@@ -1,4 +1,6 @@
 import Parser from "rss-parser";
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
 import { loadEnvFile, parseNonNegativeIntegerEnv } from "../env.js";
 import { type Source } from "../sources.js";
 import { loadSources } from "../load-sources.js";
@@ -56,17 +58,71 @@ function toCollectedArticle(source: Source, item: FeedItem): CollectedArticle[] 
   ];
 }
 
-function parseDaysArg(): number {
+async function parseDaysArg(): Promise<number> {
   const daysIndex = process.argv.indexOf("--days");
-  if (daysIndex === -1 || daysIndex === process.argv.length - 1) {
-    return parseNonNegativeIntegerEnv("WP_TREND_DAYS", 7);
+  if (daysIndex !== -1 && daysIndex < process.argv.length - 1) {
+    const value = parseInt(process.argv[daysIndex + 1], 10);
+    if (!isNaN(value) && value >= 0) {
+      return value;
+    }
+    console.warn("Invalid --days value, using automatic detection");
   }
-  const value = parseInt(process.argv[daysIndex + 1], 10);
-  if (isNaN(value) || value < 0) {
-    console.warn("Invalid --days value, defaulting to 7");
-    return 7;
+  return resolveDefaultDays();
+}
+
+/**
+ * Resolve the default `--days` value when no explicit flag is passed.
+ *
+ * Priority:
+ * 1. `WP_TREND_DAYS` env var
+ * 2. Days since the most recent report in `reports/`
+ * 3. 7 days
+ */
+async function resolveDefaultDays(): Promise<number> {
+  const envDays = parseNonNegativeIntegerEnv("WP_TREND_DAYS", -1);
+  if (envDays !== -1) {
+    return envDays;
   }
-  return value;
+  return (await findDaysSinceLastReport()) ?? 7;
+}
+
+/**
+ * Scan `reports/` for the most recent YYYY-MM-DD.md file and return
+ * the number of days between that date and today.
+ *
+ * @param reportsDir - Optional reports directory path (defaults to cwd/reports)
+ * @returns Number of days, or null when no reports exist or the directory is absent.
+ */
+export async function findDaysSinceLastReport(
+  reportsDir?: string,
+): Promise<number | null> {
+  const dir = reportsDir ?? join(process.cwd(), "reports");
+  const reportDatePattern = /^(\d{4}-\d{2}-\d{2})\.md$/;
+
+  let files: string[];
+  try {
+    files = await readdir(dir);
+  } catch {
+    return null;
+  }
+
+  const dates = files
+    .map((file) => file.match(reportDatePattern))
+    .filter((match): match is RegExpMatchArray => match !== null)
+    .map((match) => match[1])
+    .sort()
+    .reverse();
+
+  if (dates.length === 0) {
+    return null;
+  }
+
+  const latestDate = new Date(dates[0]);
+  const today = new Date();
+  const diffMs = today.getTime() - latestDate.getTime();
+  // Add 1 so a report generated today yields 1 day (not 0),
+  // and a report from yesterday catches articles from both days.
+  return Math.max(1, Math.ceil(diffMs / (1000 * 60 * 60 * 24)) + 1);
 }
 
 function filterRecentArticles(articles: CollectedArticle[], days: number): CollectedArticle[] {
@@ -87,7 +143,7 @@ function filterRecentArticles(articles: CollectedArticle[], days: number): Colle
 async function main(): Promise<void> {
   loadEnvFile();
 
-  const recentDays = parseDaysArg();
+  const recentDays = await parseDaysArg();
   const sources = await loadSources();
   const sourceCount = sources.length;
   const tier1Count = sources.filter((s) => s.tier === 1).length;

--- a/tests/collect/auto-days.test.ts
+++ b/tests/collect/auto-days.test.ts
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findDaysSinceLastReport } from "../../src/collect/index.js";
+
+test("findDaysSinceLastReport returns null when directory does not exist", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "auto-days-test-"));
+  const result = await findDaysSinceLastReport(join(dir, "nonexistent"));
+  assert.equal(result, null);
+});
+
+test("findDaysSinceLastReport returns null when directory is empty", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "auto-days-test-"));
+  const reportsDir = join(dir, "reports");
+  await mkdir(reportsDir);
+  const result = await findDaysSinceLastReport(reportsDir);
+  assert.equal(result, null);
+});
+
+test("findDaysSinceLastReport returns null when no date-named .md files exist", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "auto-days-test-"));
+  const reportsDir = join(dir, "reports");
+  await mkdir(reportsDir);
+  await writeFile(join(reportsDir, "index.md"), "# Index\n", "utf8");
+  await writeFile(join(reportsDir, "README.md"), "# README\n", "utf8");
+  await writeFile(join(reportsDir, "index.html"), "<html></html>", "utf8");
+
+  const result = await findDaysSinceLastReport(reportsDir);
+  assert.equal(result, null);
+});
+
+test("findDaysSinceLastReport returns a positive number for a report from today", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "auto-days-test-"));
+  const reportsDir = join(dir, "reports");
+  await mkdir(reportsDir);
+
+  // Create a report dated today
+  const today = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const dateStr = `${today.getFullYear()}-${pad(today.getMonth() + 1)}-${pad(today.getDate())}`;
+  await writeFile(join(reportsDir, `${dateStr}.md`), "# Test\n", "utf8");
+
+  const result = await findDaysSinceLastReport(reportsDir);
+  assert.ok(result !== null, "should find the today report");
+  assert.ok(result! >= 1, "should return at least 1 day");
+});
+
+test("findDaysSinceLastReport picks the most recent report when multiple exist", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "auto-days-test-"));
+  const reportsDir = join(dir, "reports");
+  await mkdir(reportsDir);
+
+  const pad = (n: number) => String(n).padStart(2, "0");
+
+  // Create a report from 30 days ago
+  const oldDate = new Date();
+  oldDate.setDate(oldDate.getDate() - 30);
+  const oldDateStr = `${oldDate.getFullYear()}-${pad(oldDate.getMonth() + 1)}-${pad(oldDate.getDate())}`;
+  await writeFile(join(reportsDir, `${oldDateStr}.md`), "# Old\n", "utf8");
+
+  // Create a report from 1 day ago
+  const recentDate = new Date();
+  recentDate.setDate(recentDate.getDate() - 1);
+  const recentDateStr = `${recentDate.getFullYear()}-${pad(recentDate.getMonth() + 1)}-${pad(recentDate.getDate())}`;
+  await writeFile(join(reportsDir, `${recentDateStr}.md`), "# Recent\n", "utf8");
+
+  const result = await findDaysSinceLastReport(reportsDir);
+  assert.ok(result !== null, "should find reports");
+
+  // Days since 1 day ago should be roughly 2 (ceil(1) + 1)
+  assert.ok(result! <= 3, "should calculate roughly 2 days from 1 day ago");
+  assert.ok(result! >= 1, "should be a positive number");
+});
+
+test("findDaysSinceLastReport ignores .html files and non-date patterns", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "auto-days-test-"));
+  const reportsDir = join(dir, "reports");
+  await mkdir(reportsDir);
+
+  // Create non-matching files
+  await writeFile(join(reportsDir, "2026-06.html"), "<html></html>", "utf8");
+  await writeFile(join(reportsDir, "report-june.md"), "# Report\n", "utf8");
+  await writeFile(join(reportsDir, "2026.md"), "# Year only\n", "utf8");
+
+  const result = await findDaysSinceLastReport(reportsDir);
+  assert.equal(result, null, "non-date-pattern files should be ignored");
+});


### PR DESCRIPTION
## Summary

`pnpm collect` now automatically calculates the `--days` window from the most recent report date instead of defaulting to 7.

**Priority:**
1. Explicit `--days N` flag (unchanged)
2. `WP_TREND_DAYS` env var (unchanged)
3. Auto-calculated from last report in `reports/` (new)
4. 7 days fallback (unchanged)

**How it works:** `findDaysSinceLastReport` scans `reports/` for date-named `.md` files, picks the most recent, and returns days since that date. If you generated a report yesterday, `pnpm collect` will fetch ~2 days of articles. If your last report was 2 weeks ago, it fetches ~15 days.

## Verification

- 122 tests pass (6 new), typecheck clean