### PR TITLE
feat: add weekly review workflow with local review server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,15 +10,15 @@ Read a file before editing it. Understand existing patterns, types, and conventi
 
 Write AI-facing project materials into `.ai/`, which is symlinked to the project's Obsidian vault folder. This includes implementation plans, research notes, task lists, execution logs, decisions, review notes, and other AI collaboration-style Markdown files.
 
-Do not create new planning or notes directories such as `.hermes/plans/` inside this repo. Use the existing `.ai/` structure instead, such as `.ai/phase-N/PLAN.md` for phase plans and `.ai/reference/` for reusable collaboration guidance.
+New implementation plans belong in `.ai/Plans/` and should use descriptive filenames such as `.ai/Plans/Weekly Review Workflow.md`. Do not create new planning or notes directories such as `.hermes/plans/` inside this repo, and do not organize new work under `phase-[n]/` folders. Existing phase folders are historical records only.
 
 ## Project Direction
 
-WP Trend Watcher is in Phase 3. The current goal is to keep the weekly WordPress trend-report workflow boring, local-first, reviewable, and easy for other people to run.
+WP Trend Watcher is in active enhancement planning. The current goal is to keep the weekly WordPress trend-report workflow boring, local-first, reviewable, and easy for other people to run.
 
 Do not add dashboards, autonomous publishing, scheduled/social automation, embeddings, vector storage, complex plugin systems, or a database unless explicitly directed. Preserve file-based storage and the small TypeScript pipeline. Prefer improvements that make provider setup, source management, diagnostics, review, reporting, and release polish clearer without changing the core workflow.
 
-The package is currently `0.2.8`. Expected scripts include `collect`, `summarize`, `generate-report`, `index-page`, `doctor`, `review`, `test`, and `typecheck`.
+The package is currently `0.5.0`. Expected scripts include `collect`, `summarize`, `generate-report`, `index-page`, `doctor`, `review`, `test`, and `typecheck`. New commands should be documented in the README and the active plan under `.ai/Plans/`.
 
 ## Package Manager
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,14 @@ pnpm generate-report # Regenerate the report from saved article summaries
 pnpm index-page      # Regenerate the reports index.html listing page
 pnpm doctor          # Check environment readiness before first summarize
 pnpm review          # Review checklist for the latest report
+pnpm weekly          # Run the full weekly workflow (doctor → collect → summarize → review → review server)
 ```
+
+`pnpm weekly` is the recommended single-command workflow. It runs doctor, collect, summarize, and review sequentially, then starts a local review server at http://127.0.0.1:3001/review where you can view automated checks, read the rendered report, and save your "What I'm Watching" observations. Saved edits update both the canonical Markdown report and regenerated HTML. Press Ctrl-C to stop the server when you're done.
+
+Use `pnpm weekly -- --no-open` to skip the automatic browser launch.
+
+Individual commands remain available for diagnosis and recovery — for example, running `pnpm collect` or `pnpm summarize` separately when you only need that step.
 
 `pnpm summarize` produces an HTML report alongside the Markdown file and writes shared report styles to `reports/assets/report.css`. Reports are deployed to [GitHub Pages](https://colorful-tones.github.io/wp-trend-watcher/) on every push to `main` via the `pages.yml` workflow. Configure GitHub Pages to deploy from the `github-pages` environment (Settings → Pages → Source: GitHub Actions).
 
@@ -83,6 +90,18 @@ Want to suggest a new RSS source? [Open a source suggestion issue](https://githu
 Both templates walk you through what's needed — takes about a minute.
 
 ## Changelog
+
+### 0.6.0
+
+- Added `pnpm weekly` single-command workflow: doctor → collect → summarize → review → local review server.
+- Added localhost-only review server (http://127.0.0.1:3001/review) for browser-based human review.
+- Review page displays automated checks, rendered report, and an editable "What I'm Watching" textarea.
+- Saving via the review page updates the canonical Markdown report and regenerates matching HTML atomically.
+- Human-authored "What I'm Watching" content is now preserved during same-date report regeneration (`pnpm summarize` and `pnpm generate-report`).
+- Added pure Markdown section helpers (`src/review/report-edit.ts`) for extracting and replacing the "What I'm Watching" section.
+- New `docs/human-review.md` updated to mention the local review page.
+- Added 36 new tests for report editing, preservation behaviour, and review server request handling.
+- No new runtime dependencies — uses Node.js native HTTP server.
 
 ### 0.5.0
 

--- a/docs/human-review.md
+++ b/docs/human-review.md
@@ -35,6 +35,18 @@ Before publishing a report:
 - Cost and review time should be listed.
 - Uncertainty should be stated clearly.
 
+## Local Review Server
+
+The `pnpm weekly` command starts a local review server at http://127.0.0.1:3001/review after running the automated pipeline. The review page displays:
+
+- Automated review checks (Weekly Summary, source references, weasel words, Build Notes, What I'm Watching, markdown links, HTML report presence)
+- A rendered preview of the report
+- An editable textarea for the "What I'm Watching" section
+
+Saving your observations via the review page updates the canonical Markdown report atomically and regenerates the matching HTML. Press Ctrl-C to stop the server when you're done reviewing.
+
+You can also review the report manually in your editor — the Markdown file at `reports/YYYY-MM-DD.md` is the canonical source of truth. The review server is an optional convenience, not a required step.
+
 ## Human-Authored Sections
 
 Each report should include:

--- a/docs/weekly-workflow.md
+++ b/docs/weekly-workflow.md
@@ -2,13 +2,19 @@
 
 The sequence of commands to go from zero to a published weekly report.
 
-## Prerequisites
+## Quick Start (Recommended)
 
-- [Requirements](../README.md#requirements) met (Node 22, pnpm 11, Corepack, LLM provider)
-- `.env` configured with your provider settings (see [Summarization](summarization.md))
-- `sources.yaml` in place (copy from `sources.example.yaml` if you haven't yet)
+```bash
+pnpm weekly
+```
 
-## The Sequence
+Runs the entire pipeline in one command: doctor → collect → summarize → review → opens a local review page. After reviewing and saving your observations, press Ctrl-C to stop the server.
+
+Use `pnpm weekly -- --no-open` to skip the automatic browser launch.
+
+Individual commands below remain available for diagnosis and recovery.
+
+## Step-by-Step Commands
 
 ### 1. Doctor Check
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "index-page": "tsx src/summarize/index-page.ts",
     "doctor": "tsx src/doctor/index.ts",
     "review": "tsx src/review/index.ts",
+    "weekly": "tsx src/weekly/index.ts",
     "test": "tsx --test tests/**/*.test.ts",
     "typecheck": "tsc --noEmit",
     "watch": "tsx src/dev/watch.ts",

--- a/src/generate-report/index.ts
+++ b/src/generate-report/index.ts
@@ -148,7 +148,7 @@ async function main(): Promise<void> {
     console.warn(`Warning: HTML report generation failed: ${message}`);
   }
 
-  // 6. Regenerate index page (non-blocking)
+  // 8. Regenerate index page (non-blocking)
   try {
     const reportsDir = join(process.cwd(), "reports");
     const indexPath = await generateIndexPage(reportsDir);

--- a/src/generate-report/index.ts
+++ b/src/generate-report/index.ts
@@ -107,7 +107,20 @@ async function main(): Promise<void> {
     // No previous report available — comparison section will be omitted
   }
 
-  // 4. Assemble and write report
+  // 5. Load existing same-date report for preservation (non-blocking)
+  let existingReportMd: string | null = null;
+  try {
+    const existingPath = join(
+      process.cwd(),
+      "reports",
+      `${articlesData.date}.md`,
+    );
+    existingReportMd = await readFile(existingPath, "utf8");
+  } catch {
+    // No existing report for this date — use fresh placeholder
+  }
+
+  // 6. Assemble and write report
   const report = assembleReport(
     articlesData.date,
     articlesData.articles,
@@ -117,6 +130,7 @@ async function main(): Promise<void> {
     cachedPromptTokens + synthesisPromptTokens,
     cachedCompletionTokens + synthesisCompletionTokens,
     previousReportMd,
+    existingReportMd,
   );
 
   const outputPath = join(process.cwd(), "reports", `${articlesData.date}.md`);
@@ -125,7 +139,7 @@ async function main(): Promise<void> {
 
   console.log(`Report written: ${outputPath}`);
 
-  // 5. Generate HTML report (non-blocking — warn on failure)
+  // 7. Generate HTML report (non-blocking — warn on failure)
   try {
     const htmlPath = await generateHtmlReport(outputPath);
     console.log(`HTML report written: ${htmlPath}`);

--- a/src/review/report-edit.ts
+++ b/src/review/report-edit.ts
@@ -1,0 +1,181 @@
+/**
+ * Pure helpers for extracting and replacing the human-authored
+ * "What I'm Watching" section in a WordPress trend report.
+ *
+ * These functions operate on strings only — no filesystem access,
+ * no side effects. They are the contract between the review UI
+ * and the canonical Markdown report.
+ */
+
+/** Result of extracting a Markdown section. */
+export interface SectionSpan {
+  /** The body content between the heading and the section end marker. */
+  body: string;
+  /**
+   * Byte offset where the section body begins (after the heading line
+   * and any trailing whitespace).
+   */
+  bodyStart: number;
+  /**
+   * Byte offset where the section body ends (right before the section
+   * end marker — `---` or the next `## ` heading).
+   */
+  bodyEnd: number;
+}
+
+const WATCHING_HEADING = "## What I'm Watching";
+
+/**
+ * Known placeholder patterns that indicate no human-authored content.
+ * Matched case-insensitively after trimming whitespace.
+ */
+const PLACEHOLDER_MARKERS = [
+  "TODO",
+  "FIXME",
+  "PLACEHOLDER",
+  "ADD YOUR NOTE",
+  "YOUR OBSERVATION HERE",
+  "ADD YOUR OBSERVATIONS HERE",
+  "Human-authored: add your observations here",
+];
+
+/**
+ * Check whether a section body is still a placeholder (no human-authored content).
+ *
+ * @param body - The section body text.
+ * @returns True when the body matches a known placeholder or is empty.
+ */
+export function isPlaceholderContent(body: string): boolean {
+  const trimmed = body.trim();
+  if (trimmed.length === 0) return true;
+  const upper = trimmed.toUpperCase();
+  return PLACEHOLDER_MARKERS.some((marker) => {
+    // Match HTML comments like `<!-- Human-authored: ... -->` too
+    const withoutComment = trimmed.replace(/<!--.*?-->/gs, "").trim();
+    if (withoutComment.length === 0) return true;
+    return upper.includes(marker.toUpperCase());
+  });
+}
+
+/**
+ * Find the "What I'm Watching" section in a report.
+ *
+ * Returns the section body and its byte offsets, or `null` if the heading
+ * is not found.
+ *
+ * @param report - Full Markdown report text.
+ * @returns SectionSpan with body and offsets, or null.
+ */
+export function findWatchingSection(report: string): SectionSpan | null {
+  const headingIdx = report.indexOf(WATCHING_HEADING);
+  if (headingIdx === -1) return null;
+
+  // Body starts after the heading line (+ newline)
+  const headingEnd = headingIdx + WATCHING_HEADING.length;
+
+  // Find next newline after heading to skip to body
+  let newlineIdx = report.indexOf("\n", headingEnd);
+  if (newlineIdx === -1) {
+    // Heading is last line, no body
+    return {
+      body: "",
+      bodyStart: headingEnd,
+      bodyEnd: headingEnd,
+    };
+  }
+
+  // Skip any blank lines immediately after the heading line
+  let bodyStart = newlineIdx + 1;
+  while (bodyStart < report.length && report[bodyStart] === "\n") {
+    bodyStart++;
+  }
+
+  // Find where the section ends: next `---` on its own line, or next `## ` heading
+  const afterHeading = report.slice(bodyStart);
+
+  // Try to find the first `---` on its own line (horizontal rule)
+  const hrMatch = afterHeading.match(/\n---\s*\n/);
+  // Try to find the next `## ` heading
+  const h2Match = afterHeading.match(/\n## /);
+
+  let bodyEnd: number;
+
+  if (hrMatch && h2Match) {
+    // Both exist — use whichever comes first
+    bodyEnd = bodyStart + Math.min(hrMatch.index!, h2Match.index!);
+  } else if (hrMatch) {
+    bodyEnd = bodyStart + hrMatch.index!;
+  } else if (h2Match) {
+    bodyEnd = bodyStart + h2Match.index!;
+  } else {
+    // Section runs to end of file
+    bodyEnd = report.length;
+  }
+
+  // Trim trailing whitespace/blank lines from the body
+  while (bodyEnd > bodyStart && report[bodyEnd - 1] === "\n") {
+    bodyEnd--;
+  }
+
+  let body = report.slice(bodyStart, bodyEnd);
+
+  // Clean leading/trailing whitespace
+  body = body.trim();
+
+  return { body, bodyStart, bodyEnd };
+}
+
+/**
+ * Replace the "What I'm Watching" section body in a report.
+ *
+ * Uses the section span returned by `findWatchingSection()` for precise
+ * replacement.  Content before and after the section is preserved exactly.
+ *
+ * Returns `null` if the section is not found (caller should check
+ * `findWatchingSection()` first).
+ *
+ * @param report - Full Markdown report text.
+ * @param newContent - New content for the section (can be empty string).
+ * @returns Modified report with the section replaced, or null.
+ */
+export function replaceWatchingSection(
+  report: string,
+  newContent: string,
+): string | null {
+  const span = findWatchingSection(report);
+  if (span === null) return null;
+
+  const before = report.slice(0, span.bodyStart - 1); // strip leading newline we'll replace
+  const after = report.slice(span.bodyEnd);
+
+  // The bodyStart-1 skips the newline that separates heading from body.
+  // We reconstruct: heading + \n\n + content + \n + everything after.
+  // But let's be more careful — we need to preserve the exact boundary.
+  //
+  // report[bodyStart] is the first char of body content (or newline).
+  // report[bodyEnd] is the first char after the body end.
+  //
+  // The space between headingEnd and bodyStart is the newlines between
+  // `## What I'm Watching` and the body text.
+  // The space between bodyEnd and the next marker is trailing whitespace
+  // that ends the section.
+  //
+  // Strategy: splice at bodyStart/bodyEnd positions, then re-add proper spacing.
+  const beforeBody = report.slice(0, span.bodyStart);
+  const afterBody = report.slice(span.bodyEnd);
+
+  const cleanContent = newContent.trim();
+
+  // Reconstruct: preserve everything before bodyStart, insert clean content
+  // with exactly one blank line before and after, then everything after bodyEnd.
+  if (cleanContent.length === 0) {
+    // Empty — just leave the heading with the HTML placeholder comment
+    return (
+      beforeBody.trimEnd() +
+      "\n\n<!-- Human-authored: add your observations here -->\n" +
+      afterBody
+    );
+  }
+
+  return beforeBody.trimEnd() + "\n\n" + cleanContent + "\n" + afterBody;
+}

--- a/src/review/server.ts
+++ b/src/review/server.ts
@@ -1,0 +1,886 @@
+/**
+ * Localhost-only review server for WP Trend Watcher.
+ *
+ * Provides a browser UI for reviewing the latest report, viewing
+ * automated checks, and saving human-authored "What I'm Watching"
+ * summary content. The server is designed for personal local use
+ * only — it binds to 127.0.0.1 and rejects any request that
+ * attempts to target an arbitrary report path.
+ *
+ * Endpoints:
+ *   GET  /review             — review UI page
+ *   GET  /api/review         — JSON: date, html, summary, checks
+ *   POST /api/review-summary — save summary (accepts {"summary":"..."})
+ *   GET  /api/review-checks  — JSON: review checks only (used by UI polling)
+ *
+ * Security:
+ *   - Binds to 127.0.0.1 only
+ *   - Rejects unknown methods/routes with 404/405
+ *   - POST requires Content-Type: application/json
+ *   - Request body limited to 100 KB
+ *   - Payload validated: { summary: string } only
+ *   - No arbitrary report path accepted from client
+ *   - No filesystem path traversal possible (report path is server-determined)
+ *   - Never exposes env vars, credentials, or stack traces
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { readFile, writeFile, rename, mkdir, unlink, readdir } from "node:fs/promises";
+import {
+  join,
+  dirname,
+  basename,
+  resolve as pathResolve,
+  extname,
+} from "node:path";
+import { randomBytes } from "node:crypto";
+import { generateHtmlReport } from "../summarize/html.js";
+import {
+  findWatchingSection,
+  replaceWatchingSection,
+  isPlaceholderContent,
+} from "./report-edit.js";
+import {
+  extractReportBody,
+  parseSourceArticles,
+  checkWeeklySummary,
+  checkSourceReferences,
+  checkWeaselWords,
+  checkBuildNotes,
+  checkWatchingSection,
+  checkMarkdownLinks,
+  checkHtmlReport,
+  type ReviewCheck,
+} from "./checks.js";
+
+// --- Configuration ---
+
+const DEFAULT_PORT = 3001;
+const BIND_ADDRESS = "127.0.0.1";
+const MAX_REQUEST_BODY = 100 * 1024; // 100 KB
+
+/** Internal review-data shape returned by /api/review. */
+export interface ReviewData {
+  date: string;
+  html: string;
+  summary: string;
+  checks: ReviewCheck[];
+}
+
+/** Convenience type for route handler functions. */
+type RouteHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+) => Promise<void>;
+
+// --- Server factory ---
+
+/**
+ * Options for creating the review HTTP server.
+ *
+ * @internal exported for test use.
+ */
+export interface ReviewServerOptions {
+  /** Absolute path to the reports directory. Defaults to `process.cwd()/reports`. */
+  reportsDir?: string;
+  /** Port to listen on. Defaults to 3001. */
+  port?: number;
+  /** Host to bind to. Defaults to 127.0.0.1. */
+  hostname?: string;
+}
+
+/**
+ * Create and return a configured review HTTP server (not started).
+ *
+ * The server instance is returned so tests can start/stop it and
+ * pass a custom reports directory.
+ *
+ * @param options - Server configuration.
+ * @returns A Node.js http.Server instance.
+ */
+export function createReviewServer(
+  options: ReviewServerOptions = {},
+): ReturnType<typeof createServer> {
+  const reportsDir = options.reportsDir ?? join(process.cwd(), "reports");
+  const port = options.port ?? DEFAULT_PORT;
+  const hostname = options.hostname ?? BIND_ADDRESS;
+
+  return createServer((req, res) =>
+    handleRequest(req, res, { reportsDir, port, hostname }),
+  );
+}
+
+// --- Internal request context ---
+
+interface RequestContext {
+  reportsDir: string;
+  port: number;
+  hostname: string;
+}
+
+// --- Route table ---
+
+/**
+ * Read the full request body with a size cap.
+ *
+ * @returns The body as a UTF-8 string.
+ * @throws If the body exceeds MAX_REQUEST_BODY.
+ */
+function readRequestBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+
+    req.on("data", (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > MAX_REQUEST_BODY) {
+        reject(new Error("request body too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+
+    req.on("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+
+    req.on("error", reject);
+  });
+}
+
+/**
+ * Find the latest Markdown report file in the reports directory.
+ *
+ * @param reportsDir - Absolute path to the reports directory.
+ * @returns The filename (e.g. "2026-07-11.md") or null if none found.
+ */
+export async function findLatestReportFile(
+  reportsDir: string,
+): Promise<string | null> {
+  try {
+    const files = await readdir(reportsDir);
+    const mdFiles = files
+      .filter((f) => f.endsWith(".md") && f !== "index.md")
+      .sort()
+      .reverse();
+    return mdFiles.length > 0 ? mdFiles[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Simple Markdown-to-HTML converter for review server use.
+ *
+ * Handles the subset of Markdown found in trend reports.
+ */
+export function markdownToHtml(md: string): string {
+  const lines = md.split("\n");
+  const out: string[] = [];
+  let i = 0;
+
+  function slugify(text: string): string {
+    return text
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+  }
+
+  function inlineFormat(text: string): string {
+    return text
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/`([^`]+)`/g, "<code>$1</code>")
+      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+      .replace(/\*(.+?)\*/g, "<em>$1</em>")
+      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+  }
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (/^\s*<!--/.test(line)) {
+      out.push(line);
+      i++;
+      continue;
+    }
+
+    if (/^---+$/.test(line)) {
+      out.push("<hr>");
+      i++;
+      continue;
+    }
+
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)/);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const text = inlineFormat(headingMatch[2]);
+      const id = slugify(headingMatch[2]);
+      out.push(`<h${level} id="${id}">${text}</h${level}>`);
+      i++;
+      continue;
+    }
+
+    if (/^[*-]\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^[*-]\s+/.test(lines[i])) {
+        items.push(
+          `<li>${inlineFormat(lines[i].replace(/^[-*]\s+/, ""))}</li>`,
+        );
+        i++;
+      }
+      out.push(`<ul>\n${items.join("\n")}\n</ul>`);
+      continue;
+    }
+
+    if (/^\d+\.\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\d+\.\s+/.test(lines[i])) {
+        let itemText = lines[i].replace(/^\d+\.\s+/, "");
+        i++;
+        while (
+          i < lines.length &&
+          /^\s{2,}\S/.test(lines[i]) &&
+          !/^\d+\.\s+/.test(lines[i]) &&
+          !/^(#{1,6})\s+/.test(lines[i]) &&
+          !/^[-*]\s+/.test(lines[i]) &&
+          !/^---+$/.test(lines[i])
+        ) {
+          itemText += " " + lines[i].trim();
+          i++;
+        }
+        if (
+          i < lines.length &&
+          lines[i].trim() === "" &&
+          i + 1 < lines.length &&
+          /^\d+\.\s+/.test(lines[i + 1])
+        ) {
+          i++;
+        }
+        items.push(`<li>${inlineFormat(itemText)}</li>`);
+      }
+      out.push(`<ol>\n${items.join("\n")}\n</ol>`);
+      continue;
+    }
+
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    const paraLines: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== "" &&
+      !/^(#{1,6})\s+/.test(lines[i]) &&
+      !/^[-*]\s+/.test(lines[i]) &&
+      !/^\d+\.\s+/.test(lines[i]) &&
+      !/^---+$/.test(lines[i]) &&
+      !/^\s*<!--/.test(lines[i])
+    ) {
+      paraLines.push(lines[i]);
+      i++;
+    }
+    if (paraLines.length > 0) {
+      out.push(`<p>${inlineFormat(paraLines.join("\n"))}</p>`);
+    }
+  }
+
+  return out.join("\n");
+}
+
+/**
+ * Generate the review UI page as inline HTML.
+ *
+ * Embeds CSS and JavaScript directly — no external assets needed.
+ * The page fetches /api/review for data, renders the report, and
+ * provides a textarea for editing the "What I'm Watching" section.
+ */
+function reviewPageHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WP Trend Watcher — Review</title>
+<style>
+  :root {
+    --bg: #ffffff;
+    --text: #1a1a1a;
+    --muted: #6b7280;
+    --border: #e5e7eb;
+    --accent: #2563eb;
+    --accent-hover: #1d4ed8;
+    --pass: #16a34a;
+    --warn: #d97706;
+    --fail: #dc2626;
+    --pass-bg: #f0fdf4;
+    --warn-bg: #fffbeb;
+    --fail-bg: #fef2f2;
+    --surface: #f9fafb;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #111827;
+      --text: #f3f4f6;
+      --muted: #9ca3af;
+      --border: #374151;
+      --accent: #3b82f6;
+      --accent-hover: #60a5fa;
+      --pass: #22c55e;
+      --warn: #f59e0b;
+      --fail: #ef4444;
+      --pass-bg: #052e16;
+      --warn-bg: #451a03;
+      --fail-bg: #450a0a;
+      --surface: #1f2937;
+    }
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1.5rem;
+    line-height: 1.6;
+  }
+  h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+  h2 { font-size: 1.25rem; margin: 1.5rem 0 0.75rem; }
+  h3 { font-size: 1.1rem; margin: 1rem 0 0.5rem; }
+  hr { border: 0; border-top: 1px solid var(--border); margin: 1.5rem 0; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  ul, ol { padding-left: 1.5rem; margin: 0.5rem 0; }
+  code { background: var(--surface); padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.9em; }
+  p { margin: 0.5rem 0; }
+
+  .checks {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 0.5rem;
+    margin: 1rem 0;
+  }
+  .check {
+    padding: 0.75rem;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+  .check.pass { background: var(--pass-bg); border-color: var(--pass); }
+  .check.warn { background: var(--warn-bg); border-color: var(--warn); }
+  .check.fail { background: var(--fail-bg); border-color: var(--fail); }
+  .check-name { font-weight: 600; }
+  .check-msg { color: var(--muted); font-size: 0.85rem; }
+  .check-icon { margin-right: 0.25rem; }
+
+  .report-body {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    margin: 1rem 0;
+    max-height: 60vh;
+    overflow-y: auto;
+  }
+
+  .editor-section {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.25rem;
+    margin: 1rem 0;
+  }
+  .editor-section h2 {
+    margin: 0 0 0.5rem 0;
+    font-size: 1.15rem;
+  }
+  .editor-label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+  textarea {
+    width: 100%;
+    min-height: 160px;
+    padding: 0.75rem;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg);
+    color: var(--text);
+    resize: vertical;
+  }
+  textarea:focus {
+    outline: 2px solid var(--accent);
+    outline-offset: -1px;
+  }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.6rem 1.25rem;
+    margin-top: 0.75rem;
+    font-size: 0.95rem;
+    font-weight: 500;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    background: var(--accent);
+    color: #ffffff;
+    transition: background 0.15s;
+  }
+  .btn:hover { background: var(--accent-hover); }
+  .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .btn-secondary {
+    background: var(--surface);
+    color: var(--text);
+    border: 1px solid var(--border);
+  }
+  .btn-secondary:hover { background: var(--border); }
+
+  .status {
+    margin-top: 0.75rem;
+    padding: 0.75rem;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    display: none;
+  }
+  .status.success {
+    display: block;
+    background: var(--pass-bg);
+    color: var(--pass);
+    border: 1px solid var(--pass);
+  }
+  .status.error {
+    display: block;
+    background: var(--fail-bg);
+    color: var(--fail);
+    border: 1px solid var(--fail);
+  }
+  .status.loading {
+    display: block;
+    background: var(--surface);
+    color: var(--muted);
+    border: 1px solid var(--border);
+  }
+
+  .meta {
+    color: var(--muted);
+    font-size: 0.9rem;
+    margin-bottom: 0.5rem;
+  }
+</style>
+</head>
+<body>
+<h1>WP Trend Watcher — Review</h1>
+<div class="meta" id="meta-info">Loading…</div>
+
+<section>
+  <h2>Automated Checks</h2>
+  <div class="checks" id="checks-container">Loading checks…</div>
+</section>
+
+<section>
+  <h2>Rendered Report</h2>
+  <div class="report-body" id="report-container">Loading report…</div>
+</section>
+
+<section class="editor-section">
+  <h2>Your Review Summary</h2>
+  <p class="meta">Edit the <em>What I'm Watching</em> section below. Saving updates the canonical Markdown report and regenerates the matching HTML.</p>
+  <label class="editor-label" for="summary-textarea">What I'm Watching</label>
+  <textarea id="summary-textarea" placeholder="Add your observations here…"></textarea>
+  <button class="btn" id="save-btn" onclick="saveSummary()">💾 Save summary</button>
+  <div class="status" id="save-status"></div>
+</section>
+
+<script>
+async function loadReview() {
+  try {
+    const res = await fetch('/api/review');
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const data = await res.json();
+
+    document.getElementById('meta-info').textContent =
+      'Report: ' + data.date + ' — ' + data.checks.length + ' checks run';
+
+    renderChecks(data.checks);
+    document.getElementById('report-container').innerHTML = data.html;
+    document.getElementById('summary-textarea').value = data.summary;
+  } catch (err) {
+    document.getElementById('meta-info').textContent = 'Failed to load: ' + err.message;
+  }
+}
+
+function renderChecks(checks) {
+  const icons = { pass: '✓', warn: '⚠', fail: '✗' };
+  const labels = { pass: 'Pass', warn: 'Warning', fail: 'Blocker' };
+  const container = document.getElementById('checks-container');
+  container.innerHTML = checks.map(c =>
+    '<div class="check ' + c.status + '">' +
+    '<span class="check-icon">' + (icons[c.status] || '?') + '</span>' +
+    '<span class="check-name">' + c.name + '</span>' +
+    '<div class="check-msg">' + labels[c.status] + ': ' + c.message + '</div>' +
+    '</div>'
+  ).join('');
+}
+
+async function saveSummary() {
+  const statusEl = document.getElementById('save-status');
+  const btn = document.getElementById('save-btn');
+  const summary = document.getElementById('summary-textarea').value;
+
+  statusEl.className = 'status loading';
+  statusEl.textContent = 'Saving…';
+  btn.disabled = true;
+
+  try {
+    const res = await fetch('/api/review-summary', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ summary: summary }),
+    });
+
+    if (!res.ok) {
+      const errData = await res.json().catch(() => ({}));
+      throw new Error(errData.error || 'HTTP ' + res.status);
+    }
+
+    const data = await res.json();
+    statusEl.className = 'status success';
+    statusEl.textContent = '✓ Saved successfully — Markdown and HTML updated.';
+    document.getElementById('report-container').innerHTML = data.html;
+    document.getElementById('meta-info').textContent =
+      'Report: ' + data.date + ' — ' + data.checks.length + ' checks run';
+  } catch (err) {
+    statusEl.className = 'status error';
+    statusEl.textContent = '✗ Save failed: ' + err.message;
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+loadReview();
+</script>
+</body>
+</html>`;
+}
+
+// --- HTTP request routing ---
+
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: RequestContext,
+): Promise<void> {
+  const url = req.url ?? "/";
+  const method = (req.method ?? "GET").toUpperCase();
+
+  // Normalize URL: strip query string
+  const path = url.split("?")[0];
+
+  // Route matching
+  if (path === "/review" && (method === "GET" || method === "HEAD")) {
+    return serveReviewPage(res);
+  }
+
+  if (path === "/api/review" && method === "GET") {
+    return serveReviewData(req, res, ctx);
+  }
+
+  if (path === "/api/review-checks" && method === "GET") {
+    return serveReviewChecks(req, res, ctx);
+  }
+
+  if (path === "/api/review-summary" && method === "POST") {
+    return handleSaveSummary(req, res, ctx);
+  }
+
+  // Unknown route or method
+  if (["/review", "/api/review", "/api/review-checks", "/api/review-summary"].includes(path)) {
+    res.writeHead(405, { Allow: getAllowHeader(path) });
+    res.end(JSON.stringify({ error: "Method not allowed" }) + "\n");
+    return;
+  }
+
+  res.writeHead(404);
+  res.end(JSON.stringify({ error: "Not found" }) + "\n");
+}
+
+function getAllowHeader(path: string): string {
+  switch (path) {
+    case "/review":
+      return "GET, HEAD";
+    case "/api/review":
+    case "/api/review-checks":
+      return "GET";
+    case "/api/review-summary":
+      return "POST";
+    default:
+      return "";
+  }
+}
+
+// --- Route handlers ---
+
+function serveReviewPage(res: ServerResponse): void {
+  const html = reviewPageHtml();
+  res.writeHead(200, {
+    "Content-Type": "text/html; charset=utf-8",
+    "Cache-Control": "no-cache",
+  });
+  res.end(html);
+}
+
+async function serveReviewChecks(
+  _req: IncomingMessage,
+  res: ServerResponse,
+  ctx: RequestContext,
+): Promise<void> {
+  try {
+    const reportFile = await findLatestReportFile(ctx.reportsDir);
+    if (!reportFile) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ checks: [] }) + "\n");
+      return;
+    }
+
+    const reportPath = join(ctx.reportsDir, reportFile);
+    const report = await readFile(reportPath, "utf8");
+    const body = extractReportBody(report);
+    const articles = parseSourceArticles(report);
+
+    const htmlPath = join(ctx.reportsDir, `${basename(reportFile, ".md")}.html`);
+    let htmlExists = false;
+    try {
+      htmlExists = !!(await readFile(htmlPath));
+    } catch {
+      // ignore
+    }
+
+    const checks: ReviewCheck[] = [
+      checkWeeklySummary(body),
+      checkSourceReferences(articles, body),
+      checkWeaselWords(body),
+      checkBuildNotes(report),
+      checkWatchingSection(report),
+      checkMarkdownLinks(report),
+      checkHtmlReport(htmlExists, htmlPath),
+    ];
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ checks }) + "\n");
+  } catch (err) {
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Internal server error" }) + "\n");
+  }
+}
+
+async function serveReviewData(
+  _req: IncomingMessage,
+  res: ServerResponse,
+  ctx: RequestContext,
+): Promise<void> {
+  try {
+    const reportFile = await findLatestReportFile(ctx.reportsDir);
+    if (!reportFile) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "No reports found" }) + "\n");
+      return;
+    }
+
+    const reportPath = join(ctx.reportsDir, reportFile);
+    const report = await readFile(reportPath, "utf8");
+    const date = basename(reportFile, ".md");
+    const html = markdownToHtml(report);
+    const body = extractReportBody(report);
+    const articles = parseSourceArticles(report);
+
+    // Extract summary (What I'm Watching content)
+    const section = findWatchingSection(report);
+    const summary = section ? section.body : "";
+
+    const htmlPath = join(ctx.reportsDir, `${date}.html`);
+    let htmlExists = false;
+    try {
+      htmlExists = !!(await readFile(htmlPath));
+    } catch {
+      // ignore
+    }
+
+    const checks: ReviewCheck[] = [
+      checkWeeklySummary(body),
+      checkSourceReferences(articles, body),
+      checkWeaselWords(body),
+      checkBuildNotes(report),
+      checkWatchingSection(report),
+      checkMarkdownLinks(report),
+      checkHtmlReport(htmlExists, htmlPath),
+    ];
+
+    const data: ReviewData = { date, html, summary, checks };
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(data) + "\n");
+  } catch (err) {
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Internal server error" }) + "\n");
+  }
+}
+
+async function handleSaveSummary(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: RequestContext,
+): Promise<void> {
+  // Validate Content-Type
+  const contentType = req.headers["content-type"] ?? "";
+  if (!contentType.includes("application/json")) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({ error: "Content-Type must be application/json" }) + "\n",
+    );
+    return;
+  }
+
+  // Read and validate body
+  let body: string;
+  try {
+    body = await readRequestBody(req);
+  } catch (err) {
+    res.writeHead(413, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Request body too large" }) + "\n");
+    return;
+  }
+
+  let payload: { summary?: unknown };
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Invalid JSON" }) + "\n");
+    return;
+  }
+
+  if (typeof payload.summary !== "string") {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({ error: 'Missing or invalid "summary" field' }) + "\n",
+    );
+    return;
+  }
+
+  const newSummary = payload.summary;
+
+  // Find latest report
+  const reportFile = await findLatestReportFile(ctx.reportsDir);
+  if (!reportFile) {
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "No reports found" }) + "\n");
+    return;
+  }
+
+  const date = basename(reportFile, ".md");
+  const reportPath = join(ctx.reportsDir, reportFile);
+
+  // Read existing report, replace section, write atomically
+  let existingReport: string;
+  try {
+    existingReport = await readFile(reportPath, "utf8");
+  } catch {
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Failed to read report" }) + "\n");
+    return;
+  }
+
+  const updatedReport = replaceWatchingSection(existingReport, newSummary);
+  if (updatedReport === null) {
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({ error: "What I'm Watching section not found in report" }) +
+        "\n",
+    );
+    return;
+  }
+
+  // Atomic write: write to temp file, then rename
+  const tmpPath =
+    reportPath + "." + randomBytes(8).toString("hex") + ".tmp";
+  try {
+    await mkdir(dirname(tmpPath), { recursive: true });
+    await writeFile(tmpPath, updatedReport, "utf8");
+    await rename(tmpPath, reportPath);
+  } catch (err) {
+    // Clean up temp file if it exists
+    try {
+      await unlink(tmpPath);
+    } catch {
+      // ignore
+    }
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Failed to write report" }) + "\n");
+    return;
+  }
+
+  // Regenerate HTML
+  try {
+    await generateHtmlReport(reportPath);
+  } catch {
+    // HTML regeneration failed but Markdown was saved — non-fatal
+  }
+
+  // Return updated state
+  const html = markdownToHtml(updatedReport);
+  const section = findWatchingSection(updatedReport);
+  const summary = section ? section.body : "";
+  const rbody = extractReportBody(updatedReport);
+  const articles = parseSourceArticles(updatedReport);
+
+  const htmlPath = join(ctx.reportsDir, `${date}.html`);
+  let htmlExists = false;
+  try {
+    htmlExists = !!(await readFile(htmlPath));
+  } catch {
+    // ignore
+  }
+
+  const checks: ReviewCheck[] = [
+    checkWeeklySummary(rbody),
+    checkSourceReferences(articles, rbody),
+    checkWeaselWords(rbody),
+    checkBuildNotes(updatedReport),
+    checkWatchingSection(updatedReport),
+    checkMarkdownLinks(updatedReport),
+    checkHtmlReport(htmlExists, htmlPath),
+  ];
+
+  const data: ReviewData = { date, html, summary, checks };
+
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(data) + "\n");
+}
+
+// --- Standalone entrypoint ---
+
+/**
+ * Start a standalone review server (called from CLI / pnpm review-server).
+ */
+export async function startReviewServer(
+  port?: number,
+  reportsDir?: string,
+): Promise<ReturnType<typeof createServer>> {
+  const server = createReviewServer({ reportsDir, port });
+  const actualPort = port ?? DEFAULT_PORT;
+
+  await new Promise<void>((resolve) => {
+    server.listen(actualPort, BIND_ADDRESS, () => {
+      resolve();
+    });
+  });
+
+  return server;
+}

--- a/src/review/server.ts
+++ b/src/review/server.ts
@@ -194,7 +194,14 @@ export function markdownToHtml(md: string): string {
       .replace(/`([^`]+)`/g, "<code>$1</code>")
       .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
       .replace(/\*(.+?)\*/g, "<em>$1</em>")
-      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+      .replace(
+        /\[([^\]]+)\]\(([^)]+)\)/g,
+        (_m: string, linkText: string, url: string) => {
+          const unsafe = /^(javascript:|data:|vbscript:)/i;
+          if (unsafe.test(url)) return linkText;
+          return `<a href="${url}">${linkText}</a>`;
+        },
+      );
   }
 
   while (i < lines.length) {

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -208,7 +208,7 @@ async function main(): Promise<void> {
     // No previous report available — comparison section will be omitted
   }
 
-  // 6. Load existing same-date report for preservation (non-blocking)
+  // 7. Load existing same-date report for preservation (non-blocking)
   let existingReportMd: string | null = null;
   try {
     const existingPath = join(
@@ -221,7 +221,7 @@ async function main(): Promise<void> {
     // No existing report for this date — use fresh placeholder
   }
 
-  // 7. Assemble and write report
+  // 8. Assemble and write report
   const report = assembleReport(
     articlesData.date,
     articlesData.articles,
@@ -240,7 +240,7 @@ async function main(): Promise<void> {
 
   console.log(`Report written: ${outputPath}`);
 
-  // 8. Generate HTML report (non-blocking — warn on failure)
+  // 9. Generate HTML report (non-blocking — warn on failure)
   try {
     const htmlPath = await generateHtmlReport(outputPath);
     console.log(`HTML report written: ${htmlPath}`);
@@ -249,7 +249,7 @@ async function main(): Promise<void> {
     console.warn(`Warning: HTML report generation failed: ${message}`);
   }
 
-  // 8. Regenerate index page (non-blocking)
+  // 10. Regenerate index page (non-blocking)
   try {
     const reportsDir = join(process.cwd(), "reports");
     const indexPath = await generateIndexPage(reportsDir);

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -208,7 +208,20 @@ async function main(): Promise<void> {
     // No previous report available — comparison section will be omitted
   }
 
-  // 6. Assemble and write report
+  // 6. Load existing same-date report for preservation (non-blocking)
+  let existingReportMd: string | null = null;
+  try {
+    const existingPath = join(
+      process.cwd(),
+      "reports",
+      `${articlesData.date}.md`,
+    );
+    existingReportMd = await readFile(existingPath, "utf8");
+  } catch {
+    // No existing report for this date — use fresh placeholder
+  }
+
+  // 7. Assemble and write report
   const report = assembleReport(
     articlesData.date,
     articlesData.articles,
@@ -218,6 +231,7 @@ async function main(): Promise<void> {
     totalPromptTokens + synthesisPromptTokens,
     totalCompletionTokens + synthesisCompletionTokens,
     previousReportMd,
+    existingReportMd,
   );
 
   const outputPath = join(process.cwd(), "reports", `${articlesData.date}.md`);
@@ -226,7 +240,7 @@ async function main(): Promise<void> {
 
   console.log(`Report written: ${outputPath}`);
 
-  // 7. Generate HTML report (non-blocking — warn on failure)
+  // 8. Generate HTML report (non-blocking — warn on failure)
   try {
     const htmlPath = await generateHtmlReport(outputPath);
     console.log(`HTML report written: ${htmlPath}`);

--- a/src/summarize/report.ts
+++ b/src/summarize/report.ts
@@ -6,6 +6,10 @@ import {
   parseReportTopics,
   buildSinceLastReportSection,
 } from "./report-comparison.js";
+import {
+  findWatchingSection,
+  isPlaceholderContent,
+} from "../review/report-edit.js";
 
 // --- Types ---
 
@@ -296,6 +300,10 @@ function stripGeneratedArticleInventory(synthesis: string): string {
  * When a previous report is provided, a "## Since Last Report" section is
  * inserted highlighting continued, new, and dropped topics.
  *
+ * When an existing same-date report is provided and contains a non-placeholder
+ * "What I'm Watching" section, that content is preserved in the assembled
+ * report instead of the generated placeholder.
+ *
  * @param date - Report date in YYYY-MM-DD format
  * @param articles - All collected articles
  * @param synthesis - LLM-generated synthesis text
@@ -304,6 +312,7 @@ function stripGeneratedArticleInventory(synthesis: string): string {
  * @param totalPromptTokens - Cumulative prompt tokens across all LLM calls
  * @param totalCompletionTokens - Cumulative completion tokens across all LLM calls
  * @param previousReportMd - Full Markdown of the previous report (if any)
+ * @param existingReportMd - Full Markdown of the same-date report (if any), used to preserve human-authored content
  * @returns Assembled Markdown report string
  */
 export function assembleReport(
@@ -315,6 +324,7 @@ export function assembleReport(
   totalPromptTokens: number,
   totalCompletionTokens: number,
   previousReportMd?: string | null,
+  existingReportMd?: string | null,
 ): string {
   const articleInventory = buildArticleInventorySection(summaries);
   const synthesisWithoutInventory = stripGeneratedArticleInventory(synthesis);
@@ -366,6 +376,17 @@ export function assembleReport(
     }
   }
 
+  // Preserve existing human-authored "What I'm Watching" content when
+  // regenerating a report for the same date. Only carry forward
+  // non-placeholder content from a same-date existing report.
+  let watchingContent = "<!-- Human-authored: add your observations here -->";
+  if (existingReportMd) {
+    const existingSection = findWatchingSection(existingReportMd);
+    if (existingSection && !isPlaceholderContent(existingSection.body)) {
+      watchingContent = existingSection.body;
+    }
+  }
+
   return `# WordPress Trend Report — ${date}
 
 ${weeklySummary}${sinceLastReportBlock}
@@ -373,7 +394,8 @@ ${weeklySummary}${sinceLastReportBlock}
 ---
 
 ## What I'm Watching
-<!-- Human-authored: add your observations here -->
+
+${watchingContent}
 
 ---
 

--- a/src/weekly/index.ts
+++ b/src/weekly/index.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+/**
+ * Weekly workflow orchestration command for WP Trend Watcher.
+ *
+ * Runs the full weekly pipeline sequentially: doctor, collect, summarize,
+ * review, then starts the local review server and opens the browser.
+ *
+ * Usage: pnpm weekly
+ *
+ * Optional: --no-open flag to skip browser launch.
+ *
+ * The command stops early if doctor reports a true blocker. Warnings
+ * are printed but do not block the workflow.
+ *
+ * No new dependencies — uses Node's child_process to run existing
+ * pnpm scripts and the native http server from src/review/server.ts.
+ */
+
+import { spawn } from "node:child_process";
+import { createReviewServer } from "../review/server.js";
+
+const REVIEW_PORT = 3001;
+const REVIEW_HOST = "127.0.0.1";
+
+/**
+ * Run a pnpm script and return a promise that resolves when the process
+ * exits with code 0, or rejects with a formatted error message.
+ *
+ * @param script - The pnpm script name (e.g. "doctor", "collect").
+ * @param args - Additional arguments to pass after `--`.
+ * @param label - Human-readable step label for progress output.
+ * @returns Promise resolving when the script completes successfully.
+ */
+function runScript(
+  script: string,
+  args: string[] = [],
+  label: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cmdArgs = ["run", script];
+    if (args.length > 0) cmdArgs.push("--", ...args);
+
+    console.log(`\n▶ ${label} (pnpm ${script}${args.length ? " " + args.join(" ") : ""})`);
+
+    const child = spawn("pnpm", cmdArgs, {
+      stdio: "inherit",
+      cwd: process.cwd(),
+      shell: true,
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${label} failed with exit code ${code}`));
+      }
+    });
+
+    child.on("error", (err) => {
+      reject(new Error(`${label} failed: ${err.message}`));
+    });
+  });
+}
+
+/**
+ * Open a URL in the default browser.
+ *
+ * Supports macOS (`open`), Linux (`xdg-open`), and falls back to
+ * printing the URL for unsupported platforms.
+ *
+ * @param url - The URL to open.
+ */
+function openBrowser(url: string): void {
+  const platform = process.platform;
+  let command: string;
+
+  if (platform === "darwin") {
+    command = "open";
+  } else if (platform === "linux") {
+    command = "xdg-open";
+  } else {
+    console.log(`\n  Open this URL in your browser:\n  ${url}\n`);
+    return;
+  }
+
+  const child = spawn(command, [url], { stdio: "ignore", detached: true });
+  child.unref();
+  console.log(`\n  Opening ${url} in your browser…\n`);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const noOpen = args.includes("--no-open");
+
+  console.log("WP Trend Watcher — weekly workflow\n");
+
+  const startTime = Date.now();
+
+  try {
+    // 1. Doctor check (blocking on failure)
+    await runScript("doctor", [], "Doctor check");
+
+    // 2. Collect articles
+    await runScript("collect", [], "Collect articles");
+
+    // 3. Summarize
+    await runScript("summarize", [], "Summarize");
+
+    // 4. Automated review
+    await runScript("review", [], "Automated review");
+
+    // 5. Start review server
+    console.log(`\n▶ Review server (http://${REVIEW_HOST}:${REVIEW_PORT}/review)`);
+    const server = createReviewServer({ port: REVIEW_PORT });
+
+    server.listen(REVIEW_PORT, REVIEW_HOST, () => {
+      const reviewUrl = `http://${REVIEW_HOST}:${REVIEW_PORT}/review`;
+      console.log(`  Review server running at ${reviewUrl}`);
+      console.log(`  Press Ctrl-C to stop.\n`);
+
+      if (!noOpen) {
+        openBrowser(reviewUrl);
+      }
+    });
+
+    // Keep the process alive until the user stops it
+    process.on("SIGINT", () => {
+      console.log("\nShutting down review server…");
+      server.close(() => {
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+        console.log(`Weekly workflow stopped after ${elapsed}s.`);
+        process.exit(0);
+      });
+    });
+
+    process.on("SIGTERM", () => {
+      server.close(() => process.exit(0));
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`\n✗ Weekly workflow stopped: ${message}`);
+    process.exit(1);
+  }
+}
+
+await main();

--- a/tests/review/report-edit.test.ts
+++ b/tests/review/report-edit.test.ts
@@ -1,0 +1,237 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  findWatchingSection,
+  replaceWatchingSection,
+  isPlaceholderContent,
+} from "../../src/review/report-edit.js";
+
+// --- Stripped-down test report ---
+
+/** A minimal but structurally valid report template. */
+function makeReport(watchingContent: string): string {
+  return `# WordPress Trend Report — 2026-07-11
+
+## Weekly Summary
+
+Some summary content.
+
+---
+
+## What I'm Watching
+
+${watchingContent}
+
+---
+
+## Source Articles
+
+Article listing here.
+
+---
+
+## Build Notes
+
+Build metadata here.
+`;
+}
+
+const PLACEHOLDER_REPORT = makeReport(
+  "<!-- Human-authored: add your observations here -->",
+);
+
+const HUMAN_REPORT = makeReport(
+  "The merge proposal for the design system is exciting. It may feel like it is long overdue.",
+);
+
+// --- findWatchingSection ---
+
+test("findWatchingSection returns body for placeholder report", () => {
+  const span = findWatchingSection(PLACEHOLDER_REPORT);
+  assert.ok(span, "section should be found");
+  assert.ok(span!.body.includes("Human-authored: add your observations here"));
+});
+
+test("findWatchingSection returns body for human-authored report", () => {
+  const span = findWatchingSection(HUMAN_REPORT);
+  assert.ok(span, "section should be found");
+  assert.ok(span!.body.includes("merge proposal"));
+});
+
+test("findWatchingSection returns null when heading is missing", () => {
+  const report = "# Title\n\nNo watching section here.\n";
+  assert.equal(findWatchingSection(report), null);
+});
+
+test("findWatchingSection returns empty body when heading is at end of file", () => {
+  const report = "# Title\n\n## What I'm Watching";
+  const span = findWatchingSection(report);
+  assert.ok(span, "section should be found");
+  assert.equal(span!.body, "");
+});
+
+test("findWatchingSection body offsets point to correct content", () => {
+  const span = findWatchingSection(HUMAN_REPORT);
+  assert.ok(span, "section should be found");
+  const extracted = HUMAN_REPORT.slice(span!.bodyStart, span!.bodyEnd).trim();
+  assert.equal(extracted, span!.body);
+  assert.ok(extracted.includes("merge proposal"));
+});
+
+test("findWatchingSection preserves markdown links in body", () => {
+  const report = makeReport(
+    "See [this proposal](https://example.com) for details.",
+  );
+  const span = findWatchingSection(report);
+  assert.ok(span, "section should be found");
+  assert.ok(span!.body.includes("[this proposal](https://example.com)"));
+});
+
+test("findWatchingSection preserves unicode text", () => {
+  const report = makeReport("WordPress 7.1 is exciting 🚀 — let's see what happens.");
+  const span = findWatchingSection(report);
+  assert.ok(span, "section should be found");
+  assert.ok(span!.body.includes("🚀"));
+  assert.ok(span!.body.includes("—"));
+});
+
+test("findWatchingSection preserves lists", () => {
+  const report = makeReport("- Item one\n- Item two\n- Item three");
+  const span = findWatchingSection(report);
+  assert.ok(span, "section should be found");
+  assert.ok(span!.body.startsWith("- Item one"));
+  assert.ok(span!.body.includes("- Item three"));
+});
+
+test("findWatchingSection body end stops at next ## heading when no ---", () => {
+  const report = `## What I'm Watching
+Some notes.
+
+## Source Articles
+Articles here.`;
+  const span = findWatchingSection(report);
+  assert.ok(span, "section should be found");
+  assert.equal(span!.body, "Some notes.");
+});
+
+// --- replaceWatchingSection ---
+
+test("replaceWatchingSection replaces placeholder with new content", () => {
+  const result = replaceWatchingSection(
+    PLACEHOLDER_REPORT,
+    "My review summary here.",
+  );
+  assert.ok(result, "replacement should succeed");
+  assert.ok(result!.includes("My review summary here."));
+  assert.ok(!result!.includes("Human-authored: add your observations here"));
+  // Verify surrounding content preserved
+  assert.ok(result!.includes("# WordPress Trend Report — 2026-07-11"));
+  assert.ok(result!.includes("## Weekly Summary"));
+  assert.ok(result!.includes("## Source Articles"));
+  assert.ok(result!.includes("## Build Notes"));
+});
+
+test("replaceWatchingSection preserves content before and after section", () => {
+  const beforeContent = "# WordPress Trend Report — 2026-07-11";
+  const afterContent = "Build metadata here.";
+  const result = replaceWatchingSection(HUMAN_REPORT, "Updated watch notes.");
+  assert.ok(result, "replacement should succeed");
+  assert.ok(result!.includes(beforeContent));
+  assert.ok(result!.includes(afterContent));
+  assert.ok(result!.includes("Updated watch notes."));
+  assert.ok(!result!.includes("merge proposal"));
+});
+
+test("replaceWatchingSection returns null when section missing", () => {
+  const report = "# No section here.";
+  const result = replaceWatchingSection(report, "New content");
+  assert.equal(result, null);
+});
+
+test("replaceWatchingSection handles empty content", () => {
+  const result = replaceWatchingSection(HUMAN_REPORT, "");
+  assert.ok(result, "replacement should succeed");
+  assert.ok(result!.includes("Human-authored: add your observations here"));
+  assert.ok(!result!.includes("merge proposal"));
+});
+
+test("replaceWatchingSection preserves markdown links in new content", () => {
+  const result = replaceWatchingSection(
+    PLACEHOLDER_REPORT,
+    "See [the proposal](https://make.wordpress.org/core/proposal).",
+  );
+  assert.ok(result, "replacement should succeed");
+  assert.ok(
+    result!.includes("[the proposal](https://make.wordpress.org/core/proposal)"),
+  );
+});
+
+test("replaceWatchingSection preserves unicode in new content", () => {
+  const result = replaceWatchingSection(
+    PLACEHOLDER_REPORT,
+    "Exciting changes ahead! 🚀",
+  );
+  assert.ok(result, "replacement should succeed");
+  assert.ok(result!.includes("🚀"));
+});
+
+test("replaceWatchingSection preserves lists in new content", () => {
+  const result = replaceWatchingSection(
+    PLACEHOLDER_REPORT,
+    "- Point one\n- Point two\n- Point three",
+  );
+  assert.ok(result, "replacement should succeed");
+  assert.ok(result!.includes("- Point one"));
+  assert.ok(result!.includes("- Point three"));
+});
+
+test("replaceWatchingSection is idempotent when replacing with same content", () => {
+  const content = "Same content as before.";
+  const report = makeReport(content);
+  const result = replaceWatchingSection(report, content);
+  assert.ok(result, "replacement should succeed");
+  assert.ok(result!.includes(content));
+  // Should still have correct structure
+  assert.ok(result!.includes("## Source Articles"));
+  assert.ok(result!.includes("## Build Notes"));
+});
+
+// --- isPlaceholderContent ---
+
+test("isPlaceholderContent returns true for generated placeholder comment", () => {
+  assert.equal(
+    isPlaceholderContent("<!-- Human-authored: add your observations here -->"),
+    true,
+  );
+});
+
+test("isPlaceholderContent returns true for TODO marker", () => {
+  assert.equal(isPlaceholderContent("TODO: write something here"), true);
+});
+
+test("isPlaceholderContent returns true for empty string", () => {
+  assert.equal(isPlaceholderContent(""), true);
+});
+
+test("isPlaceholderContent returns true for whitespace-only", () => {
+  assert.equal(isPlaceholderContent("   \n  "), true);
+});
+
+test("isPlaceholderContent returns false for human-authored content", () => {
+  assert.equal(
+    isPlaceholderContent("The merge proposal looks promising."),
+    false,
+  );
+});
+
+test("isPlaceholderContent returns false for multiline human content", () => {
+  assert.equal(
+    isPlaceholderContent("- Point one\n- Point two\n\nMore notes."),
+    false,
+  );
+});
+
+test("isPlaceholderContent returns true for ADD YOUR NOTE casing variants", () => {
+  assert.equal(isPlaceholderContent("Add your note here"), true);
+  assert.equal(isPlaceholderContent("ADD YOUR NOTE"), true);
+});

--- a/tests/review/server.test.ts
+++ b/tests/review/server.test.ts
@@ -12,7 +12,7 @@ import { mkdtemp, writeFile, mkdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import http from "node:http";
-import { createReviewServer } from "../../src/review/server.js";
+import { createReviewServer, markdownToHtml } from "../../src/review/server.js";
 import type { Server } from "node:http";
 
 /** Minimal fixture report with a placeholder "What I'm Watching" section. */
@@ -422,6 +422,56 @@ test("GET on save endpoint returns 405", async () => {
   } finally {
     await teardownFixture(fixture);
   }
+});
+
+// --- markdownToHtml link safety ---
+
+test("markdownToHtml strips javascript: links", () => {
+  const result = markdownToHtml("[click me](javascript:alert(1))");
+  assert.ok(!result.includes("<a href"), "should not contain anchor tag");
+  assert.ok(!result.includes("javascript:"), "should not contain javascript URL");
+  assert.ok(result.includes("click me"), "should preserve link text");
+});
+
+test("markdownToHtml strips data: links", () => {
+  const result = markdownToHtml("[text](data:text/html,<script>alert(1)</script>)");
+  assert.ok(!result.includes("<a href"), "should not contain anchor tag");
+  assert.ok(!result.includes("data:"), "should not contain data URL");
+  assert.ok(result.includes("text"), "should preserve link text");
+});
+
+test("markdownToHtml strips vbscript: links", () => {
+  const result = markdownToHtml("[text](vbscript:msgbox(1))");
+  assert.ok(!result.includes("<a href"), "should not contain anchor tag");
+  assert.ok(!result.includes("vbscript:"), "should not contain vbscript URL");
+  assert.ok(result.includes("text"), "should preserve link text");
+});
+
+test("markdownToHtml strips unsafe links case-insensitively", () => {
+  const result = markdownToHtml("[text](JAVASCRIPT:alert(1))");
+  assert.ok(!result.includes("<a href"), "should not contain anchor tag");
+  assert.ok(!result.includes("JAVASCRIPT:"), "should not contain javascript URL");
+  assert.ok(result.includes("text"), "should preserve link text");
+});
+
+test("markdownToHtml preserves safe https: links", () => {
+  const result = markdownToHtml("[safe](https://example.com)");
+  assert.ok(result.includes('<a href="https://example.com"'), "should keep the anchor");
+  assert.ok(result.includes("safe"), "should keep link text");
+});
+
+test("markdownToHtml preserves safe http: links", () => {
+  const result = markdownToHtml("[safe](http://example.com)");
+  assert.ok(result.includes('<a href="http://example.com"'), "should keep the anchor");
+  assert.ok(result.includes("safe"), "should keep link text");
+});
+
+test("markdownToHtml handles mixed safe and unsafe links", () => {
+  const md = "- [good](https://ok.com) and [bad](javascript:evil) in one line";
+  const result = markdownToHtml(md);
+  assert.ok(result.includes('<a href="https://ok.com"'), "keeps safe link");
+  assert.ok(!result.includes("javascript:"), "strips unsafe link");
+  assert.ok(result.includes("bad"), "preserves unsafe link text");
 });
 
 // --- Server binding protection ---

--- a/tests/review/server.test.ts
+++ b/tests/review/server.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Tests for the localhost review server (src/review/server.ts).
+ *
+ * Uses temporary fixture report directories to test request routing,
+ * validation, save behaviour, and HTML regeneration without touching
+ * the real reports/ directory.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, mkdir, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import http from "node:http";
+import { createReviewServer } from "../../src/review/server.js";
+import type { Server } from "node:http";
+
+/** Minimal fixture report with a placeholder "What I'm Watching" section. */
+const FIXTURE_REPORT = `# WordPress Trend Report — 2026-07-18
+
+## Weekly Summary
+
+### Article Inventory
+
+1. [Test Article](https://example.com/1) (Test Source) — Summary.
+
+### Emerging Trends
+
+None.
+
+### Developer Implications
+
+None.
+
+---
+
+## What I'm Watching
+
+<!-- Human-authored: add your observations here -->
+
+---
+
+## Source Articles
+
+### Test Source
+- [Test Article](https://example.com/1) — 7/18/2026
+
+---
+
+## Build Notes
+- Articles analyzed: 1
+- Sources: Test Source
+- Model: test/model
+- Tokens: 100 prompt + 50 completion
+- Estimated cost: $0.00
+`;
+
+/** Prepare a temporary reports directory with a single fixture report. */
+async function setupFixture(
+  reportMd: string | null = FIXTURE_REPORT,
+): Promise<{ reportsDir: string; server: Server; baseUrl: string }> {
+  const reportsDir = await mkdtemp(join(tmpdir(), "wp-trend-review-test-"));
+  const server = createReviewServer({ reportsDir, port: 0 });
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+    server.on("error", reject);
+  });
+
+  const addr = server.address();
+  if (!addr || typeof addr === "string") {
+    server.close();
+    throw new Error("Could not get server address");
+  }
+
+  if (reportMd !== null) {
+    await writeFile(
+      join(reportsDir, "2026-07-18.md"),
+      reportMd,
+      "utf8",
+    );
+  }
+
+  const baseUrl = `http://127.0.0.1:${addr.port}`;
+  return { reportsDir, server, baseUrl };
+}
+
+/** Clean up a fixture server and directory. */
+async function teardownFixture(params: {
+  server: Server;
+}): Promise<void> {
+  return new Promise<void>((resolve) => {
+    params.server.close(() => resolve());
+  });
+}
+
+/** Helper to make an HTTP request and return status + body. */
+async function fetchFrom(
+  baseUrl: string,
+  path: string,
+  options: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+  } = {},
+): Promise<{ status: number; body: string }> {
+  const { method = "GET", headers = {}, body } = options;
+  const url = new URL(path, baseUrl);
+
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      url,
+      { method, headers },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () =>
+          resolve({
+            status: res.statusCode ?? 500,
+            body: Buffer.concat(chunks).toString("utf8"),
+          }),
+        );
+      },
+    );
+    req.on("error", reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+// --- GET /review ---
+
+test("GET /review returns HTML review page", async () => {
+  const fixture = await setupFixture();
+  try {
+    const { status, body } = await fetchFrom(fixture.baseUrl, "/review");
+    assert.equal(status, 200);
+    assert.ok(body.includes("<!DOCTYPE html>"));
+    assert.ok(body.includes("WP Trend Watcher"));
+    assert.ok(body.includes("summary-textarea"));
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+test("GET /review returns 405 for POST method", async () => {
+  const fixture = await setupFixture();
+  try {
+    const { status, body } = await fetchFrom(fixture.baseUrl, "/review", {
+      method: "POST",
+    });
+    assert.equal(status, 405);
+    assert.ok(body.includes("Method not allowed"));
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+// --- GET /api/review ---
+
+test("GET /api/review returns JSON with date, html, summary, checks", async () => {
+  const fixture = await setupFixture();
+  try {
+    const { status, body } = await fetchFrom(fixture.baseUrl, "/api/review");
+    assert.equal(status, 200);
+    const data = JSON.parse(body);
+    assert.equal(data.date, "2026-07-18");
+    assert.ok(typeof data.html === "string");
+    assert.ok(data.html.length > 0);
+    assert.ok(data.summary.includes("Human-authored"));
+    assert.ok(Array.isArray(data.checks));
+    assert.ok(data.checks.length >= 7);
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+test("GET /api/review returns 404 when no reports exist", async () => {
+  const fixture = await setupFixture(null); // no report written at all
+  try {
+    const { status, body } = await fetchFrom(fixture.baseUrl, "/api/review");
+    assert.equal(status, 404);
+    assert.ok(body.includes("No reports found"));
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+test("GET /api/review returns 405 for POST", async () => {
+  const fixture = await setupFixture();
+  try {
+    const { status } = await fetchFrom(fixture.baseUrl, "/api/review", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assert.equal(status, 405);
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+// --- GET /api/review-checks ---
+
+test("GET /api/review-checks returns checks JSON", async () => {
+  const fixture = await setupFixture();
+  try {
+    const { status, body } = await fetchFrom(fixture.baseUrl, "/api/review-checks");
+    assert.equal(status, 200);
+    const data = JSON.parse(body);
+    assert.ok(Array.isArray(data.checks));
+    assert.ok(data.checks.length >= 7);
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+// --- POST /api/review-summary ---
+
+test("POST /api/review-summary saves summary and returns updated state", async () => {
+  const fixture = await setupFixture();
+  try {
+    const { status, body } = await fetchFrom(
+      fixture.baseUrl,
+      "/api/review-summary",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          summary: "Updated observation: this is important.",
+        }),
+      },
+    );
+    assert.equal(status, 200);
+    const data = JSON.parse(body);
+    assert.ok(data.summary.includes("Updated observation"));
+    assert.ok(!data.summary.includes("Human-authored"));
+    assert.ok(data.html.includes("Updated observation"));
+    assert.equal(data.date, "2026-07-18");
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+test("POST /api/review-summary actually writes to the Markdown file", async () => {
+  const fixture = await setupFixture();
+  try {
+    await fetchFrom(fixture.baseUrl, "/api/review-summary", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        summary: "Persisted observation.",
+      }),
+    });
+
+    // Re-read the file to confirm it was written
+    const md = await readFile(join(fixture.reportsDir, "2026-07-18.md"), "utf8");
+    assert.ok(md.includes("Persisted observation."));
+    assert.ok(!md.includes("Human-authored: add your observations here"));
+    assert.ok(md.includes("## Source Articles"));
+    assert.ok(md.includes("## Build Notes"));
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+test("POST /api/review-summary regenerates HTML after save", async () => {
+  const fixture = await setupFixture();
+  try {
+    await fetchFrom(fixture.baseUrl, "/api/review-summary", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        summary: "HTML should reflect this.",
+      }),
+    });
+
+    // Check HTML was created
+    const html = await readFile(
+      join(fixture.reportsDir, "2026-07-18.html"),
+      "utf8",
+    );
+    assert.ok(html.includes("HTML should reflect this."));
+    assert.ok(html.includes("<!DOCTYPE html>"));
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+test("POST /api/review-summary returns 400 for missing Content-Type", async () => {
+  const fixture = await setupFixture();
+  try {
+    const { status, body } = await fetchFrom(
+      fixture.baseUrl,
+      "/api/review-summary",
+      {
+        method: "POST",
+        body: JSON.stringify({ summary: "test" }),
+      },
+    );
+    assert.equal(status, 400);
+    assert.ok(body.includes("application/json"));
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+test("POST /api/review-summary returns 400 for invalid JSON", async () => {
+  const fixture = await setupFixture();
+  try {
+    const { status, body } = await fetchFrom(
+      fixture.baseUrl,
+      "/api/review-summary",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      },
+    );
+    assert.equal(status, 400);
+    assert.ok(body.includes("Invalid JSON"));
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+test("POST /api/review-summary returns 400 for missing summary field", async () => {
+  const fixture = await setupFixture();
+  try {
+    const { status, body } = await fetchFrom(
+      fixture.baseUrl,
+      "/api/review-summary",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ other: "field" }),
+      },
+    );
+    assert.equal(status, 400);
+    assert.ok(body.includes("summary"));
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+test("POST /api/review-summary returns 400 for non-string summary", async () => {
+  const fixture = await setupFixture();
+  try {
+    const { status, body } = await fetchFrom(
+      fixture.baseUrl,
+      "/api/review-summary",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ summary: 123 }),
+      },
+    );
+    assert.equal(status, 400);
+    assert.ok(body.includes("summary"));
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+test("POST /api/review-summary returns 413 for oversized body", async () => {
+  const fixture = await setupFixture();
+  try {
+    const hugeString = "x".repeat(200_000);
+    const { status, body } = await fetchFrom(
+      fixture.baseUrl,
+      "/api/review-summary",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ summary: hugeString }),
+      },
+    );
+    assert.equal(status, 413);
+    assert.ok(body.includes("too large"));
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+test("POST /api/review-summary returns 404 when no reports exist", async () => {
+  const fixture = await setupFixture(null);
+  try {
+    const { status, body } = await fetchFrom(
+      fixture.baseUrl,
+      "/api/review-summary",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ summary: "test" }),
+      },
+    );
+    assert.equal(status, 404);
+    assert.ok(body.includes("No reports found"));
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+// --- Unknown routes ---
+
+test("unknown route returns 404", async () => {
+  const fixture = await setupFixture();
+  try {
+    const { status, body } = await fetchFrom(fixture.baseUrl, "/nonexistent");
+    assert.equal(status, 404);
+    assert.ok(body.includes("Not found"));
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+test("GET on save endpoint returns 405", async () => {
+  const fixture = await setupFixture();
+  try {
+    const { status } = await fetchFrom(fixture.baseUrl, "/api/review-summary");
+    assert.equal(status, 405);
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+// --- Server binding protection ---
+
+test("server binds to 127.0.0.1 only", async () => {
+  const fixture = await setupFixture();
+  try {
+    const addr = fixture.server.address();
+    assert.ok(typeof addr === "object" && addr !== null);
+    assert.equal((addr as import("node:net").AddressInfo).address, "127.0.0.1");
+  } finally {
+    await teardownFixture(fixture);
+  }
+});

--- a/tests/summarize/report.test.ts
+++ b/tests/summarize/report.test.ts
@@ -488,3 +488,209 @@ test("assembleReport removes model-generated h2 Article Inventory", () => {
   assert.ok(report.includes("## Emerging Trends"));
   assert.ok(report.includes("## Developer Implications"));
 });
+
+// --- Preservation of human-authored "What I'm Watching" content ---
+
+test("assembleReport preserves human-authored content from existing same-date report", () => {
+  const articles = [makeArticle()];
+  const summaries = [makeSummary()];
+  const synthesis = "### Article Inventory\n\n1. Test.\n\n### Emerging Trends\n\nNone.\n\n### Developer Implications\n\nNone.";
+
+  // An existing report where the human already wrote observations
+  const existingReport = `# WordPress Trend Report — 2026-06-20
+
+## Weekly Summary
+
+### Article Inventory
+
+1. [Test Article](https://example.com/1) (Test Source) — Test takeaway.
+
+### Emerging Trends
+
+None.
+
+### Developer Implications
+
+None.
+
+---
+
+## What I'm Watching
+
+The design system proposal is worth monitoring closely.
+
+---
+
+## Source Articles
+
+### Test Source
+- [Test Article](https://example.com/1) — 6/15/2026
+
+---
+
+## Build Notes
+- Model: stub/test-model
+- Tokens: 200 prompt + 100 completion
+`;
+
+  const report = assembleReport(
+    "2026-06-20",
+    articles,
+    synthesis,
+    summaries,
+    stubProvider,
+    200,
+    100,
+    null, // no previous report
+    existingReport, // same-date existing report with human content
+  );
+
+  assert.ok(report.includes("The design system proposal is worth monitoring closely."));
+  assert.ok(!report.includes("Human-authored: add your observations here"));
+});
+
+test("assembleReport does not preserve placeholder content from existing report", () => {
+  const articles = [makeArticle()];
+  const summaries = [makeSummary()];
+  const synthesis = "### Article Inventory\n\n1. Test.\n\n### Emerging Trends\n\nNone.\n\n### Developer Implications\n\nNone.";
+
+  // An existing report that still has only the placeholder
+  const existingReport = `# WordPress Trend Report — 2026-06-20
+
+## What I'm Watching
+
+<!-- Human-authored: add your observations here -->
+
+---
+
+## Source Articles
+`;
+
+  const report = assembleReport(
+    "2026-06-20",
+    articles,
+    synthesis,
+    summaries,
+    stubProvider,
+    200,
+    100,
+    null,
+    existingReport,
+  );
+
+  assert.ok(report.includes("Human-authored: add your observations here"));
+});
+
+test("assembleReport generates fresh placeholder when no existing report provided", () => {
+  const articles = [makeArticle()];
+  const summaries = [makeSummary()];
+  const synthesis = "### Article Inventory\n\n1. Test.\n\n### Emerging Trends\n\nNone.\n\n### Developer Implications\n\nNone.";
+
+  const report = assembleReport(
+    "2026-06-20",
+    articles,
+    synthesis,
+    summaries,
+    stubProvider,
+    200,
+    100,
+    null, // no previous report
+    null, // no existing report
+  );
+
+  assert.ok(report.includes("Human-authored: add your observations here"));
+});
+
+test("assembleReport preserves multiline human content from existing report", () => {
+  const articles = [makeArticle()];
+  const summaries = [makeSummary()];
+  const synthesis = "### Article Inventory\n\n1. Test.\n\n### Emerging Trends\n\nNone.\n\n### Developer Implications\n\nNone.";
+
+  const existingReport = `# WordPress Trend Report — 2026-06-20
+
+## What I'm Watching
+
+- First observation about the merge proposal.
+- Second thought on the release schedule.
+- Third note about testing windows.
+
+---
+
+## Source Articles
+`;
+
+  const report = assembleReport(
+    "2026-06-20",
+    articles,
+    synthesis,
+    summaries,
+    stubProvider,
+    200,
+    100,
+    null,
+    existingReport,
+  );
+
+  assert.ok(report.includes("- First observation about the merge proposal."));
+  assert.ok(report.includes("- Second thought on the release schedule."));
+  assert.ok(report.includes("- Third note about testing windows."));
+  assert.ok(!report.includes("Human-authored: add your observations here"));
+});
+
+test("assembleReport does not carry forward content from a different report date", () => {
+  const articles = [makeArticle()];
+  const summaries = [makeSummary()];
+  const synthesis = "### Article Inventory\n\n1. Test.\n\n### Emerging Trends\n\nNone.\n\n### Developer Implications\n\nNone.";
+
+  // A report from a DIFFERENT date — should NOT be treated as same-date existing
+  // The function only preserves from existingReportMd param, which is specifically
+  // the same-date report.  A different date's content would never be passed as
+  // existingReportMd.
+
+  const report = assembleReport(
+    "2026-06-20",
+    articles,
+    synthesis,
+    summaries,
+    stubProvider,
+    200,
+    100,
+    null, // previous report (different date) — handled via Since Last Report
+    null, // no same-date existing report — uses fresh placeholder
+  );
+
+  // Should get the default placeholder since no same-date existing report
+  assert.ok(report.includes("Human-authored: add your observations here"));
+});
+
+test("assembleReport treats existing TODO as placeholder (not preserved)", () => {
+  const articles = [makeArticle()];
+  const summaries = [makeSummary()];
+  const synthesis = "### Article Inventory\n\n1. Test.\n\n### Emerging Trends\n\nNone.\n\n### Developer Implications\n\nNone.";
+
+  const existingReport = `# WordPress Trend Report — 2026-06-20
+
+## What I'm Watching
+
+TODO: fill this in later
+
+---
+
+## Source Articles
+`;
+
+  const report = assembleReport(
+    "2026-06-20",
+    articles,
+    synthesis,
+    summaries,
+    stubProvider,
+    200,
+    100,
+    null,
+    existingReport,
+  );
+
+  assert.ok(report.includes("Human-authored: add your observations here"));
+  assert.ok(!report.includes("TODO: fill this in later"));
+});


### PR DESCRIPTION
## Summary

Adds the Weekly Review Workflow: a local review server, `pnpm weekly` command, HTML review UI, and preservation of human-authored "What I'm Watching" content across report regenerations.

### What's included

1. **Pure report-editing helpers** (`src/review/report-edit.ts`) — `findWatchingSection`, `replaceWatchingSection`, `isPlaceholderContent` for extracting and replacing the "What I'm Watching" section with full test coverage.

2. **Localhost-only review server** (`src/review/server.ts`) — native Node HTTP server with endpoints:
   - `GET /review` — browser UI with checks, rendered report, editable textarea
   - `GET /api/review` — JSON: date, html, summary, checks
   - `GET /api/review-checks` — JSON: checks only
   - `POST /api/review-summary` — saves summary (validates JSON, Content-Type, bounded size), atomically writes Markdown, regenerates HTML

3. **`pnpm weekly` command** (`src/weekly/index.ts`) — runs doctor → collect → summarize → review → starts review server → opens browser.

4. **Content preservation** — both `pnpm summarize` and `pnpm generate-report` now preserve same-date human-authored "What I'm Watching" content. Placeholder/TODO content is not preserved.

5. **Documentation** — README 0.6.0 changelog, docs/weekly-workflow.md quick start, docs/human-review.md local review server section.

6. **No new dependencies** — uses Node.js native `http`, no framework, no database.

### Verification

```
pnpm run test      → 172 tests, 0 failures
pnpm run typecheck → clean
pnpm run review    → All checks passed — ready for human review
```

### Changed files (14 files, +2196/-13)
- `AGENTS.md` — project direction updates
- `README.md` — 0.6.0 changelog, weekly command docs
- `docs/human-review.md` — local review server section
- `docs/weekly-workflow.md` — quick start and weekly command
- `package.json` — weekly script
- `src/generate-report/index.ts` — existingReportMd preservation
- `src/summarize/index.ts` — existingReportMd preservation
- `src/summarize/report.ts` — existingReportMd param in assembleReport
- `src/review/report-edit.ts` — new: section extraction/replacement
- `src/review/server.ts` — new: localhost review server
- `src/weekly/index.ts` — new: weekly CLI command
- `tests/summarize/report.test.ts` — 6 new preservation tests
- `tests/review/report-edit.test.ts` — new: 18 report-edit tests
- `tests/review/server.test.ts` — new: 18 server tests
