### PR TITLE
chore: align package version with changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,


### PR DESCRIPTION
## Summary

Aligns the package version with the existing `0.4.2` README changelog entry.

- changes `package.json` version from `0.4.1` to `0.4.2`
- leaves dependencies, lockfiles, README, and project behavior unchanged

## Verification

- `pnpm run test` — 124 passed, 0 failed
- `pnpm run typecheck` — passed
- independent `code-review` — approved

## Scope boundary

One-line version-metadata correction only.

## Human review focus

Confirm that the existing README `0.4.2` changelog entry is the intended release metadata for this package version.
