### PR TITLE
docs: Phase 6 documentation cleanup and release metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ Both templates walk you through what's needed — takes about a minute.
 
 ## Changelog
 
+### 0.4.3
+
+- Repaired flaky auto-days test assertion.
+- Aligned package version with changelog.
+- Corrected README token-cap example.
+- Corrected weekly-workflow auto-window documentation.
+- Removed stale Phase 1 phrasing from active docs.
+
 ### 0.4.2
 
 - Changed generated HTML reports and the report index to share `reports/assets/report.css` instead of embedding the full stylesheet in every HTML file.

--- a/docs/cost-notes.md
+++ b/docs/cost-notes.md
@@ -4,7 +4,7 @@ WP Trend Watcher should make AI cost visible.
 
 The target is practical usage, not impressive automation.
 
-## Phase 1 Cost Targets
+## Cost Targets
 
 - Personal usage: less than $1/month.
 - Heavier usage: less than $5/month.

--- a/docs/human-review.md
+++ b/docs/human-review.md
@@ -58,7 +58,7 @@ A transparency section that may include:
 
 ## Publishing Rule
 
-Do not publish automatically in Phase 1.
+Do not publish automatically.
 
 The output of the tool is a draft. The public report is a reviewed artifact.
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -41,7 +41,7 @@ Potential providers may include:
 - Gemini
 - other compatible APIs
 
-Phase 1 should not overbuild provider support. Start with the smallest provider abstraction that allows future swapping.
+Avoid overbuilding provider support. Use the smallest provider abstraction that allows future swapping.
 
 ## Open Source First
 
@@ -59,7 +59,7 @@ Public docs should explain:
 
 Avoid unnecessary architecture until the core workflow proves useful.
 
-Phase 1 avoids:
+This project avoids:
 
 - vector databases
 - embeddings

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -1,8 +1,8 @@
 # Sources
 
-This file defines the Phase 1 source list and source-selection rules.
+This file defines the source list and source-selection rules.
 
-## Phase 1 Source Rules
+## Source Rules
 
 A source belongs in this project if it:
 

--- a/docs/weekly-workflow.md
+++ b/docs/weekly-workflow.md
@@ -26,7 +26,7 @@ pnpm collect -- --days 7
 
 Fetches RSS feeds from all configured sources (6 by default: 4 Tier 1 + 2 Tier 2). Filters to articles published in the last 7 days, deduplicates, and writes `data/articles/YYYY-MM-DD/articles.json`.
 
-- Omit `-- --days 7` to collect everything (no date filter).
+- Omit `-- --days 7` to auto-calculate from the most recent report date (falls back to 7 days if no reports exist).
 - Adjust the number for a different window (`-- --days 3`, `-- --days 14`).
 
 ### 3. Summarize
@@ -83,7 +83,7 @@ Regenerates `reports/index.html` independently. Normally `pnpm summarize` alread
 | Step | Command | Requires LLM? | Idempotent? |
 |---|---|---|---|
 | Doctor | `pnpm doctor` | No | Yes |
-| Collect | `pnpm collect -- --days 7` | No | Yes (merges) |
+| Collect | `pnpm collect` (or `-- --days 7` to override) | No | Yes (merges) |
 | Summarize | `pnpm summarize` | Yes | Yes (cached) |
 | Review | `pnpm review` | No | Yes |
 | Regenerate | `pnpm generate-report` | Yes | Yes |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,


### PR DESCRIPTION
## Summary

Final Phase 6 documentation cleanup: corrects the weekly-workflow auto-window docs, removes stale Phase 1 framing from active documentation, bumps the package to 0.4.3, and adds a corresponding changelog entry.

### Task 4 — Auto-window docs
- `docs/weekly-workflow.md` no longer claims omitting `--days` collects everything
- Quick Reference table now shows the auto-calculate default with an override option

### Task 5 — Stale framing
- Six active "Phase 1" references removed across `docs/human-review.md`, `docs/philosophy.md`, `docs/cost-notes.md`, and `docs/sources.md`
- Three historical references in `docs/sources.md` lines 25, 79, and 81 preserved intentionally

### Task 6 — Verification
- `pnpm run test` — 124 passed, 0 failed
- `pnpm run typecheck` — passed
- `pnpm run review` — all 7 checks green
- Independent `code-review` — approved
- Zero stale active "Phase 1" references remain

### Version bump
- `package.json` → 0.4.3
- Changelog entry for 0.4.3 added above the existing 0.4.2 entry

## Scope boundary

7 files changed: `README.md`, `package.json`, and 5 documentation files. No source code, tests, build scripts, reports, or data changes.

## Human review focus

Confirm the auto-window phrasing and changelog entries are accurate and complete.
