### PR TITLE
test: stabilize auto-days assertion

### DIFF
--- a/tests/collect/auto-days.test.ts
+++ b/tests/collect/auto-days.test.ts
@@ -70,7 +70,7 @@ test("findDaysSinceLastReport picks the most recent report when multiple exist",
   assert.ok(result !== null, "should find reports");
 
   // Days since 1 day ago should be roughly 2 (ceil(1) + 1)
-  assert.ok(result! <= 3, "should calculate roughly 2 days from 1 day ago");
+  assert.ok(result! <= 4, "should return a small number for a 1-day-old report");
   assert.ok(result! >= 1, "should be a positive number");
 });
 

--- a/tests/collect/auto-days.test.ts
+++ b/tests/collect/auto-days.test.ts
@@ -69,7 +69,9 @@ test("findDaysSinceLastReport picks the most recent report when multiple exist",
   const result = await findDaysSinceLastReport(reportsDir);
   assert.ok(result !== null, "should find reports");
 
-  // Days since 1 day ago should be roughly 2 (ceil(1) + 1)
+  // A filename date (e.g. "YYYY-MM-DD.md") is parsed as UTC midnight.
+  // Compared to local current time, a one-day-old report typically yields 3
+  // and can reach 4 in negative-offset timezones late in the day.
   assert.ok(result! <= 4, "should return a small number for a 1-day-old report");
   assert.ok(result! >= 1, "should be a positive number");
 });


### PR DESCRIPTION
## Summary

Stabilizes the Phase 6 auto-days test at the timezone boundary.

- allows the documented `findDaysSinceLastReport()` UTC/local-time range through `4`
- replaces the stale timing comment with the actual UTC-midnight parsing explanation
- production behavior is unchanged

## Verification

- `pnpm run test` — 124 passed, 0 failed
- `pnpm run typecheck` — passed
- independent `code-review` review — approved

## Scope boundary

Test-only change: `tests/collect/auto-days.test.ts`. No source, dependency, report, documentation, or package-version changes.

## Human review focus

Please confirm the widened upper bound (`<= 4`) correctly captures the intended timezone-aware range without changing collection behavior.
