### PR TITLE
docs: correct token cap example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pnpm collect           # add -- --days 7 for recent articles
 pnpm summarize         # requires a local LLM endpoint for summarization
 ```
 
-Summarization requires a local LLM provider (see Requirements above). LM Studio users should set `WP_TREND_MAX_TOKENS=*** in `.env` for predictable report generation. The CLI automatically loads `.env` from the project root.
+Summarization requires a local LLM provider (see Requirements above). LM Studio users should set `WP_TREND_MAX_TOKENS=2048` in `.env` for predictable report generation. The CLI automatically loads `.env` from the project root.
 
 ## What This Does
 


### PR DESCRIPTION
## Summary

Repairs the malformed LM Studio completion-cap example in the README.

- changes the displayed value from `***` to `2048`
- restores the missing closing inline-code backtick
- matches the existing recommendation in `docs/summarization.md`

## Verification

- focused documentation content check — passed
- `pnpm run test` — 124 passed, 0 failed
- `pnpm run typecheck` — passed
- independent `code-review` — approved

## Scope boundary

One README line only. No configuration, dependency, source, report, or package-version changes.

## Human review focus

Confirm the Quick Start recommendation is clear and consistent with the detailed provider configuration guide.
