### PR TITLE
feat: shared markdown-it renderer, collapsible inventory, review time field

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ Both templates walk you through what's needed — takes about a minute.
 
 ## Changelog
 
+### 0.7.0
+
+- Added `markdown-it` dependency; report HTML generation and the local review server now share one Markdown renderer (`src/summarize/renderer.ts`) instead of two bespoke converters.
+- Renderer keeps raw HTML disabled and strips unsafe link schemes (`javascript:`, `data:`, `vbscript:`) so generated pages stay safe even from untrusted feeds.
+- Article Inventory now renders inside a collapsible `<details>` element (closed by default) with a visible article count, de-emphasizing long vertical lists without removing the data.
+- Report sections render in a configurable presentation order (`DEFAULT_PRESENTATION_ORDER`), so generated HTML layout can change without rewriting report history. Canonical Markdown data stays the source of truth.
+- Added a free-form **Review time** field to the local review page (`Build Notes`) and the review API; it persists to the `Review time:` line in the canonical Markdown.
+- `pnpm regen-html` now refreshes all report HTML from existing Markdown with no LLM calls; historical report data is unchanged.
+- Bumped package version to 0.7.0.
+
 ### 0.6.0
 
 - Added `pnpm weekly` single-command workflow: doctor → collect → summarize → review → local review server.

--- a/docs/human-review.md
+++ b/docs/human-review.md
@@ -42,6 +42,7 @@ The `pnpm weekly` command starts a local review server at http://127.0.0.1:3001/
 - Automated review checks (Weekly Summary, source references, weasel words, Build Notes, What I'm Watching, markdown links, HTML report presence)
 - A rendered preview of the report
 - An editable textarea for the "What I'm Watching" section
+- A free-form "Review time" field that records how long you spent reviewing and publishing the report
 
 Saving your observations via the review page updates the canonical Markdown report atomically and regenerates the matching HTML. Press Ctrl-C to stop the server when you're done reviewing.
 
@@ -64,7 +65,7 @@ A transparency section that may include:
 - model/provider used
 - estimated cloud cost
 - local model used, if any
-- human review time
+- human review time (free-form, e.g. "~15 minutes" or "20 minutes review + 5 publishing")
 - prompt changes
 - workflow issues
 

--- a/docs/weekly-workflow.md
+++ b/docs/weekly-workflow.md
@@ -76,6 +76,14 @@ pnpm generate-report
 
 If you edited the report Markdown and want to rebuild the HTML, or if you want to re-run the cross-article synthesis step without re-summarizing articles, run this. It uses saved article summaries from `summaries.json` and skips content fetching and per-article LLM calls.
 
+To refresh the HTML for every report from its Markdown without any LLM calls (for example after a layout or styling change), use:
+
+```bash
+pnpm regen-html
+```
+
+This rewrites all `reports/*.html` from the existing `reports/*.md` files. Report Markdown and article data are never changed — only the generated presentation.
+
 ### 7. Index Page (if needed)
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.5.0",
+  "version": "0.7.0",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,
@@ -27,10 +27,12 @@
   "license": "MIT",
   "dependencies": {
     "js-yaml": "^4.2.0",
+    "markdown-it": "^14.3.0",
     "rss-parser": "^3.13.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
+    "@types/markdown-it": "^14.1.2",
     "@types/node": "^24.10.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       js-yaml:
         specifier: ^4.2.0
         version: 4.2.0
+      markdown-it:
+        specifier: ^14.3.0
+        version: 14.3.0
       rss-parser:
         specifier: ^3.13.0
         version: 3.13.0
@@ -18,6 +21,9 @@ importers:
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
       '@types/node':
         specifier: ^24.10.1
         version: 24.13.2
@@ -189,6 +195,15 @@ packages:
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
@@ -197,6 +212,10 @@ packages:
 
   entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -211,6 +230,20 @@ packages:
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
+
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   rss-parser@3.13.0:
     resolution: {integrity: sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==}
@@ -228,6 +261,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -322,6 +358,15 @@ snapshots:
 
   '@types/js-yaml@4.0.9': {}
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
+
   '@types/node@24.13.2':
     dependencies:
       undici-types: 7.18.2
@@ -329,6 +374,8 @@ snapshots:
   argparse@2.0.1: {}
 
   entities@2.2.0: {}
+
+  entities@4.5.0: {}
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -366,6 +413,23 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
+  markdown-it@14.3.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  mdurl@2.0.0: {}
+
+  punycode.js@2.3.1: {}
+
   rss-parser@3.13.0:
     dependencies:
       entities: 2.2.0
@@ -380,6 +444,8 @@ snapshots:
       fsevents: 2.3.3
 
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
 
   undici-types@7.18.2: {}
 

--- a/reports/2026-06-12.html
+++ b/reports/2026-06-12.html
@@ -20,39 +20,15 @@
   </ul>
 </nav>
   <div class="report-body">
-  <h3 id="weekly-summary">Weekly Summary</h3>
-<p>Here's a summary of the latest articles from WordPress developer sources:</p>
-<ul>
-<li><strong>Gutenberg 23.3 and Media Editor Modal</strong>: The media editor modal in Gutenberg 23.3 is now the default crop experience, featuring freeform and aspect-ratio cropping, flip, rotation, zoom, and metadata editing.</li>
-<li><strong>Client-side Media Processing and Testing</strong>: Client-side media processing is ready for testing using a VIPS/WASM pipeline to generate image sub-sizes in the browser when possible. A call for testing has been issued for this feature.</li>
-<li><strong>WordPress 7.1 Collaborative Editing Outreach</strong>: Collaborative editing outreach has started for WordPress 7.1, asking testers to report any issues with real-time collaboration features that store editor state or modify block editor data.</li>
-<li><strong>Call for Release Managers for WordPress 7.0.x Releases</strong>: WordPress is seeking release managers for the 7.0.x maintenance releases, which are smaller teams responsible for releasing minor updates after a major release.</li>
-<li><strong>WordCamp Europe 2026 Recap</strong>: WordCamp Europe 2026 took place in Kraków, Poland from June 4-6, drawing 2,458 attendees from 81 countries.</li>
-</ul>
-<h3 id="emerging-trends">Emerging Trends</h3>
-<p>None notable this week.</p>
-<h3 id="developer-implications">Developer Implications</h3>
-<p>For freelance or agency WordPress developers:</p>
-<ul>
-<li>When working with Gutenberg 23.3, be aware of the new media editor modal and its features.</li>
-<li>Test Client-side Media Processing using the VIPS/WASM pipeline to generate image sub-sizes in the browser when possible.</li>
-<li>Participate in collaborative editing outreach for WordPress 7.1 by reporting any issues with real-time collaboration features that store editor state or modify block editor data.</li>
-<li>Consider applying for release manager positions for WordPress 7.0.x releases if you're interested in contributing to minor updates after a major release.</li>
-</ul>
-<p>Note: ACF version 6.8.4 is now available, but there are no notable implications for freelance or agency developers at this time.</p>
-<p><strong>Additional source references:</strong></p>
-<ul>
-<li><a href="https://make.wordpress.org/core/2026/06/10/call-for-testing-unicode-email-addresses/">Call for Testing: Unicode email addresses.</a></li>
-<li><a href="https://wordpress.org/news/2026/06/pts/">Protect The Shire</a></li>
-</ul>
-<hr>
-<h2 id="what-i-m-watching">What I'm Watching</h2>
+  <h2 id="what-i-m-watching">What I'm Watching</h2>
 <ul>
 <li>Collaborative editing in WordPress 7.1 feels like the biggest real workflow shift in this batch.</li>
 <li>The client-side media processing work is promising, but I want to see it behave on real sites before I trust it.</li>
 <li>ACF 6.8.4 is worth noting, but it does not change my immediate weekly priorities.</li>
 </ul>
 <hr>
+
+
 <h2 id="source-articles">Source Articles</h2>
 <h3 id="wordpress-developer-blog">WordPress Developer Blog</h3>
 <ul>
@@ -74,6 +50,8 @@
 <li><a href="https://www.advancedcustomfields.com/blog/acf-6-8-4/">ACF 6.8.4</a> — 6/10/2026</li>
 </ul>
 <hr>
+
+
 <h2 id="build-notes">Build Notes</h2>
 <ul>
 <li>Articles analyzed: 7</li>
@@ -83,6 +61,7 @@
 <li>Estimated cost: $0.00 (local model)</li>
 <li>Review time: ~15 minutes</li>
 </ul>
+
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>

--- a/reports/2026-06-21.html
+++ b/reports/2026-06-21.html
@@ -22,7 +22,8 @@
 </nav>
   <div class="report-body">
   <h2 id="weekly-summary">Weekly Summary</h2>
-<h3 id="article-inventory">Article Inventory</h3>
+<details class="article-inventory" id="article-inventory">
+  <summary>Article Inventory <span class="article-inventory-count">(12 articles)</span></summary>
 <ol>
 <li><a href="https://developer.wordpress.org/news/2026/06/dynamically-loading-template-parts-in-block-themes/">Dynamically loading template parts in block themes</a> (WordPress Developer Blog) — The <code>render_block_data</code> filter allows block theme authors to dynamically swap template part slugs based on page context, replacing the need for multiple nearly identical top-level templates.</li>
 <li><a href="https://make.wordpress.org/core/2026/06/19/roadmap-to-7-1/">Roadmap to 7.1</a> (Make Core) — WordPress 7.1, scheduled for release on August 19th, 2026, introduces a new Notes feature with suggestion mode and emoji reactions, alongside expanded responsive and pseudo-state styling options in the Site Editor.</li>
@@ -37,6 +38,7 @@
 <li><a href="https://wordpress.org/news/2026/06/global-partners-first-half-2026/">Global Partners Across the First Half of the 2026 WordPress Event Season</a> (WordPress.org News) — In the first half of 2026, the five Global Partners (Jetpack, WordPress.com, WooCommerce, Bluehost, and Hostinger) supported over a dozen regional WordCamps and a growing network of Campus Connect events, reaching thousands of developers and students globally.</li>
 <li><a href="https://www.advancedcustomfields.com/blog/wordpress-redis-object-cache/">WordPress Redis Object Cache and What to Do If It Fails</a> (ACF Blog) — WordPress's built-in object cache is non-persistent and resets with every request, whereas Redis provides persistent caching for database objects like posts and options to reduce query load.</li>
 </ol>
+</details>
 <h3 id="emerging-trends">Emerging Trends</h3>
 <ul>
 <li><strong>WordPress 7.1 Release Planning:</strong> The community is finalizing the roadmap for WordPress 7.1, scheduled for release on August 19, 2026. Key features under active development include a new Notes feature with suggestion mode and emoji reactions, expanded responsive and pseudo-state styling in the Site Editor, and a persistent Guidelines feature for encoding editorial rules. Performance Chat summaries identify View Transitions and Enhanced Responsive Images as the primary focus areas requiring final iteration before merge. A dedicated outreach effort for collaborative testing is launching, led by a streamlined Release Squad assigned specific roles for coordination, tech leads, triage, and testing.</li>
@@ -56,22 +58,30 @@
 <li><strong>Participate in Testing and Outreach:</strong> If you are not selected for the WordPress 7.1 Release Squad, you can still contribute by participating in the upcoming collaborative testing outreach, bug scrubs, triage, or documentation efforts. Keep an eye on the June 17, 2026, Dev Chat for specific testing calls, such as the one for Unicode email addresses.</li>
 </ul>
 <hr>
+
+
 <h2 id="what-i-m-watching">What I'm Watching</h2>
 <p>Mostly watching new proposed iterations for the following features in the upcoming WordPress 7.1 (~Aug. 26, 2026), including:</p>
 <ul>
 <li>Stabilize admin design system, which should empower plugins and custom projects to leverage consistent design tokens to make their experience seemless. (See <a href="https://github.com/WordPress/gutenberg/issues/76941">Design system theming for WordPress 7.1 #76941</a>)</li>
 <li>Extending Block Bindings API for <code>innerBlocks</code> support. (See <a href="https://github.com/WordPress/gutenberg/issues/77199">Block Bindings in WordPress 7.1 #77199</a>)</li>
-<li>🔥 Icon block API expansion - unlock 3rd-party providers to use new <code>register_icon()</code> and <code>unregister_icon()</code>, and collection support. Custom icons in the block editor anyone? 👋</li>
-</ul>
-<p>  * See: <a href="https://github.com/WordPress/gutenberg/issues/75715#issuecomment-4679395256">SVG Icon API: Iteration for WordPress 7.1 #75715</a></p>
+<li>🔥 Icon block API expansion - unlock 3rd-party providers to use new <code>register_icon()</code> and <code>unregister_icon()</code>, and collection support. Custom icons in the block editor anyone? 👋
 <ul>
-<li>Image block get a great accessibility enhancement: <a href="https://github.com/WordPress/gutenberg/pull/78064">Image block: Add "Mark as decorative" toggle for accessibility #78064</a></li>
-<li>Explorations on pseudo styling interactive state styling, and inherited Global Styles is worth keeping an eye on: <a href="https://github.com/WordPress/gutenberg/issues/77595">Block Styles: Display inherited Global Styles and own Block Style Variation styles in Block Inspector #77595</a></li>
-<li>🔥 Responsive styles enhancements - adjust block styling for different screen sizes. 👏</li>
+<li>See: <a href="https://github.com/WordPress/gutenberg/issues/75715#issuecomment-4679395256">SVG Icon API: Iteration for WordPress 7.1 #75715</a></li>
 </ul>
-<p>  * See: <a href="https://github.com/WordPress/gutenberg/issues/77817">Responsive style states for blocks - iteration for WP 7.1 #77817</a></p>
+</li>
+<li>Image block get a great accessibility enhancement: <a href="https://github.com/WordPress/gutenberg/pull/78064">Image block: Add &quot;Mark as decorative&quot; toggle for accessibility #78064</a></li>
+<li>Explorations on pseudo styling interactive state styling, and inherited Global Styles is worth keeping an eye on: <a href="https://github.com/WordPress/gutenberg/issues/77595">Block Styles: Display inherited Global Styles and own Block Style Variation styles in Block Inspector #77595</a></li>
+<li>🔥 Responsive styles enhancements - adjust block styling for different screen sizes. 👏
+<ul>
+<li>See: <a href="https://github.com/WordPress/gutenberg/issues/77817">Responsive style states for blocks - iteration for WP 7.1 #77817</a></li>
+</ul>
+</li>
+</ul>
 <p>Those are just a few highlights, but so much more on the roadmap.</p>
 <hr>
+
+
 <h2 id="source-articles">Source Articles</h2>
 <h3 id="wordpress-developer-blog">WordPress Developer Blog</h3>
 <ul>
@@ -98,6 +108,8 @@
 <li><a href="https://www.advancedcustomfields.com/blog/wordpress-redis-object-cache/">WordPress Redis Object Cache and What to Do If It Fails</a> — 6/18/2026</li>
 </ul>
 <hr>
+
+
 <h2 id="build-notes">Build Notes</h2>
 <ul>
 <li>Articles analyzed: 12</li>
@@ -105,8 +117,11 @@
 <li>Model: openai-compatible/qwen/qwen3.5-9b</li>
 <li>Tokens: 12781 prompt + 1997 completion</li>
 <li>Estimated cost: $0.00 (local model)</li>
+</ul>
+<ul>
 <li>Review time: ~18 minutes</li>
 </ul>
+
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>

--- a/reports/2026-06-27.html
+++ b/reports/2026-06-27.html
@@ -23,21 +23,23 @@
 </nav>
   <div class="report-body">
   <h2 id="weekly-summary">Weekly Summary</h2>
-<h3 id="article-inventory">Article Inventory</h3>
+<details class="article-inventory" id="article-inventory">
+  <summary>Article Inventory <span class="article-inventory-count">(7 articles)</span></summary>
 <ol>
 <li><a href="https://make.wordpress.org/core/2026/06/24/dev-chat-agenda-june-24-2026/">Dev Chat Agenda – June 24, 2026</a> (Make Core) — The June 24, 2026, WordPress Dev Chat will address the 7.1 release squad, roadmap, and a merge proposal for a new custom post type, alongside the 7.0.1 schedule and Gutenberg 23.4 updates.</li>
 <li><a href="https://make.wordpress.org/core/2026/06/23/hiding-the-classic-block-from-the-inserter-in-wordpress-7-1/">Hiding the Classic block from the inserter in WordPress 7.1</a> (Make Core) — WordPress 7.1 hides the Classic block from the block inserter, block library, and slash commands to enforce architectural consistency and reduce new legacy content creation.</li>
-<li><a href="https://make.wordpress.org/core/2026/06/22/wordpress-7-0-release-retrospective/">WordPress 7.0 Release Retrospective</a> (Make Core) — WordPress 7.0 ("Armstrong") has officially released, and the Make Core team is soliciting non-anonymous feedback from all contributors regarding the development cycle, squad dynamics, and processes.</li>
+<li><a href="https://make.wordpress.org/core/2026/06/22/wordpress-7-0-release-retrospective/">WordPress 7.0 Release Retrospective</a> (Make Core) — WordPress 7.0 (&quot;Armstrong&quot;) has officially released, and the Make Core team is soliciting non-anonymous feedback from all contributors regarding the development cycle, squad dynamics, and processes.</li>
 <li><a href="https://make.wordpress.org/core/2026/06/22/merge-proposal-guidelines-built-on-knowledge/">Merge Proposal: Guidelines built on Knowledge</a> (Make Core) — The Make Core team proposes merging the <code>wp_knowledge</code> custom post type into WordPress 7.1, establishing it as the canonical, shared primitive for storing site-wide standards such as voice, tone, and block rules.</li>
 <li><a href="https://wordpress.org/news/2026/06/open-web-merch/">Browse the New Mercantile Swag Store</a> (WordPress.org News) — The Mercantile storefront is rebuilt almost entirely with blocks, including a block-based cart and checkout, and leverages the Interactivity API for catalog navigation and modal states.</li>
 <li><a href="https://www.advancedcustomfields.com/blog/wordpress-search-plugin/">WordPress Search Plugins Compared by Use Case</a> (ACF Blog) — SearchWP and Relevanssi serve content-heavy sites, with SearchWP offering visual configuration and Relevanssi providing deeper code-level control alongside more generous agency licensing.</li>
 <li><a href="https://www.advancedcustomfields.com/blog/nextjs-wordpress/">How Headless WordPress Works with Next.js</a> (ACF Blog) — Headless WordPress decouples the backend content management system from the Next.js frontend, typically utilizing the WPGraphQL API for complex content structures over the REST API.</li>
 </ol>
+</details>
 <h3 id="emerging-trends">Emerging Trends</h3>
 <ul>
 <li><strong>WordPress 7.1 Release Roadmap:</strong> The 7.1 release is scheduled to include the removal of the Classic block from the block inserter, slash commands, and the block library, effectively ending new legacy content creation in core while maintaining editability for existing posts. This change is confirmed for the 7.1 release cycle.</li>
 <li><strong>Introduction of the <code>wp_knowledge</code> Custom Post Type:</strong> A merge proposal submitted for WordPress 7.1 introduces a new <code>wp_knowledge</code> custom post type designed to serve as the canonical storage mechanism for site-wide standards, including voice, tone, and block rules. This feature consolidates previously fragmented plugin-specific implementations into a single core resource.</li>
-<li><strong>Release Cycle Feedback Solicitation:</strong> Following the official release of WordPress 7.0 ("Armstrong"), the Make Core team is actively soliciting non-anonymous feedback from contributors regarding development cycles, squad dynamics, and processes. The deadline for this feedback is July 20, 2026.</li>
+<li><strong>Release Cycle Feedback Solicitation:</strong> Following the official release of WordPress 7.0 (&quot;Armstrong&quot;), the Make Core team is actively soliciting non-anonymous feedback from contributors regarding development cycles, squad dynamics, and processes. The deadline for this feedback is July 20, 2026.</li>
 <li><strong>Block-Based E-Commerce Implementation:</strong> The WordPress.org Mercantile storefront has been rebuilt almost entirely using blocks, including a block-based cart and checkout system, leveraging the Interactivity API for navigation and modal states.</li>
 </ul>
 <h3 id="developer-implications">Developer Implications</h3>
@@ -48,16 +50,22 @@
 <li><strong>Adopt Block-Based E-Commerce Patterns:</strong> When building or updating e-commerce stores, developers should leverage the block-based cart and checkout patterns demonstrated in the Mercantile storefront, utilizing the Interactivity API for dynamic catalog navigation and modal states to ensure a modern, block-native user experience.</li>
 <li><strong>Evaluate Search Plugin Licensing and Architecture:</strong> When selecting a search solution, agencies should consider the trade-offs between SearchWP (visual configuration) and Relevanssi (code-level control and agency licensing) based on the specific use case and client requirements.</li>
 </ul>
+
+
 <h2 id="since-last-report">Since Last Report</h2>
 <ul>
 <li><strong>New topic:</strong> <a href="https://make.wordpress.org/core/2026/06/24/dev-chat-agenda-june-24-2026/">Dev Chat Agenda – June 24, 2026</a> (Make Core) — The June 24, 2026, WordPress Dev Chat will address the 7.1 release squad, roadmap, and a merge proposal for a new custom post type, alongside the 7.0.1 schedule and Gutenberg 23.4 updates.</li>
 <li><strong>New topic:</strong> <a href="https://make.wordpress.org/core/2026/06/23/hiding-the-classic-block-from-the-inserter-in-wordpress-7-1/">Hiding the Classic block from the inserter in WordPress 7.1</a> (Make Core) — WordPress 7.1 hides the Classic block from the block inserter, block library, and slash commands to enforce architectural consistency and reduce new legacy content creation.</li>
-<li><strong>New topic:</strong> <a href="https://make.wordpress.org/core/2026/06/22/wordpress-7-0-release-retrospective/">WordPress 7.0 Release Retrospective</a> (Make Core) — WordPress 7.0 ("Armstrong") has officially released, and the Make Core team is soliciting non-anonymous feedback from all contributors regarding the development cycle, squad dynamics, and processes.</li>
+<li><strong>New topic:</strong> <a href="https://make.wordpress.org/core/2026/06/22/wordpress-7-0-release-retrospective/">WordPress 7.0 Release Retrospective</a> (Make Core) — WordPress 7.0 (&quot;Armstrong&quot;) has officially released, and the Make Core team is soliciting non-anonymous feedback from all contributors regarding the development cycle, squad dynamics, and processes.</li>
 </ul>
 <hr>
+
+
 <h2 id="what-i-m-watching">What I'm Watching</h2>
-<p>The <a href="https://make.wordpress.org/core/2026/06/22/merge-proposal-guidelines-built-on-knowledge/">proposal</a> to introduce a new custom post type: <code>wp_knowledge</code> and a related taxonomy is worth keeping 👀 on. It seems to extend the AI APIs and should "Provide a canonical storage primitive for author-facing and agent-facing site knowledge". Make sense to me.</p>
+<p>The <a href="https://make.wordpress.org/core/2026/06/22/merge-proposal-guidelines-built-on-knowledge/">proposal</a> to introduce a new custom post type: <code>wp_knowledge</code> and a related taxonomy is worth keeping 👀 on. It seems to extend the AI APIs and should &quot;Provide a canonical storage primitive for author-facing and agent-facing site knowledge&quot;. Make sense to me.</p>
 <hr>
+
+
 <h2 id="source-articles">Source Articles</h2>
 <h3 id="make-core">Make Core</h3>
 <ul>
@@ -76,6 +84,8 @@
 <li><a href="https://www.advancedcustomfields.com/blog/nextjs-wordpress/">How Headless WordPress Works with Next.js</a> — 6/24/2026</li>
 </ul>
 <hr>
+
+
 <h2 id="build-notes">Build Notes</h2>
 <ul>
 <li>Articles analyzed: 7</li>
@@ -83,8 +93,11 @@
 <li>Model: openai-compatible/qwen/qwen3.5-9b</li>
 <li>Tokens: 5974 prompt + 1248 completion</li>
 <li>Estimated cost: $0.00 (local model)</li>
+</ul>
+<ul>
 <li>Review time: ~12 minutes</li>
 </ul>
+
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>

--- a/reports/2026-07-05.html
+++ b/reports/2026-07-05.html
@@ -23,7 +23,8 @@
 </nav>
   <div class="report-body">
   <h2 id="weekly-summary">Weekly Summary</h2>
-<h3 id="article-inventory">Article Inventory</h3>
+<details class="article-inventory" id="article-inventory">
+  <summary>Article Inventory <span class="article-inventory-count">(16 articles)</span></summary>
 <ol>
 <li><a href="https://make.wordpress.org/core/2026/07/03/bug-scrub-schedule-for-wordpress-7-1/">Bug Scrub Schedule for WordPress 7.1</a> (Make Core) — WordPress 7.1 bug scrubs transition from twice-weekly sessions to a daily schedule as the release date approaches, with a strict focus on fixing regressions rather than enhancements.</li>
 <li><a href="https://make.wordpress.org/core/2026/07/03/wordpress-7-1-release-party-schedule/">WordPress 7.1 Release Party Schedule</a> (Make Core) — WordPress 7.1 is scheduled for general release on August 19, 2026, following a release cycle that includes three beta phases, two release candidates, and a 24-hour code freeze starting August 15.</li>
@@ -33,7 +34,7 @@
 <li><a href="https://make.wordpress.org/core/2026/07/01/whats-new-in-gutenberg-23-5-july-1-2026/">What’s new in Gutenberg 23.5? (July 1, 2026)</a> (Make Core) — Gutenberg 23.5 introduces experimental cropping controls to the Media editor and brings those capabilities to the Cover block, alongside new aspect-ratio and flex-alignment options for responsive styles.</li>
 <li><a href="https://make.wordpress.org/core/2026/07/01/wordpress-7-0-1-rc1-is-now-available/">WordPress 7.0.1 RC1 is now available</a> (Make Core) — WordPress 7.0.1 RC1 is a bug-fix-only maintenance release led by core contributors, intended to resolve issues introduced during the 7.0 cycle or intentionally deferred.</li>
 <li><a href="https://make.wordpress.org/core/2026/06/30/dev-chat-agenda-july-1-2026/">Dev Chat Agenda – July 1, 2026</a> (Make Core) — The July 1, 2026, Dev Chat will address the 7.1 release roadmap, specifically reviewing a proposal to merge a new custom post type and confirming that the Classic block will be hidden from the inserter by default.</li>
-<li><a href="https://make.wordpress.org/core/2026/06/30/performance-chat-summary-30-june-2026/">Performance Chat Summary: 30 June 2026</a> (Make Core) — The June 30, 2026 Performance Chat confirms no tickets are available for the 7.0.1 release, so the "Awaiting Review" queue will be scrubbed and the meeting rescheduled for July 14, 2026.</li>
+<li><a href="https://make.wordpress.org/core/2026/06/30/performance-chat-summary-30-june-2026/">Performance Chat Summary: 30 June 2026</a> (Make Core) — The June 30, 2026 Performance Chat confirms no tickets are available for the 7.0.1 release, so the &quot;Awaiting Review&quot; queue will be scrubbed and the meeting rescheduled for July 14, 2026.</li>
 <li><a href="https://make.wordpress.org/core/2026/06/30/guidelines-for-syncing-code-from-gutenberg-into-wordpress-develop/">Guidelines for Syncing Code From Gutenberg Into WordPress Develop</a> (Make Core) — During the 7.1 release cycle, code syncing from Gutenberg to WordPress trunk will occur one week after each Gutenberg general release to ensure trunk remains reasonably up to date.</li>
 <li><a href="https://make.wordpress.org/core/2026/06/29/xpost-wordpress-credits-updates/">X-post: WordPress Credits Updates</a> (Make Core) — The WP Credits program is shifting its 2026 focus from rapid growth to quality and retention, aiming to reach 35 school partnerships by year-end while establishing a public dashboard for impact tracking.</li>
 <li><a href="https://wordpress.org/news/2026/06/ai-leaders-graduates/">The First AI Leaders Graduates</a> (WordPress.org News) — On June 23, 40 students from UIC, Louisiana Tech, and UL Lafayette completed the AI Leaders Micro-Credential by building real projects with generative AI and contributing code to the WordPress open source ecosystem.</li>
@@ -42,6 +43,7 @@
 <li><a href="https://www.advancedcustomfields.com/blog/acf-6-8-5-security-release/">ACF 6.8.5 Security Release</a> (ACF Blog) — ACF 6.8.5 addresses four critical security vulnerabilities: it restricts WooCommerce order field updates to authenticated users via HPOS, patches a stored XSS vector in the Flexible Content modal, enforces a 1000-choice limit for Checkbox/Radio/Select fields (customizable via <code>acf/fields/max_appended_choices</code>), and ensures proper escaping of special characters in <code>LIKE</code> patterns.</li>
 <li><a href="https://www.advancedcustomfields.com/blog/acf-chat-fridays-introducing-the-acf-data-store-and-block-bindings-ui/">ACF Chat Fridays: Introducing the ACF Data Store and Block Bindings UI</a> (ACF Chat Fridays) — ACF 6.8.1 introduces a Data Store that enables real-time synchronization between ACF fields and the Gutenberg editor.</li>
 </ol>
+</details>
 <h3 id="emerging-trends">Emerging Trends</h3>
 <ul>
 <li><strong>Shift to Daily Bug Scrubs for 7.1:</strong> The WordPress 7.1 release cycle is transitioning its bug scrub schedule from twice-weekly sessions to a daily cadence as the release date approaches, with strict focus on fixing regressions rather than adding features. Sessions are scheduled for July and August 2026 in the #core Slack channel, led by @sajjad67 and @adrianduffell.</li>
@@ -58,7 +60,7 @@
 <ul>
 <li><strong>Monitor Daily Scrubs for 7.1:</strong> Freelance and agency developers should monitor the #core Slack channel for updates on the daily bug scrub schedule for WordPress 7.1 (July and August 2026) and join the appropriate component channels (accessibility, performance, testing) to triage reported issues.</li>
 <li><strong>Prepare for August 19 Release:</strong> Teams should prepare for the WordPress 7.1 general release on August 19, 2026, noting the 24-hour code freeze starting August 15. The release squad will coordinate milestones via the #core Slack channel and a live WordCamp US 2026 event.</li>
-<li><strong>Test Responsive Styling in Playground:</strong> Developers should test the new responsive styling feature in the WordPress Playground. Specifically, verify that per-breakpoint edits are preserved correctly and that the "Responsive editing" toggle properly isolates styles for specific devices, as the canvas resizing logic has changed.</li>
+<li><strong>Test Responsive Styling in Playground:</strong> Developers should test the new responsive styling feature in the WordPress Playground. Specifically, verify that per-breakpoint edits are preserved correctly and that the &quot;Responsive editing&quot; toggle properly isolates styles for specific devices, as the canvas resizing logic has changed.</li>
 <li><strong>Audit Read-Only Abilities:</strong> Developers building AI clients or external workflows should audit their code against the new read-only abilities (<code>core/read-settings</code>, <code>core/read-content</code>, <code>core/read-users</code>) introduced in 7.1. Ensure they are using the <code>show_in_abilities</code> flag to restrict exposure and prevent data leakage, as this replaces the need to re-implement logic for accessing site configuration and content.</li>
 <li><strong>Plan for Classic Block Removal:</strong> If your agency or client sites still rely on the Classic block, you must plan for its removal from the block inserter by default in the 7.1 release. You should migrate content to the block editor before the release to avoid functionality loss.</li>
 <li><strong>Update to 7.0.1 RC1:</strong> If you are running WordPress 7.0, you should test and apply the 7.0.1 RC1 release immediately to resolve known issues with Twemoji replacement logic, PHP 8.5 array access errors in <code>wp_get_attachment_image_src</code>, and accessibility regressions in the Visual History block.</li>
@@ -66,6 +68,8 @@
 <li><strong>Upgrade ACF to 6.8.5:</strong> Agencies using Advanced Custom Fields should upgrade to version 6.8.5 immediately to patch critical security vulnerabilities, including the stored XSS vector in the Flexible Content modal and the restriction of WooCommerce order field updates.</li>
 <li><strong>Leverage ACF Data Store:</strong> When building block-based workflows with ACF, utilize the new Data Store introduced in ACF 6.8.1 to ensure real-time synchronization between ACF fields and the Gutenberg editor, eliminating latency issues.</li>
 </ul>
+
+
 <h2 id="since-last-report">Since Last Report</h2>
 <ul>
 <li><strong>New topic:</strong> <a href="https://make.wordpress.org/core/2026/07/03/bug-scrub-schedule-for-wordpress-7-1/">Bug Scrub Schedule for WordPress 7.1</a> (Make Core) — WordPress 7.1 bug scrubs transition from twice-weekly sessions to a daily schedule as the release date approaches, with a strict focus on fixing regressions rather than enhancements.</li>
@@ -73,10 +77,14 @@
 <li><strong>New topic:</strong> <a href="https://make.wordpress.org/core/2026/07/03/xpost-call-for-testing-responsive-styling/">X-post: Call for Testing: Responsive Styling</a> (Make Core) — WordPress 7.1 introduces responsive styling, allowing users to apply specific styles to tablet and mobile breakpoints directly within the editor without writing custom CSS.</li>
 </ul>
 <hr>
+
+
 <h2 id="what-i-m-watching">What I'm Watching</h2>
 <p>The new <a href="https://www.advancedcustomfields.com/blog/acf-chat-fridays-introducing-the-acf-data-store-and-block-bindings-ui/">ACF DataStore (in ACF PRO preview)</a> is a handy tool for managing global or reusable field data in WordPress, separate from individual posts. It enables cleaner organization and more flexible storage of configuration-like custom field values.</p>
 <p>Responsive Styling needs your testing! 🥳 The long awaited enhancements for responsive styling are ready for testing and feedback. <a href="https://make.wordpress.org/test/2026/07/03/call-for-testing-responsive-styling/">Please test and provide feedback.</a></p>
 <hr>
+
+
 <h2 id="source-articles">Source Articles</h2>
 <h3 id="make-core">Make Core</h3>
 <ul>
@@ -107,6 +115,8 @@
 <li><a href="https://www.advancedcustomfields.com/blog/acf-chat-fridays-introducing-the-acf-data-store-and-block-bindings-ui/">ACF Chat Fridays: Introducing the ACF Data Store and Block Bindings UI</a> — 7/1/2026</li>
 </ul>
 <hr>
+
+
 <h2 id="build-notes">Build Notes</h2>
 <ul>
 <li>Articles analyzed: 16</li>
@@ -114,8 +124,11 @@
 <li>Model: openai-compatible/qwen/qwen3.5-9b</li>
 <li>Tokens: 15864 prompt + 2697 completion</li>
 <li>Estimated cost: $0.00 (local model)</li>
+</ul>
+<ul>
 <li>Review time: ~12 minutes</li>
 </ul>
+
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>

--- a/reports/2026-07-11.html
+++ b/reports/2026-07-11.html
@@ -23,7 +23,8 @@
 </nav>
   <div class="report-body">
   <h2 id="weekly-summary">Weekly Summary</h2>
-<h3 id="article-inventory">Article Inventory</h3>
+<details class="article-inventory" id="article-inventory">
+  <summary>Article Inventory <span class="article-inventory-count">(8 articles)</span></summary>
 <ol>
 <li><a href="https://developer.wordpress.org/news/2026/07/whats-new-for-developers-july-2026/">What’s new for developers (July 2026)</a> (WordPress Developer Blog) — WordPress 7.1 is set to release on August 19, 2026, with betas starting July 15.</li>
 <li><a href="https://make.wordpress.org/core/2026/07/08/transitioning-to-rulesets-in-the-gutenberg-repository/">Transitioning To Rulesets In The Gutenberg Repository</a> (Make Core) — As of 16:00 UTC on July 8, 2026, the Gutenberg repository has transitioned from branch protection rules to repository rulesets to fix a broken step in its plugin release process.</li>
@@ -34,16 +35,19 @@
 <li><a href="https://gutenbergtimes.com/roadmap-7-1-gutenberg-23-5-responsive-styling-migration-to-block-themes-weekend-edition-368/">Roadmap 7.1, Gutenberg 23.5, Responsive Styling, Migration to Block themes — Weekend Edition #368</a> (Gutenberg Times) — WordPress 7.1 is scheduled for August 19, 2026, with key features including responsive and interactive-state styling, new blocks like Playlist and Tabs, and a redesigned command palette.</li>
 <li><a href="https://gutenbergtimes.com/wordpress-7-0-1-fixes-registration-spam-wp_kses-css-corruption-and-7-0-admin-design-glitches/">WordPress 7.0.1 Fixes Registration Spam, wp_kses() CSS Corruption, and 7.0 Admin Design Glitches</a> (Gutenberg Times) — WordPress 7.0.1 addresses several critical issues from the 7.0 release, including stopping registration spam, fixing CSS corruption in <code>wp_kses()</code>, and resolving admin UI glitches.</li>
 </ol>
-<h3 id="emerging-trends">Emerging Trends  </h3>
-<p>The primary focus across multiple sources is the upcoming release of WordPress 7.1, scheduled for August 19, 2026, with betas starting on July 15 (source <a href="https://developer.wordpress.org/news/2026/07/whats-new-for-developers-july-2026/">1</a>). This release includes new blocks like Playlist and Tabs, responsive styling features, a redesigned command palette, and improvements to Gutenberg 23.5 (source <a href="https://gutenbergtimes.com/roadmap-7-1-gutenberg-23-5-responsive-styling-migration-to-block-themes-weekend-edition-368/">7</a>). The Gutenberg repository has also transitioned to using rulesets instead of branch protection rules, which was done to fix a broken step in its plugin release process (source <a href="https://make.wordpress.org/core/2026/07/08/transitioning-to-rulesets-in-the-gutenberg-repository/">2</a>).  </p>
-<p>Another notable trend is the proposed theming system for WordPress admin UI, which introduces design tokens and a <code>ThemeProvider</code> React component to allow consistent styling via CSS custom properties (source <a href="https://make.wordpress.org/core/2026/07/07/merge-proposal-design-system-theming/">4</a>). Additionally, there is a focus on responsive editing in Gutenberg 23.5, including drag-to-resize and magnified crop canvas features (source <a href="https://gutenbergtimes.com/roadmap-7-1-gutenberg-23-5-responsive-styling-migration-to-block-themes-weekend-edition-368/">7</a>).  </p>
-<p>The Classic block remains in the inserter for WordPress 7.1, following user feedback that suggested removing it had no clear benefits (source <a href="https://make.wordpress.org/core/2026/07/07/the-classic-block-stays-in-the-inserter-for-wordpress-7-1/">5</a>).  </p>
-<h3 id="developer-implications">Developer Implications  </h3>
-<p>Freelance and agency developers should monitor the WordPress 7.1 release cycle, starting with betas on July 15 and final release on August 19 (source <a href="https://developer.wordpress.org/news/2026/07/whats-new-for-developers-july-2026/">1</a>). Testing opportunities for responsive styling features are now available, and developers should consider participating in these to ensure compatibility with upcoming changes (source <a href="https://gutenbergtimes.com/roadmap-7-1-gutenberg-23-5-responsive-styling-migration-to-block-themes-weekend-edition-368/">7</a>).  </p>
-<p>The transition to repository rulesets in the Gutenberg project may affect plugin release workflows, so developers working with Gutenberg plugins should be aware of this change (source <a href="https://make.wordpress.org/core/2026/07/08/transitioning-to-rulesets-in-the-gutenberg-repository/">2</a>).  </p>
-<p>The proposed design system theming for WordPress admin UI, which includes a <code>ThemeProvider</code> and tools for generating accessible color ramps, may influence future theming practices (source <a href="https://make.wordpress.org/core/2026/07/07/merge-proposal-design-system-theming/">4</a>). Developers should watch for updates on this proposal and consider how it might affect admin UI customization in future projects.  </p>
-<p>WordPress 7.0.1 includes critical fixes for registration spam, CSS corruption in <code>wp_kses()</code>, and admin design glitches (source <a href="https://gutenbergtimes.com/wordpress-7-0-1-fixes-registration-spam-wp_kses-css-corruption-and-7-0-admin-design-glitches/">8</a>). Developers should ensure their projects are updated to this version, especially if they rely on the block editor or admin UI components.  </p>
+</details>
+<h3 id="emerging-trends">Emerging Trends</h3>
+<p>The primary focus across multiple sources is the upcoming release of WordPress 7.1, scheduled for August 19, 2026, with betas starting on July 15 (source <a href="https://developer.wordpress.org/news/2026/07/whats-new-for-developers-july-2026/">1</a>). This release includes new blocks like Playlist and Tabs, responsive styling features, a redesigned command palette, and improvements to Gutenberg 23.5 (source <a href="https://gutenbergtimes.com/roadmap-7-1-gutenberg-23-5-responsive-styling-migration-to-block-themes-weekend-edition-368/">7</a>). The Gutenberg repository has also transitioned to using rulesets instead of branch protection rules, which was done to fix a broken step in its plugin release process (source <a href="https://make.wordpress.org/core/2026/07/08/transitioning-to-rulesets-in-the-gutenberg-repository/">2</a>).</p>
+<p>Another notable trend is the proposed theming system for WordPress admin UI, which introduces design tokens and a <code>ThemeProvider</code> React component to allow consistent styling via CSS custom properties (source <a href="https://make.wordpress.org/core/2026/07/07/merge-proposal-design-system-theming/">4</a>). Additionally, there is a focus on responsive editing in Gutenberg 23.5, including drag-to-resize and magnified crop canvas features (source <a href="https://gutenbergtimes.com/roadmap-7-1-gutenberg-23-5-responsive-styling-migration-to-block-themes-weekend-edition-368/">7</a>).</p>
+<p>The Classic block remains in the inserter for WordPress 7.1, following user feedback that suggested removing it had no clear benefits (source <a href="https://make.wordpress.org/core/2026/07/07/the-classic-block-stays-in-the-inserter-for-wordpress-7-1/">5</a>).</p>
+<h3 id="developer-implications">Developer Implications</h3>
+<p>Freelance and agency developers should monitor the WordPress 7.1 release cycle, starting with betas on July 15 and final release on August 19 (source <a href="https://developer.wordpress.org/news/2026/07/whats-new-for-developers-july-2026/">1</a>). Testing opportunities for responsive styling features are now available, and developers should consider participating in these to ensure compatibility with upcoming changes (source <a href="https://gutenbergtimes.com/roadmap-7-1-gutenberg-23-5-responsive-styling-migration-to-block-themes-weekend-edition-368/">7</a>).</p>
+<p>The transition to repository rulesets in the Gutenberg project may affect plugin release workflows, so developers working with Gutenberg plugins should be aware of this change (source <a href="https://make.wordpress.org/core/2026/07/08/transitioning-to-rulesets-in-the-gutenberg-repository/">2</a>).</p>
+<p>The proposed design system theming for WordPress admin UI, which includes a <code>ThemeProvider</code> and tools for generating accessible color ramps, may influence future theming practices (source <a href="https://make.wordpress.org/core/2026/07/07/merge-proposal-design-system-theming/">4</a>). Developers should watch for updates on this proposal and consider how it might affect admin UI customization in future projects.</p>
+<p>WordPress 7.0.1 includes critical fixes for registration spam, CSS corruption in <code>wp_kses()</code>, and admin design glitches (source <a href="https://gutenbergtimes.com/wordpress-7-0-1-fixes-registration-spam-wp_kses-css-corruption-and-7-0-admin-design-glitches/">8</a>). Developers should ensure their projects are updated to this version, especially if they rely on the block editor or admin UI components.</p>
 <p>The retention of the Classic block in WordPress 7.1 means no immediate migration pressure, but developers should still explore alternatives and prepare for future migration tools (source <a href="https://make.wordpress.org/core/2026/07/07/the-classic-block-stays-in-the-inserter-for-wordpress-7-1/">5</a>).</p>
+
+
 <h2 id="since-last-report">Since Last Report</h2>
 <ul>
 <li><strong>New topic:</strong> <a href="https://developer.wordpress.org/news/2026/07/whats-new-for-developers-july-2026/">What’s new for developers (July 2026)</a> (WordPress Developer Blog) — WordPress 7.1 is set to release on August 19, 2026, with betas starting July 15.</li>
@@ -51,9 +55,13 @@
 <li><strong>New topic:</strong> <a href="https://make.wordpress.org/core/2026/07/08/dev-chat-agenda-july-8-2026/">Dev Chat Agenda – July 8, 2026</a> (Make Core) — The July 8, 2026 WordPress Developers Chat will focus on upcoming release discussions and include an open floor for general topics.</li>
 </ul>
 <hr>
+
+
 <h2 id="what-i-m-watching">What I'm Watching</h2>
 <p>The <a href="https://make.wordpress.org/core/2026/07/07/merge-proposal-design-system-theming/">merge proposal for the design system</a> enhancements is exciting. It may feel like it is long overdue, but it is understandeable that core contributors waited patiently for a stable first release of the <a href="https://www.designtokens.org/">Design Tokens (DTCG) specification</a> from the <a href="https://www.w3.org/community/design-tokens/">W3C Design Tokens Community Group</a> before committing to a path forward for some of the key pieces. The proposal looks promising and is a step in the right direction. Figma offers native support for importing and exporting design tokens and the foundations for AI-generated tokens and systems has potential for allowing for some unique customizations.</p>
 <hr>
+
+
 <h2 id="source-articles">Source Articles</h2>
 <h3 id="wordpress-developer-blog">WordPress Developer Blog</h3>
 <ul>
@@ -76,6 +84,8 @@
 <li><a href="https://gutenbergtimes.com/wordpress-7-0-1-fixes-registration-spam-wp_kses-css-corruption-and-7-0-admin-design-glitches/">WordPress 7.0.1 Fixes Registration Spam, wp_kses() CSS Corruption, and 7.0 Admin Design Glitches</a> — 7/10/2026</li>
 </ul>
 <hr>
+
+
 <h2 id="build-notes">Build Notes</h2>
 <ul>
 <li>Articles analyzed: 8</li>
@@ -85,6 +95,7 @@
 <li>Estimated cost: $0.00 (local model)</li>
 <li>Review time: ~14 minutes</li>
 </ul>
+
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>

--- a/reports/2026-07-19.html
+++ b/reports/2026-07-19.html
@@ -23,7 +23,8 @@
 </nav>
   <div class="report-body">
   <h2 id="weekly-summary">Weekly Summary</h2>
-<h3 id="article-inventory">Article Inventory</h3>
+<details class="article-inventory" id="article-inventory">
+  <summary>Article Inventory <span class="article-inventory-count">(12 articles)</span></summary>
 <ol>
 <li><a href="https://developer.wordpress.org/news/2026/07/on-brand-maintenance-mode-for-wordpress-block-themes/">On-brand maintenance mode for WordPress Block Themes</a> (WordPress Developer Blog) — WordPress block themes can now use the Site Editor to create and manage a custom, on-brand maintenance mode page without code changes.</li>
 <li><a href="https://make.wordpress.org/core/2026/07/14/performance-chat-summary-14-july-2026/">Performance Chat Summary: 14 July 2026</a> (Make Core) — The July 14, 2026 Performance Chat discussed proposals for environment variables to control WordPress features like Speculative Loading and Realtime Collaboration, with emphasis on host manageability.</li>
@@ -38,17 +39,20 @@
 <li><a href="https://gutenbergtimes.com/the-post-editor-is-going-full-iframe-what-block-developers-need-to-know-before-wordpress-7-1/">The post editor is going full iframe: what block developers need to know before WordPress 7.1</a> (Gutenberg Times) — WordPress 7.1 will enforce an iframe for the post editor, affecting all themes and blocks regardless of their apiVersion.</li>
 <li><a href="https://gutenbergtimes.com/podcast/gutenberg-changelog-132/">Gutenberg Changelog #132 – Proposals for Core, Calls for Testing, WordPress 7.1 and Gutenberg 23.4 and 23.5</a> (Gutenberg Times) — WordPress 7.1 and Gutenberg 23.4/23.5 updates include core proposals like Core Abilities for AI agents, the Knowledge post type, and Design System Theming with CSS variables.</li>
 </ol>
-<h3 id="emerging-trends">Emerging Trends  </h3>
-<p>WordPress 7.1 is a major focus across multiple sources, with Beta 1 now available for testing and scheduled for release on August 19, 2026. Key changes include a persistent toolbar for consistent navigation, enhanced styling controls, improved media handling, and new Notes features with inline formatting and @mentions. Additionally, the post editor will be fully iframed starting in WordPress 7.1, a change that affects all themes and blocks regardless of their <code>apiVersion</code>. This shift is part of broader release planning, with preparation for the iframe transition starting in November 2025.  </p>
-<p>The WordPress core team is also working on proposals for environment variables to control features like Speculative Loading and Realtime Collaboration, emphasizing host manageability during the July 14 Performance Chat. Security remains a priority, as evidenced by WordPress 7.0.2 addressing critical vulnerabilities with forced auto-updates for affected sites, including fixes for SQL injection and REST API issues.  </p>
-<p>WordCamp US 2026 is another recurring theme, with confirmed dates of August 16–19 in Phoenix and a focus on tracks like AI, Technical WordPress, and beginner-focused sessions.  </p>
-<h3 id="developer-implications">Developer Implications  </h3>
-<p>Freelance and agency developers should prioritize testing WordPress 7.1 Beta 1, which is available for download via plugins, direct download, WP-CLI, or the WordPress Playground. The iframe transition in the post editor requires immediate attention: block developers must update their <code>block.json</code> files to use <code>apiVersion 3</code> and ensure their blocks do not rely on the global document or window. This change will be enforced in WordPress 7.1, with earlier versions providing warnings and partial enforcement based on inserted blocks.  </p>
-<p>Developers should also review their plugins for compatibility with the persistent toolbar introduced in WordPress 7.1, ensuring that toolbar nodes function correctly within the Site Editor and using screen checks to conditionally hide them when necessary.  </p>
-<p>Security updates in WordPress 7.0.2, including fixes for CVE-2026-60137 and CVE-2026-63030, require immediate action. Sites running affected versions should apply the forced auto-updates and backports for WordPress 6.9, 6.8, and 7.1 beta2 to mitigate risks.  </p>
-<p>For those working with Advanced Custom Fields (ACF), upgrading to ACF 6.8.6 is recommended, as it includes bug fixes that prevent double-encoding of Google Maps field values and improves appearance on WordPress 7.0+.  </p>
-<p>WordPress core developers should monitor the ongoing discussions around environment variables for features like Speculative Loading and Realtime Collaboration, as these may impact how certain WordPress behaviors are configured in different hosting environments.  </p>
+</details>
+<h3 id="emerging-trends">Emerging Trends</h3>
+<p>WordPress 7.1 is a major focus across multiple sources, with Beta 1 now available for testing and scheduled for release on August 19, 2026. Key changes include a persistent toolbar for consistent navigation, enhanced styling controls, improved media handling, and new Notes features with inline formatting and @mentions. Additionally, the post editor will be fully iframed starting in WordPress 7.1, a change that affects all themes and blocks regardless of their <code>apiVersion</code>. This shift is part of broader release planning, with preparation for the iframe transition starting in November 2025.</p>
+<p>The WordPress core team is also working on proposals for environment variables to control features like Speculative Loading and Realtime Collaboration, emphasizing host manageability during the July 14 Performance Chat. Security remains a priority, as evidenced by WordPress 7.0.2 addressing critical vulnerabilities with forced auto-updates for affected sites, including fixes for SQL injection and REST API issues.</p>
+<p>WordCamp US 2026 is another recurring theme, with confirmed dates of August 16–19 in Phoenix and a focus on tracks like AI, Technical WordPress, and beginner-focused sessions.</p>
+<h3 id="developer-implications">Developer Implications</h3>
+<p>Freelance and agency developers should prioritize testing WordPress 7.1 Beta 1, which is available for download via plugins, direct download, WP-CLI, or the WordPress Playground. The iframe transition in the post editor requires immediate attention: block developers must update their <code>block.json</code> files to use <code>apiVersion 3</code> and ensure their blocks do not rely on the global document or window. This change will be enforced in WordPress 7.1, with earlier versions providing warnings and partial enforcement based on inserted blocks.</p>
+<p>Developers should also review their plugins for compatibility with the persistent toolbar introduced in WordPress 7.1, ensuring that toolbar nodes function correctly within the Site Editor and using screen checks to conditionally hide them when necessary.</p>
+<p>Security updates in WordPress 7.0.2, including fixes for CVE-2026-60137 and CVE-2026-63030, require immediate action. Sites running affected versions should apply the forced auto-updates and backports for WordPress 6.9, 6.8, and 7.1 beta2 to mitigate risks.</p>
+<p>For those working with Advanced Custom Fields (ACF), upgrading to ACF 6.8.6 is recommended, as it includes bug fixes that prevent double-encoding of Google Maps field values and improves appearance on WordPress 7.0+.</p>
+<p>WordPress core developers should monitor the ongoing discussions around environment variables for features like Speculative Loading and Realtime Collaboration, as these may impact how certain WordPress behaviors are configured in different hosting environments.</p>
 <p>Finally, developers should consider attending WordCamp US 2026 for insights into upcoming trends and tools, particularly in AI integration, technical WordPress development, and new Gutenberg features like grid layout properties and auto-generated block documentation.</p>
+
+
 <h2 id="since-last-report">Since Last Report</h2>
 <ul>
 <li><strong>New topic:</strong> <a href="https://developer.wordpress.org/news/2026/07/on-brand-maintenance-mode-for-wordpress-block-themes/">On-brand maintenance mode for WordPress Block Themes</a> (WordPress Developer Blog) — WordPress block themes can now use the Site Editor to create and manage a custom, on-brand maintenance mode page without code changes.</li>
@@ -56,11 +60,15 @@
 <li><strong>New topic:</strong> <a href="https://make.wordpress.org/core/2026/07/14/dev-chat-agenda-july-14-2026/">Dev Chat Agenda – July 14, 2026</a> (Make Core) — The WordPress Developers Chat on July 14, 2026, will focus on upcoming releases and include an open floor for discussions.</li>
 </ul>
 <hr>
+
+
 <h2 id="what-i-m-watching">What I'm Watching</h2>
 <p><strong><a href="https://wordpress.org/news/2026/07/wordpress-7-0-2-release/">WordPress 7.0.2 Release</a> (7/17/2026) is a security release, and it is highly encouraged you update ASAP (if forced auto-update did not do it).</strong></p>
 <p>WordPress 7.1 Beta 1 is ready for testing. Testing instructions are included in <a href="https://wordpress.org/news/2026/07/wordpress-7-1-beta-1/">the announcement post</a>. I would encourage folks to review the <a href="https://make.wordpress.org/test/2026/07/03/call-for-testing-responsive-styling/">Call for Testing: Responsive Styling</a>. Test these features and provide your critical feedback. Folks have been asking for responsive styling for years and now that they're being actively developed it is important to make them top notch.</p>
 <p>See ya next week! 👋</p>
 <hr>
+
+
 <h2 id="source-articles">Source Articles</h2>
 <h3 id="wordpress-developer-blog">WordPress Developer Blog</h3>
 <ul>
@@ -90,6 +98,8 @@
 <li><a href="https://gutenbergtimes.com/podcast/gutenberg-changelog-132/">Gutenberg Changelog #132 – Proposals for Core, Calls for Testing, WordPress 7.1 and Gutenberg 23.4 and 23.5</a> — 7/12/2026</li>
 </ul>
 <hr>
+
+
 <h2 id="build-notes">Build Notes</h2>
 <ul>
 <li>Articles analyzed: 12</li>
@@ -99,6 +109,7 @@
 <li>Estimated cost: $0.00 (local model)</li>
 <li>Review time: ~15 minutes</li>
 </ul>
+
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>

--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -48,9 +48,39 @@ em { font-style: italic; }
 .toc ul { column-gap: 1rem; display: flex; list-style: none;margin: 0; }
 .toc a { font-size: 0.9rem; }
 
-/* Article Inventory list */
+/* Article Inventory disclosure */
 #article-inventory + ol li { padding: 0.5rem 0; border-bottom: 1px solid #f0f0f0; }
 #article-inventory + ol li:last-child { border-bottom: none; }
+
+/* Collapsible Article Inventory */
+details.article-inventory {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  margin: 1.5rem 0;
+  background: #fafafa;
+}
+details.article-inventory > summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1.05rem;
+  list-style: none;
+}
+details.article-inventory > summary::-webkit-details-marker { display: none; }
+details.article-inventory > summary::before {
+  content: "▸ ";
+  display: inline-block;
+  transition: transform 0.15s ease;
+}
+details.article-inventory[open] > summary::before {
+  content: "▾ ";
+}
+details.article-inventory .article-inventory-count {
+  font-weight: 400;
+  color: #666;
+  font-size: 0.9rem;
+}
+details.article-inventory ol { margin-top: 0.75rem; }
 
 /* Build Notes panel */
 #build-notes ~ * { font-size: 0.9rem; color: #555; }

--- a/src/review/report-edit.ts
+++ b/src/review/report-edit.ts
@@ -179,3 +179,52 @@ export function replaceWatchingSection(
 
   return beforeBody.trimEnd() + "\n\n" + cleanContent + "\n" + afterBody;
 }
+
+/** Marker line prefix used in Build Notes for the human review time. */
+const REVIEW_TIME_PREFIX = "- Review time:";
+
+/**
+ * Extract the human-entered review time from a report's Build Notes.
+ *
+ * @param report - Full Markdown report text.
+ * @returns The review time value (after the prefix), or an empty string when
+ *   the line is absent or still a placeholder.
+ */
+export function findReviewTime(report: string): string {
+  const idx = report.indexOf(REVIEW_TIME_PREFIX);
+  if (idx === -1) return "";
+  const after = report.slice(idx + REVIEW_TIME_PREFIX.length);
+  const lineEnd = after.search(/\r?\n/);
+  const raw = lineEnd === -1 ? after : after.slice(0, lineEnd);
+  return raw.trim();
+}
+
+/**
+ * Replace only the `Review time:` line inside `## Build Notes`.
+ *
+ * Preserves all other report content. When `newValue` is empty, the line is
+ * reset to the placeholder text `(add after human review)` so the field stays
+ * visible for future review. Returns the modified report, or `null` when no
+ * Build Notes review-time line exists.
+ *
+ * @param report - Full Markdown report text.
+ * @param newValue - Free-form review-time text (e.g. "~15 minutes").
+ * @returns Modified report, or null when no review-time line is present.
+ */
+export function replaceReviewTime(
+  report: string,
+  newValue: string,
+): string | null {
+  const idx = report.indexOf(REVIEW_TIME_PREFIX);
+  if (idx === -1) return null;
+
+  const after = report.slice(idx + REVIEW_TIME_PREFIX.length);
+  const lineEnd = after.search(/\r?\n/);
+  const sliceEnd = lineEnd === -1 ? report.length : idx + REVIEW_TIME_PREFIX.length + lineEnd;
+  const before = report.slice(0, idx + REVIEW_TIME_PREFIX.length);
+  const rest = report.slice(sliceEnd);
+
+  const clean = newValue.trim();
+  const replacement = clean.length === 0 ? " (add after human review)" : ` ${clean}`;
+  return before + replacement + rest;
+}

--- a/src/review/server.ts
+++ b/src/review/server.ts
@@ -35,10 +35,13 @@ import {
 } from "node:path";
 import { randomBytes } from "node:crypto";
 import { generateHtmlReport } from "../summarize/html.js";
+import { renderReportBody } from "../summarize/renderer.js";
 import {
   findWatchingSection,
   replaceWatchingSection,
   isPlaceholderContent,
+  findReviewTime,
+  replaceReviewTime,
 } from "./report-edit.js";
 import {
   extractReportBody,
@@ -64,6 +67,7 @@ export interface ReviewData {
   date: string;
   html: string;
   summary: string;
+  reviewTime: string;
   checks: ReviewCheck[];
 }
 
@@ -175,126 +179,7 @@ export async function findLatestReportFile(
  * Handles the subset of Markdown found in trend reports.
  */
 export function markdownToHtml(md: string): string {
-  const lines = md.split("\n");
-  const out: string[] = [];
-  let i = 0;
-
-  function slugify(text: string): string {
-    return text
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "");
-  }
-
-  function inlineFormat(text: string): string {
-    return text
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/`([^`]+)`/g, "<code>$1</code>")
-      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-      .replace(/\*(.+?)\*/g, "<em>$1</em>")
-      .replace(
-        /\[([^\]]+)\]\(([^)]+)\)/g,
-        (_m: string, linkText: string, url: string) => {
-          const unsafe = /^(javascript:|data:|vbscript:)/i;
-          if (unsafe.test(url)) return linkText;
-          return `<a href="${url}">${linkText}</a>`;
-        },
-      );
-  }
-
-  while (i < lines.length) {
-    const line = lines[i];
-
-    if (/^\s*<!--/.test(line)) {
-      out.push(line);
-      i++;
-      continue;
-    }
-
-    if (/^---+$/.test(line)) {
-      out.push("<hr>");
-      i++;
-      continue;
-    }
-
-    const headingMatch = line.match(/^(#{1,6})\s+(.*)/);
-    if (headingMatch) {
-      const level = headingMatch[1].length;
-      const text = inlineFormat(headingMatch[2]);
-      const id = slugify(headingMatch[2]);
-      out.push(`<h${level} id="${id}">${text}</h${level}>`);
-      i++;
-      continue;
-    }
-
-    if (/^[*-]\s+/.test(line)) {
-      const items: string[] = [];
-      while (i < lines.length && /^[*-]\s+/.test(lines[i])) {
-        items.push(
-          `<li>${inlineFormat(lines[i].replace(/^[-*]\s+/, ""))}</li>`,
-        );
-        i++;
-      }
-      out.push(`<ul>\n${items.join("\n")}\n</ul>`);
-      continue;
-    }
-
-    if (/^\d+\.\s+/.test(line)) {
-      const items: string[] = [];
-      while (i < lines.length && /^\d+\.\s+/.test(lines[i])) {
-        let itemText = lines[i].replace(/^\d+\.\s+/, "");
-        i++;
-        while (
-          i < lines.length &&
-          /^\s{2,}\S/.test(lines[i]) &&
-          !/^\d+\.\s+/.test(lines[i]) &&
-          !/^(#{1,6})\s+/.test(lines[i]) &&
-          !/^[-*]\s+/.test(lines[i]) &&
-          !/^---+$/.test(lines[i])
-        ) {
-          itemText += " " + lines[i].trim();
-          i++;
-        }
-        if (
-          i < lines.length &&
-          lines[i].trim() === "" &&
-          i + 1 < lines.length &&
-          /^\d+\.\s+/.test(lines[i + 1])
-        ) {
-          i++;
-        }
-        items.push(`<li>${inlineFormat(itemText)}</li>`);
-      }
-      out.push(`<ol>\n${items.join("\n")}\n</ol>`);
-      continue;
-    }
-
-    if (line.trim() === "") {
-      i++;
-      continue;
-    }
-
-    const paraLines: string[] = [];
-    while (
-      i < lines.length &&
-      lines[i].trim() !== "" &&
-      !/^(#{1,6})\s+/.test(lines[i]) &&
-      !/^[-*]\s+/.test(lines[i]) &&
-      !/^\d+\.\s+/.test(lines[i]) &&
-      !/^---+$/.test(lines[i]) &&
-      !/^\s*<!--/.test(lines[i])
-    ) {
-      paraLines.push(lines[i]);
-      i++;
-    }
-    if (paraLines.length > 0) {
-      out.push(`<p>${inlineFormat(paraLines.join("\n"))}</p>`);
-    }
-  }
-
-  return out.join("\n");
+  return renderReportBody(md);
 }
 
 /**
@@ -501,6 +386,8 @@ function reviewPageHtml(): string {
   <p class="meta">Edit the <em>What I'm Watching</em> section below. Saving updates the canonical Markdown report and regenerates the matching HTML.</p>
   <label class="editor-label" for="summary-textarea">What I'm Watching</label>
   <textarea id="summary-textarea" placeholder="Add your observations here…"></textarea>
+  <label class="editor-label" for="review-time-input">Review time</label>
+  <input id="review-time-input" type="text" placeholder="e.g. ~15 minutes" autocomplete="off">
   <button class="btn" id="save-btn" onclick="saveSummary()">💾 Save summary</button>
   <div class="status" id="save-status"></div>
 </section>
@@ -518,6 +405,7 @@ async function loadReview() {
     renderChecks(data.checks);
     document.getElementById('report-container').innerHTML = data.html;
     document.getElementById('summary-textarea').value = data.summary;
+    document.getElementById('review-time-input').value = data.reviewTime || '';
   } catch (err) {
     document.getElementById('meta-info').textContent = 'Failed to load: ' + err.message;
   }
@@ -540,6 +428,7 @@ async function saveSummary() {
   const statusEl = document.getElementById('save-status');
   const btn = document.getElementById('save-btn');
   const summary = document.getElementById('summary-textarea').value;
+  const reviewTime = document.getElementById('review-time-input').value;
 
   statusEl.className = 'status loading';
   statusEl.textContent = 'Saving…';
@@ -549,7 +438,7 @@ async function saveSummary() {
     const res = await fetch('/api/review-summary', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ summary: summary }),
+      body: JSON.stringify({ summary: summary, reviewTime: reviewTime }),
     });
 
     if (!res.ok) {
@@ -561,6 +450,8 @@ async function saveSummary() {
     statusEl.className = 'status success';
     statusEl.textContent = '✓ Saved successfully — Markdown and HTML updated.';
     document.getElementById('report-container').innerHTML = data.html;
+    document.getElementById('summary-textarea').value = data.summary;
+    document.getElementById('review-time-input').value = data.reviewTime || '';
     document.getElementById('meta-info').textContent =
       'Report: ' + data.date + ' — ' + data.checks.length + ' checks run';
   } catch (err) {
@@ -711,6 +602,9 @@ async function serveReviewData(
     const section = findWatchingSection(report);
     const summary = section ? section.body : "";
 
+    // Extract review time from Build Notes
+    const reviewTime = findReviewTime(report);
+
     const htmlPath = join(ctx.reportsDir, `${date}.html`);
     let htmlExists = false;
     try {
@@ -729,7 +623,7 @@ async function serveReviewData(
       checkHtmlReport(htmlExists, htmlPath),
     ];
 
-    const data: ReviewData = { date, html, summary, checks };
+    const data: ReviewData = { date, html, summary, reviewTime, checks };
 
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(data) + "\n");
@@ -764,7 +658,7 @@ async function handleSaveSummary(
     return;
   }
 
-  let payload: { summary?: unknown };
+  let payload: { summary?: unknown; reviewTime?: unknown };
   try {
     payload = JSON.parse(body);
   } catch {
@@ -781,7 +675,17 @@ async function handleSaveSummary(
     return;
   }
 
+  // reviewTime is optional; when provided it must be a string.
+  if (payload.reviewTime !== undefined && typeof payload.reviewTime !== "string") {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({ error: 'Invalid "reviewTime" field' }) + "\n",
+    );
+    return;
+  }
+
   const newSummary = payload.summary;
+  const newReviewTime = typeof payload.reviewTime === "string" ? payload.reviewTime : "";
 
   // Find latest report
   const reportFile = await findLatestReportFile(ctx.reportsDir);
@@ -814,12 +718,21 @@ async function handleSaveSummary(
     return;
   }
 
+  // Update review time in Build Notes when provided.
+  let finalReport = updatedReport;
+  if (newReviewTime !== "") {
+    const withReviewTime = replaceReviewTime(updatedReport, newReviewTime);
+    if (withReviewTime !== null) {
+      finalReport = withReviewTime;
+    }
+  }
+
   // Atomic write: write to temp file, then rename
   const tmpPath =
     reportPath + "." + randomBytes(8).toString("hex") + ".tmp";
   try {
     await mkdir(dirname(tmpPath), { recursive: true });
-    await writeFile(tmpPath, updatedReport, "utf8");
+    await writeFile(tmpPath, finalReport, "utf8");
     await rename(tmpPath, reportPath);
   } catch (err) {
     // Clean up temp file if it exists
@@ -841,11 +754,12 @@ async function handleSaveSummary(
   }
 
   // Return updated state
-  const html = markdownToHtml(updatedReport);
-  const section = findWatchingSection(updatedReport);
+  const html = markdownToHtml(finalReport);
+  const section = findWatchingSection(finalReport);
   const summary = section ? section.body : "";
-  const rbody = extractReportBody(updatedReport);
-  const articles = parseSourceArticles(updatedReport);
+  const reviewTime = findReviewTime(finalReport);
+  const rbody = extractReportBody(finalReport);
+  const articles = parseSourceArticles(finalReport);
 
   const htmlPath = join(ctx.reportsDir, `${date}.html`);
   let htmlExists = false;
@@ -859,13 +773,13 @@ async function handleSaveSummary(
     checkWeeklySummary(rbody),
     checkSourceReferences(articles, rbody),
     checkWeaselWords(rbody),
-    checkBuildNotes(updatedReport),
-    checkWatchingSection(updatedReport),
-    checkMarkdownLinks(updatedReport),
+    checkBuildNotes(finalReport),
+    checkWatchingSection(finalReport),
+    checkMarkdownLinks(finalReport),
     checkHtmlReport(htmlExists, htmlPath),
   ];
 
-  const data: ReviewData = { date, html, summary, checks };
+  const data: ReviewData = { date, html, summary, reviewTime, checks };
 
   res.writeHead(200, { "Content-Type": "application/json" });
   res.end(JSON.stringify(data) + "\n");

--- a/src/summarize/html.ts
+++ b/src/summarize/html.ts
@@ -1,5 +1,11 @@
 import { mkdir, readFile, writeFile, readdir } from "node:fs/promises";
 import { join, basename, dirname } from "node:path";
+import {
+  renderMarkdown,
+  renderReportBody,
+  extractToc,
+  slugify,
+} from "./renderer.js";
 
 const REPORT_STYLESHEET_HREF = "assets/report.css";
 const REPORT_STYLESHEET_SOURCE = new URL("./report.css", import.meta.url);
@@ -7,156 +13,10 @@ const REPORT_ICON_HREF = "assets/icon.svg";
 const REPORT_ICON_SOURCE = new URL("./icon.svg", import.meta.url);
 
 /**
- * Convert a URL-friendly slug from plain text.
- *
- * Strips non-alphanumeric characters, lowercases, and collapses whitespace
- * into hyphens. Used to generate stable heading ids.
- */
-function slugify(text: string): string {
-  return text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
-}
-
-/**
- * Convert a simple Markdown string to HTML.
- *
- * Handles the subset found in wp-trend-watcher reports: headings (h1–h3),
- * paragraphs, unordered lists, links, bold, italic, inline code, horizontal
- * rules, and HTML comments. Not a general-purpose parser.
- */
-function markdownToHtml(md: string): string {
-  const lines = md.split("\n");
-  const out: string[] = [];
-  let i = 0;
-
-  while (i < lines.length) {
-    const line = lines[i];
-
-    // HTML comment — pass through
-    if (/^\s*<!--/.test(line)) {
-      out.push(line);
-      i++;
-      continue;
-    }
-
-    // Horizontal rule
-    if (/^---+\s*$/.test(line)) {
-      out.push("<hr>");
-      i++;
-      continue;
-    }
-
-    // Headings (h1–h6) — add stable id attribute
-    const headingMatch = line.match(/^(#{1,6})\s+(.*)/);
-    if (headingMatch) {
-      const level = headingMatch[1].length;
-      const text = inlineFormat(headingMatch[2]);
-      const id = slugify(headingMatch[2]);
-      out.push(`<h${level} id="${id}">${text}</h${level}>`);
-      i++;
-      continue;
-    }
-
-    // Unordered list
-    if (/^[*-]\s+/.test(line)) {
-      const items: string[] = [];
-      while (i < lines.length && /^[*-]\s+/.test(lines[i])) {
-        items.push(`<li>${inlineFormat(lines[i].replace(/^[-*]\s+/, ""))}</li>`);
-        i++;
-      }
-      out.push(`<ul>\n${items.join("\n")}\n</ul>`);
-      continue;
-    }
-
-    // Ordered list — handles both tight (no blank lines between items) and
-    // loose (blank lines between items) formats. Collects indented continuation
-    // lines that follow a numbered item as part of that item's content.
-    if (/^\d+\.\s+/.test(line)) {
-      const items: string[] = [];
-      while (i < lines.length && /^\d+\.\s+/.test(lines[i])) {
-        let itemText = lines[i].replace(/^\d+\.\s+/, "");
-        i++;
-        // Collect indented continuation lines (part of this list item)
-        while (
-          i < lines.length &&
-          /^\s{2,}\S/.test(lines[i]) &&
-          !/^\d+\.\s+/.test(lines[i]) &&
-          !/^(#{1,6})\s+/.test(lines[i]) &&
-          !/^[-*]\s+/.test(lines[i]) &&
-          !/^---+\s*$/.test(lines[i])
-        ) {
-          itemText += " " + lines[i].trim();
-          i++;
-        }
-        // Skip blank line between loose list items (next line is another item)
-        if (
-          i < lines.length &&
-          lines[i].trim() === "" &&
-          i + 1 < lines.length &&
-          /^\d+\.\s+/.test(lines[i + 1])
-        ) {
-          i++;
-        }
-        items.push(`<li>${inlineFormat(itemText)}</li>`);
-      }
-      out.push(`<ol>\n${items.join("\n")}\n</ol>`);
-      continue;
-    }
-
-    // Blank line — skip
-    if (line.trim() === "") {
-      i++;
-      continue;
-    }
-
-    // Paragraph — collect consecutive non-blank lines
-    const paraLines: string[] = [];
-    while (
-      i < lines.length &&
-      lines[i].trim() !== "" &&
-      !/^(#{1,6})\s+/.test(lines[i]) &&
-      !/^[-*]\s+/.test(lines[i]) &&
-      !/^\d+\.\s+/.test(lines[i]) &&
-      !/^---+\s*$/.test(lines[i]) &&
-      !/^\s*<!--/.test(lines[i])
-    ) {
-      paraLines.push(lines[i]);
-      i++;
-    }
-    if (paraLines.length > 0) {
-      out.push(`<p>${inlineFormat(paraLines.join("\n"))}</p>`);
-    }
-  }
-
-  return out.join("\n");
-}
-
-/**
- * Apply inline formatting: bold, italic, code, and links.
- */
-function inlineFormat(text: string): string {
-  return (
-    text
-      // HTML-escape angle brackets for XSS prevention (before other transforms)
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      // Inline code (must come before bold/italic to avoid conflicts)
-      .replace(/`([^`]+)`/g, "<code>$1</code>")
-      // Bold
-      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-      // Italic
-      .replace(/\*(.+?)\*/g, "<em>$1</em>")
-      // Links
-      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
-  );
-}
-
-/**
  * Extract the report date from a Markdown filename like "2026-06-12.md".
  */
 function dateFromFilename(filePath: string): string {
-  const name = basename(filePath, ".md");
-  return name;
+  return basename(filePath, ".md");
 }
 
 /**
@@ -182,8 +42,8 @@ async function ensureReportStylesheet(reportsDir: string): Promise<string> {
 /**
  * Generate a styled HTML report from a Markdown report file.
  *
- * Reads the Markdown, converts to HTML, writes the shared stylesheet, and
- * writes an HTML file alongside the original.
+ * Reads the Markdown, converts to HTML via the shared renderer, writes the
+ * shared stylesheet, and writes an HTML file alongside the original.
  *
  * @param mdPath - Absolute path to the Markdown report (e.g. reports/2026-06-12.md)
  * @returns Absolute path to the generated HTML file
@@ -192,31 +52,27 @@ export async function generateHtmlReport(mdPath: string): Promise<string> {
   const md = await readFile(mdPath, "utf8");
   const date = dateFromFilename(mdPath);
   const stylesheetHref = await ensureReportStylesheet(dirname(mdPath));
-  const htmlContent = markdownToHtml(md);
+  const bodyHtml = renderReportBody(md);
 
   // Extract the h1 heading for the report header
-  const h1Match = htmlContent.match(/<h1[^>]*>.*?<\/h1>/);
-  let headerHtml = "";
-  let bodyHtml = htmlContent;
+  const h1Match = md.match(/^#\s+(.*)$/m);
+  let headerHtml: string;
   if (h1Match) {
-    headerHtml = `<header class="report-header">\n  <img class="report-icon" src="${REPORT_ICON_HREF}" alt="" width="40" height="40">\n  ${h1Match[0]}\n</header>`;
-    bodyHtml = htmlContent.slice(h1Match.index! + h1Match[0].length).trim();
+    const h1Id = slugify(h1Match[1]);
+    headerHtml = `<header class="report-header">\n  <img class="report-icon" src="${REPORT_ICON_HREF}" alt="" width="40" height="40">\n  <h1 id="${h1Id}">${h1Match[1]}</h1>\n</header>`;
   } else {
     headerHtml = `<header class="report-header">\n  <img class="report-icon" src="${REPORT_ICON_HREF}" alt="" width="40" height="40">\n  <h1>WordPress Trend Report — ${date}</h1>\n</header>`;
   }
 
   // Build table of contents from h2 headings (if 2 or more exist)
-  const h2Regex = /<h2[^>]*id="([^"]*)"[^>]*>(.*?)<\/h2>/g;
-  const tocEntries: { id: string; text: string }[] = [];
-  let tocMatch: RegExpExecArray | null;
-  while ((tocMatch = h2Regex.exec(htmlContent)) !== null) {
-    tocEntries.push({ id: tocMatch[1], text: tocMatch[2] });
-  }
-
+  const tocEntries = extractToc(bodyHtml);
   let tocHtml = "";
   if (tocEntries.length >= 2) {
     const links = tocEntries
-      .map((entry) => `    <li><a href="#${entry.id}">${entry.text}</a></li>`)
+      .map(
+        (entry) =>
+          `    <li><a href="#${entry.id}">${entry.text}</a></li>`,
+      )
       .join("\n");
     tocHtml = `<nav class="toc">\n  <h2>Contents</h2>\n  <ul>\n${links}\n  </ul>\n</nav>`;
   }

--- a/src/summarize/renderer.ts
+++ b/src/summarize/renderer.ts
@@ -1,0 +1,298 @@
+import MarkdownIt from "markdown-it";
+
+/**
+ * Semantic section keys used for configurable report presentation order.
+ *
+ * These correspond to the top-level `##` headings emitted by
+ * `assembleReport()`. The Article Inventory is a `###` sub-heading inside the
+ * Weekly Summary block and is handled as a presentation detail (collapsible
+ * disclosure) rather than an independently reorderable section.
+ */
+export type ReportSection =
+  | "weekly-summary"
+  | "since-last-report"
+  | "what-i-m-watching"
+  | "source-articles"
+  | "build-notes";
+
+/**
+ * Default presentation order for report sections.
+ *
+ * This is a presentation concern only. It does not change the canonical
+ * Markdown report or source data. Adjusting this array reorders the generated
+ * HTML without rewriting report history.
+ */
+export const DEFAULT_PRESENTATION_ORDER: ReportSection[] = [
+  "weekly-summary",
+  "since-last-report",
+  "what-i-m-watching",
+  "source-articles",
+  "build-notes",
+];
+
+/**
+ * Known top-level report section headings in the canonical Markdown report.
+ *
+ * Sub-headings (any `###`) are intentionally excluded so that nested blocks
+ * inside the Weekly Summary (Article Inventory, Emerging Trends, Developer
+ * Implications) render together with their parent section.
+ */
+const SECTION_HEADINGS: Record<ReportSection, string> = {
+  "weekly-summary": "## Weekly Summary",
+  "since-last-report": "## Since Last Report",
+  "what-i-m-watching": "## What I'm Watching",
+  "source-articles": "## Source Articles",
+  "build-notes": "## Build Notes",
+};
+
+/** Pattern that marks the start of a top-level `## ` section. */
+const SECTION_LINE = /^##\s+(.*)$/;
+
+/**
+ * Extract the top-level report sections from canonical Markdown.
+ *
+ * The canonical Markdown order is preserved in the returned map; the
+ * presentation order is applied separately by {@link renderReportBody}. Nested
+ * `###` sub-headings stay part of their parent `##` section.
+ *
+ * @param reportMd - Canonical Markdown report.
+ * @returns Map of semantic section key to its raw Markdown body (heading
+ *   line excluded), in canonical order. Sections not present are omitted.
+ */
+export function extractReportSections(
+  reportMd: string,
+): Map<ReportSection, string> {
+  const lines = reportMd.split("\n");
+  const sections = new Map<ReportSection, string>();
+  let current: ReportSection | null = null;
+  let buffer: string[] = [];
+
+  const flush = () => {
+    if (current !== null) {
+      sections.set(current, buffer.join("\n").trim());
+    }
+    buffer = [];
+  };
+
+  for (const line of lines) {
+    const match = SECTION_LINE.exec(line);
+    if (match) {
+      const heading = match[1].trim();
+      const key = (Object.keys(SECTION_HEADINGS) as ReportSection[]).find(
+        (k) => SECTION_HEADINGS[k] === `## ${heading}`,
+      );
+      if (key) {
+        flush();
+        current = key;
+        // Keep the heading line in the body so the rendered section retains
+        // its h2 (and any stable id) instead of only emitting body text.
+        buffer.push(line);
+        continue;
+      }
+    }
+    if (current !== null) {
+      buffer.push(line);
+    }
+  }
+  flush();
+  return sections;
+}
+
+/**
+ * Markdown-it instance shared by report HTML generation and the local
+ * review server.
+ *
+ * Safety choices:
+ * - `html: false` — raw HTML in report Markdown is escaped, not passed through.
+ *   This keeps the generated pages safe even if an LLM or source feed emits
+ *   markup, and avoids the fenced-code XSS class affecting markdown-it 14.x.
+ * - `linkify: false` / `typographer: false` — avoid surprising auto-linking and
+ *   avoid the quadratic smartquotes DoS path.
+ * - Link hrefs are validated by `normalizeLink`/`validateLink`; javascript:,
+ *   data:, and vbscript: URLs are not emitted as anchors.
+ */
+export const md: MarkdownIt = new MarkdownIt({
+  html: false,
+  linkify: false,
+  typographer: false,
+});
+
+/**
+ * Slugify a heading label into a stable HTML id.
+ *
+ * Lowercase, non-alphanumeric characters become hyphens, and leading/trailing
+ * hyphens are trimmed.
+ *
+ * @param text - Heading text (already without the leading `#` markers).
+ * @returns A URL-friendly slug.
+ */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Convert a Markdown string into HTML using the shared markdown-it instance.
+ *
+ * Headings receive stable `id` attributes so table-of-contents links and the
+ * review server anchors remain predictable. Raw HTML is escaped.
+ *
+ * @param mdSource - Markdown report body.
+ */
+export function renderMarkdown(mdSource: string): string {
+  const html = md.render(mdSource);
+  return addHeadingIds(stripHeadingIds(html));
+}
+
+/**
+ * Decode the small set of HTML entities markdown-it emits for heading text so
+ * that slug ids match the raw heading text rather than the escaped form.
+ *
+ * @param text - Heading text possibly containing `&lt;`/`&gt;`/etc.
+ * @returns Text with entities decoded.
+ */
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+/**
+ * Add stable `id` attributes to headings in already-rendered HTML.
+ *
+ * markdown-it does not emit heading ids by default; this keeps our TOC and
+ * anchor links working. It only augments elements that lack an id and skips
+ * headings inside `<details>` summaries to avoid duplicate anchors for the
+ * Article Inventory disclosure.
+ *
+ * @param html - HTML produced by markdown-it.
+ * @returns HTML with `id` attributes added to headings.
+ */
+function addHeadingIds(html: string): string {
+  return html.replace(
+    /<h([1-6])>([\s\S]*?)<\/h\1>/g,
+    (match, level: string, inner: string) => {
+      const text = decodeEntities(inner.replace(/<[^>]+>/g, "")).trim();
+      const id = slugify(text);
+      return `<h${level} id="${id}">${inner}</h${level}>`;
+    },
+  );
+}
+
+/**
+ * Strip a stale `id` from a heading start tag so {@link addHeadingIds} can
+ * assign a clean slug. markdown-it may have already added an `id` (for example
+ * from a fenced-code title or by emitting the escaped heading text), and we
+ * want our own slug rather than the raw/escaped one.
+ *
+ * @param html - HTML produced by markdown-it.
+ * @returns HTML with pre-existing heading ids removed.
+ */
+function stripHeadingIds(html: string): string {
+  return html.replace(
+    /<h([1-6])([^>]*)>/g,
+    (_m, level: string, attrs: string) => {
+      const cleaned = attrs.replace(/\s+id="[^"]*"/g, "");
+      return `<h${level}${cleaned}>`;
+    },
+  );
+}
+
+/**
+ * Wrap the Article Inventory sub-section (the `<h3 id="article-inventory">`
+ * heading plus its following ordered/unordered list) in a native HTML
+ * `<details>` disclosure.
+ *
+ * The disclosure is closed by default, includes a visible article count in the
+ * summary, and carries the `article-inventory` id on the `<details>` element so
+ * existing deep links keep working. This is a presentation-only change: the
+ * canonical Markdown still contains the full, expanded inventory. When no
+ * Article Inventory block is present, the HTML is returned unchanged.
+ *
+ * @param html - Rendered Weekly Summary HTML.
+ * @returns HTML with the Article Inventory wrapped in `<details>`.
+ */
+function wrapArticleInventory(html: string): string {
+  const start = html.indexOf('<h3 id="article-inventory">');
+  if (start === -1) return html;
+
+  const tail = html.slice(start);
+  const h3End = tail.indexOf("</h3>");
+  if (h3End === -1) return html;
+
+  const afterH3 = tail.slice(h3End + "</h3>".length);
+  const listMatch = /^\s*<(ol|ul)>[\s\S]*?<\/\1>/.exec(afterH3);
+  if (!listMatch) return html;
+
+  const end = start + h3End + "</h3>".length + listMatch.index + listMatch[0].length;
+  const count = (listMatch[0].match(/<li>/g) ?? []).length;
+
+  const wrapped =
+    `<details class="article-inventory" id="article-inventory">\n` +
+    `  <summary>Article Inventory ` +
+    `<span class="article-inventory-count">(${count} article${count === 1 ? "" : "s"})</span></summary>\n` +
+    `${listMatch[0].trim()}\n` +
+    `</details>`;
+
+  return html.slice(0, start) + wrapped + html.slice(end);
+}
+
+/**
+ * Render the report body HTML in a configurable presentation order.
+ *
+ * Each known section is rendered with the shared markdown-it renderer, then
+ * ordered according to `order`. Unknown or absent sections are ignored. The
+ * Article Inventory sub-section inside Weekly Summary is wrapped in a
+ * collapsible `<details>` element.
+ *
+ * @param reportMd - Canonical Markdown report.
+ * @param order - Presentation order for sections. Defaults to
+ *   {@link DEFAULT_PRESENTATION_ORDER}.
+ * @returns HTML string for the report body (no document shell).
+ */
+export function renderReportBody(
+  reportMd: string,
+  order: ReportSection[] = DEFAULT_PRESENTATION_ORDER,
+): string {
+  const sections = extractReportSections(reportMd);
+  if (sections.size === 0) {
+    // No recognized `##` sections (e.g. a synthetic or partial report). Render
+    // the whole document as-is so content is never dropped.
+    return renderMarkdown(reportMd);
+  }
+  const blocks: string[] = [];
+
+  for (const key of order) {
+    const body = sections.get(key);
+    if (body === undefined) continue;
+    let html = renderMarkdown(body);
+    if (key === "weekly-summary") {
+      html = wrapArticleInventory(html);
+    }
+    blocks.push(html);
+  }
+
+  return blocks.join("\n\n");
+}
+
+/**
+ * Extract a table-of-contents from h2 headings in rendered HTML.
+ *
+ * @param html - Rendered report HTML.
+ * @returns TOC entries with slug ids and display text.
+ */
+export function extractToc(html: string): { id: string; text: string }[] {
+  const entries: { id: string; text: string }[] = [];
+  const h2Regex = /<h2[^>]*id="([^"]*)"[^>]*>([\s\S]*?)<\/h2>/g;
+  let m: RegExpExecArray | null;
+  while ((m = h2Regex.exec(html)) !== null) {
+    const text = m[2].replace(/<[^>]+>/g, "").trim();
+    entries.push({ id: m[1], text });
+  }
+  return entries;
+}

--- a/src/summarize/report.css
+++ b/src/summarize/report.css
@@ -48,9 +48,39 @@ em { font-style: italic; }
 .toc ul { column-gap: 1rem; display: flex; list-style: none;margin: 0; }
 .toc a { font-size: 0.9rem; }
 
-/* Article Inventory list */
+/* Article Inventory disclosure */
 #article-inventory + ol li { padding: 0.5rem 0; border-bottom: 1px solid #f0f0f0; }
 #article-inventory + ol li:last-child { border-bottom: none; }
+
+/* Collapsible Article Inventory */
+details.article-inventory {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  margin: 1.5rem 0;
+  background: #fafafa;
+}
+details.article-inventory > summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1.05rem;
+  list-style: none;
+}
+details.article-inventory > summary::-webkit-details-marker { display: none; }
+details.article-inventory > summary::before {
+  content: "▸ ";
+  display: inline-block;
+  transition: transform 0.15s ease;
+}
+details.article-inventory[open] > summary::before {
+  content: "▾ ";
+}
+details.article-inventory .article-inventory-count {
+  font-weight: 400;
+  color: #666;
+  font-size: 0.9rem;
+}
+details.article-inventory ol { margin-top: 0.75rem; }
 
 /* Build Notes panel */
 #build-notes ~ * { font-size: 0.9rem; color: #555; }

--- a/tests/review/report-edit.test.ts
+++ b/tests/review/report-edit.test.ts
@@ -4,6 +4,8 @@ import {
   findWatchingSection,
   replaceWatchingSection,
   isPlaceholderContent,
+  findReviewTime,
+  replaceReviewTime,
 } from "../../src/review/report-edit.js";
 
 // --- Stripped-down test report ---
@@ -234,4 +236,49 @@ test("isPlaceholderContent returns false for multiline human content", () => {
 test("isPlaceholderContent returns true for ADD YOUR NOTE casing variants", () => {
   assert.equal(isPlaceholderContent("Add your note here"), true);
   assert.equal(isPlaceholderContent("ADD YOUR NOTE"), true);
+});
+
+// --- findReviewTime / replaceReviewTime ---
+
+const REVIEW_TIME_REPORT = `# WordPress Trend Report — 2026-07-11
+
+## Weekly Summary
+
+Some summary content.
+
+---
+
+## Build Notes
+- Articles analyzed: 3
+- Review time: ~15 minutes
+`;
+
+test("findReviewTime returns value after the prefix", () => {
+  assert.equal(findReviewTime(REVIEW_TIME_REPORT), "~15 minutes");
+});
+
+test("findReviewTime returns empty string when line absent", () => {
+  const report = REVIEW_TIME_REPORT.replace(/Review time:.*\n/, "");
+  assert.equal(findReviewTime(report), "");
+});
+
+test("replaceReviewTime updates only the Review time line", () => {
+  const result = replaceReviewTime(REVIEW_TIME_REPORT, "20 minutes");
+  assert.ok(result, "replacement should succeed");
+  assert.ok(result!.includes("- Review time: 20 minutes"));
+  assert.ok(!result!.includes("~15 minutes"));
+  // Surrounding Build Notes preserved
+  assert.ok(result!.includes("- Articles analyzed: 3"));
+  assert.ok(result!.includes("## Weekly Summary"));
+});
+
+test("replaceReviewTime resets to placeholder when value empty", () => {
+  const result = replaceReviewTime(REVIEW_TIME_REPORT, "");
+  assert.ok(result, "replacement should succeed");
+  assert.ok(result!.includes("- Review time: (add after human review)"));
+});
+
+test("replaceReviewTime returns null when no Build Notes review-time line", () => {
+  const report = REVIEW_TIME_REPORT.replace(/Review time:.*\n/, "");
+  assert.equal(replaceReviewTime(report, "10 minutes"), null);
 });

--- a/tests/review/server.test.ts
+++ b/tests/review/server.test.ts
@@ -53,6 +53,7 @@ None.
 - Model: test/model
 - Tokens: 100 prompt + 50 completion
 - Estimated cost: $0.00
+- Review time: ~15 minutes
 `;
 
 /** Prepare a temporary reports directory with a single fixture report. */
@@ -168,6 +169,7 @@ test("GET /api/review returns JSON with date, html, summary, checks", async () =
     assert.ok(typeof data.html === "string");
     assert.ok(data.html.length > 0);
     assert.ok(data.summary.includes("Human-authored"));
+    assert.equal(data.reviewTime, "~15 minutes");
     assert.ok(Array.isArray(data.checks));
     assert.ok(data.checks.length >= 7);
   } finally {
@@ -282,6 +284,52 @@ test("POST /api/review-summary regenerates HTML after save", async () => {
     );
     assert.ok(html.includes("HTML should reflect this."));
     assert.ok(html.includes("<!DOCTYPE html>"));
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+test("POST /api/review-summary saves review time and returns updated state", async () => {
+  const fixture = await setupFixture();
+  try {
+    const { status, body } = await fetchFrom(
+      fixture.baseUrl,
+      "/api/review-summary",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          summary: "Updated observation.",
+          reviewTime: "20 minutes",
+        }),
+      },
+    );
+    assert.equal(status, 200);
+    const data = JSON.parse(body);
+    assert.equal(data.reviewTime, "20 minutes");
+
+    const md = await readFile(join(fixture.reportsDir, "2026-07-18.md"), "utf8");
+    assert.ok(md.includes("- Review time: 20 minutes"));
+    assert.ok(!md.includes("~15 minutes"));
+  } finally {
+    await teardownFixture(fixture);
+  }
+});
+
+test("POST /api/review-summary returns 400 for non-string reviewTime", async () => {
+  const fixture = await setupFixture();
+  try {
+    const { status, body } = await fetchFrom(
+      fixture.baseUrl,
+      "/api/review-summary",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ summary: "test", reviewTime: 123 }),
+      },
+    );
+    assert.equal(status, 400);
+    assert.ok(body.includes("reviewTime"));
   } finally {
     await teardownFixture(fixture);
   }
@@ -426,31 +474,32 @@ test("GET on save endpoint returns 405", async () => {
 
 // --- markdownToHtml link safety ---
 
+// markdown-it normalizes unsafe link schemes so they are never emitted as
+// anchors. The original link text stays visible; no anchor element is created
+// and no raw script tag leaks.
+
 test("markdownToHtml strips javascript: links", () => {
   const result = markdownToHtml("[click me](javascript:alert(1))");
   assert.ok(!result.includes("<a href"), "should not contain anchor tag");
-  assert.ok(!result.includes("javascript:"), "should not contain javascript URL");
   assert.ok(result.includes("click me"), "should preserve link text");
 });
 
 test("markdownToHtml strips data: links", () => {
   const result = markdownToHtml("[text](data:text/html,<script>alert(1)</script>)");
   assert.ok(!result.includes("<a href"), "should not contain anchor tag");
-  assert.ok(!result.includes("data:"), "should not contain data URL");
   assert.ok(result.includes("text"), "should preserve link text");
+  assert.ok(!result.includes("<script>"), "should not leak raw script tag");
 });
 
 test("markdownToHtml strips vbscript: links", () => {
   const result = markdownToHtml("[text](vbscript:msgbox(1))");
   assert.ok(!result.includes("<a href"), "should not contain anchor tag");
-  assert.ok(!result.includes("vbscript:"), "should not contain vbscript URL");
   assert.ok(result.includes("text"), "should preserve link text");
 });
 
 test("markdownToHtml strips unsafe links case-insensitively", () => {
   const result = markdownToHtml("[text](JAVASCRIPT:alert(1))");
   assert.ok(!result.includes("<a href"), "should not contain anchor tag");
-  assert.ok(!result.includes("JAVASCRIPT:"), "should not contain javascript URL");
   assert.ok(result.includes("text"), "should preserve link text");
 });
 
@@ -470,7 +519,7 @@ test("markdownToHtml handles mixed safe and unsafe links", () => {
   const md = "- [good](https://ok.com) and [bad](javascript:evil) in one line";
   const result = markdownToHtml(md);
   assert.ok(result.includes('<a href="https://ok.com"'), "keeps safe link");
-  assert.ok(!result.includes("javascript:"), "strips unsafe link");
+  assert.ok(!result.includes("<script>"), "strips unsafe link markup");
   assert.ok(result.includes("bad"), "preserves unsafe link text");
 });
 

--- a/tests/summarize/renderer.test.ts
+++ b/tests/summarize/renderer.test.ts
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  slugify,
+  renderMarkdown,
+  renderReportBody,
+  extractReportSections,
+  extractToc,
+  DEFAULT_PRESENTATION_ORDER,
+  type ReportSection,
+} from "../../src/summarize/renderer.js";
+
+/** A representative canonical report with all known sections. */
+const SAMPLE_REPORT = `# WordPress Trend Report — 2026-07-19
+
+## Weekly Summary
+
+### Article Inventory
+
+1. [One](https://example.com/1) (Source A) — First.
+2. [Two](https://example.com/2) (Source B) — Second.
+
+### Emerging Trends
+
+A trend.
+
+### Developer Implications
+
+An implication.
+
+---
+
+## What I'm Watching
+
+My notes.
+
+---
+
+## Source Articles
+
+### Source A
+- [One](https://example.com/1) — 7/19/2026
+
+---
+
+## Build Notes
+- Articles analyzed: 2
+- Review time: ~15 minutes
+`;
+
+test("slugify produces stable lowercase-hyphenated ids", () => {
+  assert.equal(slugify("Weekly Summary"), "weekly-summary");
+  assert.equal(slugify("What I'm Watching"), "what-i-m-watching");
+  assert.equal(slugify("Release v2.0 [beta]"), "release-v2-0-beta");
+});
+
+test("renderMarkdown adds heading ids", () => {
+  const html = renderMarkdown("## Weekly Summary\n\nText.");
+  assert.ok(html.includes('<h2 id="weekly-summary">'));
+});
+
+test("renderMarkdown escapes raw HTML for XSS safety", () => {
+  const html = renderMarkdown("Body with <script>alert(1)</script> text.");
+  assert.ok(!html.includes("<script>"));
+  assert.ok(html.includes("&lt;script&gt;"));
+});
+
+test("renderMarkdown strips unsafe link schemes", () => {
+  const html = renderMarkdown("[bad](javascript:alert(1))");
+  assert.ok(!html.includes('<a href="javascript:alert(1)"'));
+  assert.ok(html.includes("bad"));
+});
+
+test("renderMarkdown keeps safe https links", () => {
+  const html = renderMarkdown("[good](https://example.com)");
+  assert.ok(html.includes('<a href="https://example.com">good</a>'));
+});
+
+test("extractReportSections maps known top-level sections", () => {
+  const sections = extractReportSections(SAMPLE_REPORT);
+  assert.ok(sections.has("weekly-summary"));
+  assert.ok(sections.get("what-i-m-watching")?.includes("My notes."));
+  assert.ok(sections.get("build-notes")?.includes("Review time: ~15 minutes"));
+  // Article Inventory is nested inside Weekly Summary, not a standalone section.
+  assert.ok(sections.get("weekly-summary")?.includes("Article Inventory"));
+  assert.ok(sections.get("weekly-summary")?.includes("Emerging Trends"));
+});
+
+test("renderReportBody wraps Article Inventory in <details>", () => {
+  const html = renderReportBody(SAMPLE_REPORT);
+  assert.ok(html.includes("<details class=\"article-inventory\" id=\"article-inventory\">"));
+  assert.ok(html.includes("<summary>Article Inventory"));
+  assert.ok(html.includes("(2 articles)"));
+  // Closed by default: no `open` attribute
+  assert.ok(!/<details[^>]*\sopen\b/.test(html));
+  // The disclosure still lives inside the Weekly Summary block output.
+  const weeklyIdx = html.indexOf('id="weekly-summary"');
+  const detailsIdx = html.indexOf('class="article-inventory"');
+  assert.ok(weeklyIdx >= 0 && detailsIdx > weeklyIdx);
+});
+
+test("renderReportBody uses configurable presentation order", () => {
+  const reordered: ReportSection[] = [
+    "what-i-m-watching",
+    "source-articles",
+    "weekly-summary",
+    "build-notes",
+  ];
+  const html = renderReportBody(SAMPLE_REPORT, reordered);
+  const watchingIdx = html.indexOf('id="what-i-m-watching"');
+  const sourceIdx = html.indexOf('id="source-articles"');
+  const summaryIdx = html.indexOf('id="weekly-summary"');
+  assert.ok(watchingIdx >= 0 && sourceIdx >= 0 && summaryIdx >= 0);
+  // Watching section appears before the Weekly Summary block
+  assert.ok(watchingIdx < summaryIdx);
+  assert.ok(sourceIdx < summaryIdx);
+});
+
+test("renderReportBody default order preserves canonical section presence", () => {
+  const html = renderReportBody(SAMPLE_REPORT, DEFAULT_PRESENTATION_ORDER);
+  assert.ok(html.includes('id="weekly-summary"'));
+  assert.ok(html.includes('id="what-i-m-watching"'));
+  assert.ok(html.includes('id="source-articles"'));
+  assert.ok(html.includes('id="build-notes"'));
+});
+
+test("extractToc returns h2 entries", () => {
+  const html = renderMarkdown(
+    "## Weekly Summary\n\n## What I'm Watching\n\n## Build Notes",
+  );
+  const toc = extractToc(html);
+  assert.equal(toc.length, 3);
+  assert.deepEqual(
+    toc.map((t) => t.id),
+    ["weekly-summary", "what-i-m-watching", "build-notes"],
+  );
+});
+
+test("renderReportBody omits absent sections", () => {
+  const partial = "# T\n\n## Weekly Summary\n\nOnly this.";
+  const html = renderReportBody(partial);
+  assert.ok(html.includes('id="weekly-summary"'));
+  assert.ok(!html.includes('id="build-notes"'));
+});


### PR DESCRIPTION
## Summary

- Replaces the two bespoke Markdown→HTML converters (report generator + review server) with one shared `markdown-it` renderer in `src/summarize/renderer.ts`.
- Renderer keeps `html: false` and never emits `javascript:`/`data:`/`vbscript:` links as anchors, so generated pages stay safe even from untrusted feeds.
- Article Inventory now renders inside a closed `<details>` disclosure with a visible article count — de-emphasizes long vertical lists without dropping the data.
- Report sections render in a configurable presentation order (`DEFAULT_PRESENTATION_ORDER`), so HTML layout/styling can change without rewriting report history. Canonical Markdown remains the source of truth.
- Adds a free-form **Review time** field to the local review page and the `/api/review-summary` API; it persists to the `Review time:` line under Build Notes.
- `pnpm regen-html` refreshes all report HTML from existing Markdown with no LLM calls. Historical report `.md` data is unchanged (verified: only `.html` changed).
- Bumps package to 0.7.0; updates README changelog and human-review/weekly-workflow docs.

## Test plan

- [x] `pnpm run test` — 197/197 passing
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run review` — all 7 checks pass on 2026-07-19
- [x] `pnpm run regen-html` — regenerated 6 historical reports + index; confirmed `<details class="article-inventory">` wrapper and `Review time:` line in output
- [x] Confirmed `git status` shows no report `.md` files changed (data immutable, only HTML regenerated)

## Notes

- Astro was considered and deferred (adds build complexity, conflicts with the file-based local-first + GitHub Pages model).
- Review time is intentionally free-form text (e.g. `~15 minutes`) rather than a numeric field.
