### PR TITLE
feat: regen-html command, CSS refinements, and 0.5.0 release metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ Both templates walk you through what's needed — takes about a minute.
 
 ## Changelog
 
+### 0.5.0
+
+- Added `pnpm watch` zero-dependency live-reload dev server with SSE browser reload.
+- Added project icon to report headers and index page (flexbox-aligned with h1).
+- Added `pnpm regen-html` command to batch-regenerate all report HTML from existing Markdown — no LLM calls.
+- Refined report CSS: cleaned-up header, horizontal table-of-contents layout, tighter spacing on build notes and footer.
+
 ### 0.4.3
 
 - Repaired flaky auto-days test assertion.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "review": "tsx src/review/index.ts",
     "test": "tsx --test tests/**/*.test.ts",
     "typecheck": "tsc --noEmit",
-    "watch": "tsx src/dev/watch.ts"
+    "watch": "tsx src/dev/watch.ts",
+    "regen-html": "tsx src/dev/regen-html.ts"
   },
   "keywords": [
     "wordpress",

--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -9,7 +9,7 @@ body {
   padding: 2rem 1.5rem;
 }
 h1 { font-size: 1.75rem; margin-bottom: 0.5rem; line-height: 1.3; }
-h2 { font-size: 1.35rem; margin-top: 2rem; margin-bottom: 0.5rem; padding-bottom: 0.25rem; }
+h2 { font-size: 1.35rem; margin-top: 2rem; margin-bottom: 0.5rem; border-bottom: 1px solid #e0e0e0; padding-bottom: 0.25rem; }
 h3 { font-size: 1.1rem; margin-top: 1.5rem; margin-bottom: 0.4rem; }
 p { margin-bottom: 1rem; }
 ul, ol { margin: 0 0 1rem 1.5rem; }
@@ -38,15 +38,14 @@ em { font-style: italic; }
 .meta { color: #666; font-size: 0.85rem; margin-bottom: 2rem; }
 
 /* Report header */
-.report-header { margin-bottom: 1.5rem; display: flex; align-items: center; gap: 0.75rem; }
+.report-header { border-left: 4px solid #0969da; padding-left: 1rem; margin-bottom: 1.5rem; display: flex; align-items: center; gap: 0.75rem; }
 .report-header h1 { margin-bottom: 0.25rem; border-bottom: none; }
 .report-icon { flex-shrink: 0; }
 
 /* Table of contents */
 .toc { background: #f6f8fa; border: 1px solid #e0e0e0; border-radius: 6px; padding: 1rem 1.5rem; margin-bottom: 2rem; }
 .toc h2 { margin-top: 0; border-bottom: none; font-size: 1rem; }
-.toc ul { column-gap: 1rem; display: flex; list-style: none; margin: 0; }
-.toc li { margin-bottom: 0; }
+.toc ul { margin-bottom: 0; }
 .toc a { font-size: 0.9rem; }
 
 /* Article Inventory list */
@@ -55,7 +54,7 @@ em { font-style: italic; }
 
 /* Build Notes panel */
 #build-notes ~ * { font-size: 0.9rem; color: #555; }
-#build-notes { font-size: 1rem; color: #666; margin-top: 2rem; padding-top: 0.25rem; }
+#build-notes { font-size: 1rem; color: #666; margin-top: 2rem; border-top: 1px solid #e0e0e0; padding-top: 1rem; }
 
 /* Report index page */
 .report-index h1 { border-bottom: none; }
@@ -66,6 +65,7 @@ em { font-style: italic; }
   border-radius: 6px;
   padding: 1rem 1.25rem;
   text-decoration: none;
+  color: inherit;
   transition: background 0.15s;
 }
 .report-card:hover { background: #f6f8fa; border-color: #d0d0d0; }
@@ -83,7 +83,7 @@ em { font-style: italic; }
 
 /* Navigation footer */
 .nav-footer {
-  margin-top: 2rem;
+  margin-top: 3rem;
   padding-top: 1rem;
   border-top: 1px solid #e0e0e0;
   font-size: 0.9rem;

--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -9,7 +9,7 @@ body {
   padding: 2rem 1.5rem;
 }
 h1 { font-size: 1.75rem; margin-bottom: 0.5rem; line-height: 1.3; }
-h2 { font-size: 1.35rem; margin-top: 2rem; margin-bottom: 0.5rem; border-bottom: 1px solid #e0e0e0; padding-bottom: 0.25rem; }
+h2 { font-size: 1.35rem; margin-top: 2rem; margin-bottom: 0.5rem; padding-bottom: 0.25rem; }
 h3 { font-size: 1.1rem; margin-top: 1.5rem; margin-bottom: 0.4rem; }
 p { margin-bottom: 1rem; }
 ul, ol { margin: 0 0 1rem 1.5rem; }
@@ -38,23 +38,23 @@ em { font-style: italic; }
 .meta { color: #666; font-size: 0.85rem; margin-bottom: 2rem; }
 
 /* Report header */
-.report-header { border-left: 4px solid #0969da; padding-left: 1rem; margin-bottom: 1.5rem; display: flex; align-items: center; gap: 0.75rem; }
+.report-header { margin-bottom: 1.5rem; display: flex; align-items: center; gap: 0.75rem; }
 .report-header h1 { margin-bottom: 0.25rem; border-bottom: none; }
 .report-icon { flex-shrink: 0; }
 
 /* Table of contents */
 .toc { background: #f6f8fa; border: 1px solid #e0e0e0; border-radius: 6px; padding: 1rem 1.5rem; margin-bottom: 2rem; }
 .toc h2 { margin-top: 0; border-bottom: none; font-size: 1rem; }
-.toc ul { margin-bottom: 0; }
+.toc ul { column-gap: 1rem; display: flex; list-style: none;margin: 0; }
 .toc a { font-size: 0.9rem; }
 
 /* Article Inventory list */
-#article-inventory + ol li { padding: 0.25rem 0; border-bottom: 1px solid #f0f0f0; }
+#article-inventory + ol li { padding: 0.5rem 0; border-bottom: 1px solid #f0f0f0; }
 #article-inventory + ol li:last-child { border-bottom: none; }
 
 /* Build Notes panel */
 #build-notes ~ * { font-size: 0.9rem; color: #555; }
-#build-notes { font-size: 1rem; color: #666; margin-top: 2rem; border-top: 1px solid #e0e0e0; padding-top: 1rem; }
+#build-notes { font-size: 1rem; color: #666; margin-top: 2rem; padding-top: 0.25rem; }
 
 /* Report index page */
 .report-index h1 { border-bottom: none; }
@@ -83,7 +83,7 @@ em { font-style: italic; }
 
 /* Navigation footer */
 .nav-footer {
-  margin-top: 3rem;
+  margin-top: 2rem;
   padding-top: 1rem;
   border-top: 1px solid #e0e0e0;
   font-size: 0.9rem;

--- a/src/dev/regen-html.ts
+++ b/src/dev/regen-html.ts
@@ -1,3 +1,12 @@
+/**
+ * Regenerate all report HTML and the index page from existing Markdown reports.
+ *
+ * Scans `reports/` for `*.md` files (excluding index.md), converts each
+ * to HTML via `generateHtmlReport()`, then rebuilds the index page.
+ * No LLM calls, no article fetching — purely a file-to-file conversion.
+ *
+ * Usage: `pnpm regen-html`
+ */
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { generateHtmlReport, generateIndexPage } from "../summarize/html.js";

--- a/src/summarize/report.css
+++ b/src/summarize/report.css
@@ -9,7 +9,7 @@ body {
   padding: 2rem 1.5rem;
 }
 h1 { font-size: 1.75rem; margin-bottom: 0.5rem; line-height: 1.3; }
-h2 { font-size: 1.35rem; margin-top: 2rem; margin-bottom: 0.5rem; border-bottom: 1px solid #e0e0e0; padding-bottom: 0.25rem; }
+h2 { font-size: 1.35rem; margin-top: 2rem; margin-bottom: 0.5rem; padding-bottom: 0.25rem; }
 h3 { font-size: 1.1rem; margin-top: 1.5rem; margin-bottom: 0.4rem; }
 p { margin-bottom: 1rem; }
 ul, ol { margin: 0 0 1rem 1.5rem; }
@@ -38,23 +38,23 @@ em { font-style: italic; }
 .meta { color: #666; font-size: 0.85rem; margin-bottom: 2rem; }
 
 /* Report header */
-.report-header { border-left: 4px solid #0969da; padding-left: 1rem; margin-bottom: 1.5rem; display: flex; align-items: center; gap: 0.75rem; }
+.report-header { margin-bottom: 1.5rem; display: flex; align-items: center; gap: 0.75rem; }
 .report-header h1 { margin-bottom: 0.25rem; border-bottom: none; }
 .report-icon { flex-shrink: 0; }
 
 /* Table of contents */
 .toc { background: #f6f8fa; border: 1px solid #e0e0e0; border-radius: 6px; padding: 1rem 1.5rem; margin-bottom: 2rem; }
 .toc h2 { margin-top: 0; border-bottom: none; font-size: 1rem; }
-.toc ul { margin-bottom: 0; }
+.toc ul { column-gap: 1rem; display: flex; list-style: none;margin: 0; }
 .toc a { font-size: 0.9rem; }
 
 /* Article Inventory list */
-#article-inventory + ol li { padding: 0.25rem 0; border-bottom: 1px solid #f0f0f0; }
+#article-inventory + ol li { padding: 0.5rem 0; border-bottom: 1px solid #f0f0f0; }
 #article-inventory + ol li:last-child { border-bottom: none; }
 
 /* Build Notes panel */
 #build-notes ~ * { font-size: 0.9rem; color: #555; }
-#build-notes { font-size: 1rem; color: #666; margin-top: 2rem; border-top: 1px solid #e0e0e0; padding-top: 1rem; }
+#build-notes { font-size: 1rem; color: #666; margin-top: 2rem; padding-top: 0.25rem; }
 
 /* Report index page */
 .report-index h1 { border-bottom: none; }
@@ -83,7 +83,7 @@ em { font-style: italic; }
 
 /* Navigation footer */
 .nav-footer {
-  margin-top: 3rem;
+  margin-top: 2rem;
   padding-top: 1rem;
   border-top: 1px solid #e0e0e0;
   font-size: 0.9rem;


### PR DESCRIPTION
## Summary

Wires `src/dev/regen-html.ts` as a first-class `pnpm regen-html` script.

Regenerates all report HTML and the index page from existing Markdown files — no LLM calls, no article fetching. Useful after template or CSS changes outside of a full `pnpm summarize` run.

## Usage

```bash
pnpm regen-html
# → regenerates reports/2026-06-12.html
# → regenerates reports/2026-06-21.html
# → ...
# → regenerates reports/index.html
```

## Files
- `src/dev/regen-html.ts` — adds JSDoc docblock
- `package.json` — adds `"regen-html"` script entry

## Verification
- `pnpm run test` — 124 passed, 0 failed
- `pnpm run typecheck` — passed
- `pnpm regen-html` smoke test — passed
- Independent `code-review` — approved