### PR TITLE
feat(reports): add selectable report themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Individual commands remain available for diagnosis and recovery — for example,
 
 `pnpm summarize` produces an HTML report alongside the Markdown file and writes shared report styles to `reports/assets/report.css`. The Radio Canada variable font is copied to `reports/assets/` alongside it. Reports are deployed to [GitHub Pages](https://colorful-tones.github.io/wp-trend-watcher/) on every push to `main` via the `pages.yml` workflow. Configure GitHub Pages to deploy from the `github-pages` environment (Settings → Pages → Source: GitHub Actions).
 
+Generated report pages include Style and Mode controls for Aurora Blueprint, Aurora Mesh, and Signal Stripe, with Light, Dark, and System modes. The selected preferences are saved in the browser's local storage and reused across the report index and individual reports.
+
 See [Summarization](docs/summarization.md) for provider configuration, model options, and synthesis strategy.
 
 ## Project Principles
@@ -78,6 +80,7 @@ See:
 - [Sources](docs/sources.md)
 - [Summarization](docs/summarization.md)
 - [Human Review](docs/human-review.md)
+- [Report Themes](docs/report-themes.md)
 - [Cost Notes](docs/cost-notes.md)
 - [Contributing](CONTRIBUTING.md)
 
@@ -90,6 +93,11 @@ Want to suggest a new RSS source? [Open a source suggestion issue](https://githu
 Both templates walk you through what's needed — takes about a minute.
 
 ## Changelog
+
+### 0.8.0
+
+- Added GitHub project links to the report index and individual report footers.
+- Added persistent report style and color-mode controls with accessible light and dark variants for all three visual directions.
 
 ### 0.7.0
 

--- a/docs/report-themes.md
+++ b/docs/report-themes.md
@@ -1,0 +1,119 @@
+# Report Themes
+
+Generated report pages support selectable visual themes and color modes. The theme is applied to both the report index and individual reports, and the selected values are saved in `localStorage`.
+
+The current theme system is defined in:
+
+- `src/summarize/html.ts` — theme names, selector options, and the small pre-paint persistence script.
+- `src/summarize/report.css` — theme tokens and visual styles.
+- `reports/` — generated HTML and copied CSS. Do not edit these files directly; regenerate them instead.
+
+## Add a theme
+
+Use a short lowercase identifier for the stored value. For example, a theme named `forest` uses the value `forest` everywhere.
+
+### 1. Add the option in the generated controls
+
+In `src/summarize/html.ts`, add an option to `REPORT_THEME_CONTROLS`:
+
+```html
+<option value="forest">Forest</option>
+```
+
+### 2. Add the identifier to the persistence allow-list
+
+In `REPORT_THEME_SCRIPT`, add the same identifier to the `themes` array:
+
+```js
+var themes = ["aurora-blueprint", "aurora", "signal", "forest"];
+```
+
+The allow-list is intentional: values loaded from `localStorage` must be known themes before they are applied to the document.
+
+### 3. Define the light-mode tokens
+
+Add a selector to `src/summarize/report.css`:
+
+```css
+:root[data-theme="forest"] {
+  --accent: #176b4d;
+  --theme-gradient: radial-gradient(
+    circle at 12% 0%,
+    rgba(110, 231, 183, 0.24),
+    transparent 42%
+  );
+  --theme-grid-x: none;
+  --theme-grid-y: none;
+}
+```
+
+Themes inherit the base light-mode surface, text, border, and muted colors unless they override those variables. The main theme-specific variables are:
+
+- `--accent` — links, card borders, labels, and focus outlines.
+- `--theme-gradient` — the broad background effect.
+- `--theme-grid-x` and `--theme-grid-y` — optional repeating grid layers.
+
+Keep the effect subtle enough that report content remains the visual priority.
+
+### 4. Define the dark-mode tokens
+
+Add a dark selector with a readable accent and a darker gradient:
+
+```css
+:root[data-theme="forest"][data-mode="dark"] {
+  --accent: #75e0b0;
+  --theme-gradient: radial-gradient(
+    circle at 12% 0%,
+    rgba(16, 128, 88, 0.28),
+    transparent 42%
+  );
+}
+```
+
+### 5. Define the System-mode dark variant
+
+`system` follows the user's operating-system preference through the existing `@media (prefers-color-scheme: dark)` block. Add the matching selector there too:
+
+```css
+:root[data-theme="forest"][data-mode="system"] {
+  --accent: #75e0b0;
+  --theme-gradient: radial-gradient(
+    circle at 12% 0%,
+    rgba(16, 128, 88, 0.28),
+    transparent 42%
+  );
+}
+```
+
+Without this selector, the new theme will fall back to its light-mode appearance when Mode is set to System and the user's system is dark.
+
+## Regenerate and verify
+
+From the repository root:
+
+```bash
+pnpm run regen-html
+pnpm run test
+pnpm run typecheck
+git diff --check
+```
+
+`regen-html` updates every report page and `reports/index.html`, and copies the shared stylesheet to `reports/assets/report.css`. Confirm the new option appears on both the index and an individual report.
+
+For a quick browser check, serve the generated reports locally:
+
+```bash
+pnpm watch
+```
+
+Then open <http://127.0.0.1:3000/index.html> and check the new theme in Light, Dark, and System modes. Stop the watcher with `Ctrl-C` when finished.
+
+## Accessibility checklist
+
+Before keeping a new theme:
+
+- Check body text and muted text against both light and dark surfaces.
+- Check links, card labels, and focus outlines against their backgrounds.
+- Keep the gradient and pattern low-contrast so it does not compete with report content.
+- Test narrow screens; the controls stack on viewports below 560px.
+- Preserve the existing `data-theme` and `data-mode` attribute pattern so persistence and no-flash initialization continue to work.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,

--- a/reports/2026-06-12.html
+++ b/reports/2026-06-12.html
@@ -5,6 +5,74 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>WordPress Trend Report — 2026-06-12</title>
   <link rel="stylesheet" href="assets/report.css">
+  <script>
+(function () {
+  var root = document.documentElement;
+  var themeKey = "wp-trend-watcher-theme";
+  var modeKey = "wp-trend-watcher-mode";
+  var themes = ["aurora-blueprint", "aurora", "signal"];
+  var modes = ["system", "light", "dark"];
+
+  function read(key, allowed, fallback) {
+    try {
+      var value = window.localStorage.getItem(key);
+      return allowed.indexOf(value) >= 0 ? value : fallback;
+    } catch (_error) {
+      return fallback;
+    }
+  }
+
+  function persist(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (_error) {
+      // Continue without persistence when storage is unavailable.
+    }
+  }
+
+  function apply(theme, mode, save) {
+    root.dataset.theme = theme;
+    root.dataset.mode = mode;
+    if (save) {
+      persist(themeKey, theme);
+      persist(modeKey, mode);
+    }
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.value = theme;
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.value = mode;
+    });
+  }
+
+  apply(
+    read(themeKey, themes, "aurora-blueprint"),
+    read(modeKey, modes, "system"),
+    false,
+  );
+
+  var controlsBound = false;
+  function bindControls() {
+    if (controlsBound) return;
+    controlsBound = true;
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(event.target.value, root.dataset.mode || "system", true);
+      });
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(root.dataset.theme || "aurora-blueprint", event.target.value, true);
+      });
+    });
+    apply(root.dataset.theme || "aurora-blueprint", root.dataset.mode || "system", false);
+  }
+
+  document.addEventListener("DOMContentLoaded", bindControls);
+  window.addEventListener("load", bindControls);
+  if (document.readyState !== "loading") bindControls();
+})();
+</script>
   <meta name="description" content="Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-06-12.html">
   <meta property="og:type" content="article">
@@ -23,6 +91,24 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-06-12"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-06-12</h1>
 </header>
+  <div class="theme-controls" aria-label="Report display settings">
+  <label>
+    <span>Style</span>
+    <select data-theme-control="theme" aria-label="Report visual style">
+      <option value="aurora-blueprint">Aurora Blueprint</option>
+      <option value="aurora">Aurora Mesh</option>
+      <option value="signal">Signal Stripe</option>
+    </select>
+  </label>
+  <label>
+    <span>Mode</span>
+    <select data-theme-control="mode" aria-label="Report color mode">
+      <option value="system">System</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </label>
+</div>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>
@@ -77,6 +163,8 @@
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>
+    <span class="nav-footer-separator">·</span>
+    <a class="repo-link" href="https://github.com/colorful-tones/wp-trend-watcher">View on GitHub ↗</a>
   </footer>
 </body>
 </html>

--- a/reports/2026-06-21.html
+++ b/reports/2026-06-21.html
@@ -5,6 +5,74 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>WordPress Trend Report — 2026-06-21</title>
   <link rel="stylesheet" href="assets/report.css">
+  <script>
+(function () {
+  var root = document.documentElement;
+  var themeKey = "wp-trend-watcher-theme";
+  var modeKey = "wp-trend-watcher-mode";
+  var themes = ["aurora-blueprint", "aurora", "signal"];
+  var modes = ["system", "light", "dark"];
+
+  function read(key, allowed, fallback) {
+    try {
+      var value = window.localStorage.getItem(key);
+      return allowed.indexOf(value) >= 0 ? value : fallback;
+    } catch (_error) {
+      return fallback;
+    }
+  }
+
+  function persist(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (_error) {
+      // Continue without persistence when storage is unavailable.
+    }
+  }
+
+  function apply(theme, mode, save) {
+    root.dataset.theme = theme;
+    root.dataset.mode = mode;
+    if (save) {
+      persist(themeKey, theme);
+      persist(modeKey, mode);
+    }
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.value = theme;
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.value = mode;
+    });
+  }
+
+  apply(
+    read(themeKey, themes, "aurora-blueprint"),
+    read(modeKey, modes, "system"),
+    false,
+  );
+
+  var controlsBound = false;
+  function bindControls() {
+    if (controlsBound) return;
+    controlsBound = true;
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(event.target.value, root.dataset.mode || "system", true);
+      });
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(root.dataset.theme || "aurora-blueprint", event.target.value, true);
+      });
+    });
+    apply(root.dataset.theme || "aurora-blueprint", root.dataset.mode || "system", false);
+  }
+
+  document.addEventListener("DOMContentLoaded", bindControls);
+  window.addEventListener("load", bindControls);
+  if (document.readyState !== "loading") bindControls();
+})();
+</script>
   <meta name="description" content="Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-06-21.html">
   <meta property="og:type" content="article">
@@ -23,6 +91,24 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-06-21"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-06-21</h1>
 </header>
+  <div class="theme-controls" aria-label="Report display settings">
+  <label>
+    <span>Style</span>
+    <select data-theme-control="theme" aria-label="Report visual style">
+      <option value="aurora-blueprint">Aurora Blueprint</option>
+      <option value="aurora">Aurora Mesh</option>
+      <option value="signal">Signal Stripe</option>
+    </select>
+  </label>
+  <label>
+    <span>Mode</span>
+    <select data-theme-control="mode" aria-label="Report color mode">
+      <option value="system">System</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </label>
+</div>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>
@@ -137,6 +223,8 @@
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>
+    <span class="nav-footer-separator">·</span>
+    <a class="repo-link" href="https://github.com/colorful-tones/wp-trend-watcher">View on GitHub ↗</a>
   </footer>
 </body>
 </html>

--- a/reports/2026-06-27.html
+++ b/reports/2026-06-27.html
@@ -5,6 +5,74 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>WordPress Trend Report — 2026-06-27</title>
   <link rel="stylesheet" href="assets/report.css">
+  <script>
+(function () {
+  var root = document.documentElement;
+  var themeKey = "wp-trend-watcher-theme";
+  var modeKey = "wp-trend-watcher-mode";
+  var themes = ["aurora-blueprint", "aurora", "signal"];
+  var modes = ["system", "light", "dark"];
+
+  function read(key, allowed, fallback) {
+    try {
+      var value = window.localStorage.getItem(key);
+      return allowed.indexOf(value) >= 0 ? value : fallback;
+    } catch (_error) {
+      return fallback;
+    }
+  }
+
+  function persist(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (_error) {
+      // Continue without persistence when storage is unavailable.
+    }
+  }
+
+  function apply(theme, mode, save) {
+    root.dataset.theme = theme;
+    root.dataset.mode = mode;
+    if (save) {
+      persist(themeKey, theme);
+      persist(modeKey, mode);
+    }
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.value = theme;
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.value = mode;
+    });
+  }
+
+  apply(
+    read(themeKey, themes, "aurora-blueprint"),
+    read(modeKey, modes, "system"),
+    false,
+  );
+
+  var controlsBound = false;
+  function bindControls() {
+    if (controlsBound) return;
+    controlsBound = true;
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(event.target.value, root.dataset.mode || "system", true);
+      });
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(root.dataset.theme || "aurora-blueprint", event.target.value, true);
+      });
+    });
+    apply(root.dataset.theme || "aurora-blueprint", root.dataset.mode || "system", false);
+  }
+
+  document.addEventListener("DOMContentLoaded", bindControls);
+  window.addEventListener("load", bindControls);
+  if (document.readyState !== "loading") bindControls();
+})();
+</script>
   <meta name="description" content="Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-06-27.html">
   <meta property="og:type" content="article">
@@ -23,6 +91,24 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-06-27"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-06-27</h1>
 </header>
+  <div class="theme-controls" aria-label="Report display settings">
+  <label>
+    <span>Style</span>
+    <select data-theme-control="theme" aria-label="Report visual style">
+      <option value="aurora-blueprint">Aurora Blueprint</option>
+      <option value="aurora">Aurora Mesh</option>
+      <option value="signal">Signal Stripe</option>
+    </select>
+  </label>
+  <label>
+    <span>Mode</span>
+    <select data-theme-control="mode" aria-label="Report color mode">
+      <option value="system">System</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </label>
+</div>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>
@@ -113,6 +199,8 @@
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>
+    <span class="nav-footer-separator">·</span>
+    <a class="repo-link" href="https://github.com/colorful-tones/wp-trend-watcher">View on GitHub ↗</a>
   </footer>
 </body>
 </html>

--- a/reports/2026-07-05.html
+++ b/reports/2026-07-05.html
@@ -5,6 +5,74 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>WordPress Trend Report — 2026-07-05</title>
   <link rel="stylesheet" href="assets/report.css">
+  <script>
+(function () {
+  var root = document.documentElement;
+  var themeKey = "wp-trend-watcher-theme";
+  var modeKey = "wp-trend-watcher-mode";
+  var themes = ["aurora-blueprint", "aurora", "signal"];
+  var modes = ["system", "light", "dark"];
+
+  function read(key, allowed, fallback) {
+    try {
+      var value = window.localStorage.getItem(key);
+      return allowed.indexOf(value) >= 0 ? value : fallback;
+    } catch (_error) {
+      return fallback;
+    }
+  }
+
+  function persist(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (_error) {
+      // Continue without persistence when storage is unavailable.
+    }
+  }
+
+  function apply(theme, mode, save) {
+    root.dataset.theme = theme;
+    root.dataset.mode = mode;
+    if (save) {
+      persist(themeKey, theme);
+      persist(modeKey, mode);
+    }
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.value = theme;
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.value = mode;
+    });
+  }
+
+  apply(
+    read(themeKey, themes, "aurora-blueprint"),
+    read(modeKey, modes, "system"),
+    false,
+  );
+
+  var controlsBound = false;
+  function bindControls() {
+    if (controlsBound) return;
+    controlsBound = true;
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(event.target.value, root.dataset.mode || "system", true);
+      });
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(root.dataset.theme || "aurora-blueprint", event.target.value, true);
+      });
+    });
+    apply(root.dataset.theme || "aurora-blueprint", root.dataset.mode || "system", false);
+  }
+
+  document.addEventListener("DOMContentLoaded", bindControls);
+  window.addEventListener("load", bindControls);
+  if (document.readyState !== "loading") bindControls();
+})();
+</script>
   <meta name="description" content="Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-07-05.html">
   <meta property="og:type" content="article">
@@ -23,6 +91,24 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-05"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-05</h1>
 </header>
+  <div class="theme-controls" aria-label="Report display settings">
+  <label>
+    <span>Style</span>
+    <select data-theme-control="theme" aria-label="Report visual style">
+      <option value="aurora-blueprint">Aurora Blueprint</option>
+      <option value="aurora">Aurora Mesh</option>
+      <option value="signal">Signal Stripe</option>
+    </select>
+  </label>
+  <label>
+    <span>Mode</span>
+    <select data-theme-control="mode" aria-label="Report color mode">
+      <option value="system">System</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </label>
+</div>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>
@@ -144,6 +230,8 @@
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>
+    <span class="nav-footer-separator">·</span>
+    <a class="repo-link" href="https://github.com/colorful-tones/wp-trend-watcher">View on GitHub ↗</a>
   </footer>
 </body>
 </html>

--- a/reports/2026-07-11.html
+++ b/reports/2026-07-11.html
@@ -5,6 +5,74 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>WordPress Trend Report — 2026-07-11</title>
   <link rel="stylesheet" href="assets/report.css">
+  <script>
+(function () {
+  var root = document.documentElement;
+  var themeKey = "wp-trend-watcher-theme";
+  var modeKey = "wp-trend-watcher-mode";
+  var themes = ["aurora-blueprint", "aurora", "signal"];
+  var modes = ["system", "light", "dark"];
+
+  function read(key, allowed, fallback) {
+    try {
+      var value = window.localStorage.getItem(key);
+      return allowed.indexOf(value) >= 0 ? value : fallback;
+    } catch (_error) {
+      return fallback;
+    }
+  }
+
+  function persist(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (_error) {
+      // Continue without persistence when storage is unavailable.
+    }
+  }
+
+  function apply(theme, mode, save) {
+    root.dataset.theme = theme;
+    root.dataset.mode = mode;
+    if (save) {
+      persist(themeKey, theme);
+      persist(modeKey, mode);
+    }
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.value = theme;
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.value = mode;
+    });
+  }
+
+  apply(
+    read(themeKey, themes, "aurora-blueprint"),
+    read(modeKey, modes, "system"),
+    false,
+  );
+
+  var controlsBound = false;
+  function bindControls() {
+    if (controlsBound) return;
+    controlsBound = true;
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(event.target.value, root.dataset.mode || "system", true);
+      });
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(root.dataset.theme || "aurora-blueprint", event.target.value, true);
+      });
+    });
+    apply(root.dataset.theme || "aurora-blueprint", root.dataset.mode || "system", false);
+  }
+
+  document.addEventListener("DOMContentLoaded", bindControls);
+  window.addEventListener("load", bindControls);
+  if (document.readyState !== "loading") bindControls();
+})();
+</script>
   <meta name="description" content="Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-07-11.html">
   <meta property="og:type" content="article">
@@ -23,6 +91,24 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-11"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-11</h1>
 </header>
+  <div class="theme-controls" aria-label="Report display settings">
+  <label>
+    <span>Style</span>
+    <select data-theme-control="theme" aria-label="Report visual style">
+      <option value="aurora-blueprint">Aurora Blueprint</option>
+      <option value="aurora">Aurora Mesh</option>
+      <option value="signal">Signal Stripe</option>
+    </select>
+  </label>
+  <label>
+    <span>Mode</span>
+    <select data-theme-control="mode" aria-label="Report color mode">
+      <option value="system">System</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </label>
+</div>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>
@@ -111,6 +197,8 @@
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>
+    <span class="nav-footer-separator">·</span>
+    <a class="repo-link" href="https://github.com/colorful-tones/wp-trend-watcher">View on GitHub ↗</a>
   </footer>
 </body>
 </html>

--- a/reports/2026-07-19.html
+++ b/reports/2026-07-19.html
@@ -5,6 +5,74 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>WordPress Trend Report — 2026-07-19</title>
   <link rel="stylesheet" href="assets/report.css">
+  <script>
+(function () {
+  var root = document.documentElement;
+  var themeKey = "wp-trend-watcher-theme";
+  var modeKey = "wp-trend-watcher-mode";
+  var themes = ["aurora-blueprint", "aurora", "signal"];
+  var modes = ["system", "light", "dark"];
+
+  function read(key, allowed, fallback) {
+    try {
+      var value = window.localStorage.getItem(key);
+      return allowed.indexOf(value) >= 0 ? value : fallback;
+    } catch (_error) {
+      return fallback;
+    }
+  }
+
+  function persist(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (_error) {
+      // Continue without persistence when storage is unavailable.
+    }
+  }
+
+  function apply(theme, mode, save) {
+    root.dataset.theme = theme;
+    root.dataset.mode = mode;
+    if (save) {
+      persist(themeKey, theme);
+      persist(modeKey, mode);
+    }
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.value = theme;
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.value = mode;
+    });
+  }
+
+  apply(
+    read(themeKey, themes, "aurora-blueprint"),
+    read(modeKey, modes, "system"),
+    false,
+  );
+
+  var controlsBound = false;
+  function bindControls() {
+    if (controlsBound) return;
+    controlsBound = true;
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(event.target.value, root.dataset.mode || "system", true);
+      });
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(root.dataset.theme || "aurora-blueprint", event.target.value, true);
+      });
+    });
+    apply(root.dataset.theme || "aurora-blueprint", root.dataset.mode || "system", false);
+  }
+
+  document.addEventListener("DOMContentLoaded", bindControls);
+  window.addEventListener("load", bindControls);
+  if (document.readyState !== "loading") bindControls();
+})();
+</script>
   <meta name="description" content="Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-07-19.html">
   <meta property="og:type" content="article">
@@ -23,6 +91,24 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-19"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-19</h1>
 </header>
+  <div class="theme-controls" aria-label="Report display settings">
+  <label>
+    <span>Style</span>
+    <select data-theme-control="theme" aria-label="Report visual style">
+      <option value="aurora-blueprint">Aurora Blueprint</option>
+      <option value="aurora">Aurora Mesh</option>
+      <option value="signal">Signal Stripe</option>
+    </select>
+  </label>
+  <label>
+    <span>Mode</span>
+    <select data-theme-control="mode" aria-label="Report color mode">
+      <option value="system">System</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </label>
+</div>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>
@@ -125,6 +211,8 @@
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>
+    <span class="nav-footer-separator">·</span>
+    <a class="repo-link" href="https://github.com/colorful-tones/wp-trend-watcher">View on GitHub ↗</a>
   </footer>
 </body>
 </html>

--- a/reports/2026-07-26.html
+++ b/reports/2026-07-26.html
@@ -5,6 +5,74 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>WordPress Trend Report — 2026-07-26</title>
   <link rel="stylesheet" href="assets/report.css">
+  <script>
+(function () {
+  var root = document.documentElement;
+  var themeKey = "wp-trend-watcher-theme";
+  var modeKey = "wp-trend-watcher-mode";
+  var themes = ["aurora-blueprint", "aurora", "signal"];
+  var modes = ["system", "light", "dark"];
+
+  function read(key, allowed, fallback) {
+    try {
+      var value = window.localStorage.getItem(key);
+      return allowed.indexOf(value) >= 0 ? value : fallback;
+    } catch (_error) {
+      return fallback;
+    }
+  }
+
+  function persist(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (_error) {
+      // Continue without persistence when storage is unavailable.
+    }
+  }
+
+  function apply(theme, mode, save) {
+    root.dataset.theme = theme;
+    root.dataset.mode = mode;
+    if (save) {
+      persist(themeKey, theme);
+      persist(modeKey, mode);
+    }
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.value = theme;
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.value = mode;
+    });
+  }
+
+  apply(
+    read(themeKey, themes, "aurora-blueprint"),
+    read(modeKey, modes, "system"),
+    false,
+  );
+
+  var controlsBound = false;
+  function bindControls() {
+    if (controlsBound) return;
+    controlsBound = true;
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(event.target.value, root.dataset.mode || "system", true);
+      });
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(root.dataset.theme || "aurora-blueprint", event.target.value, true);
+      });
+    });
+    apply(root.dataset.theme || "aurora-blueprint", root.dataset.mode || "system", false);
+  }
+
+  document.addEventListener("DOMContentLoaded", bindControls);
+  window.addEventListener("load", bindControls);
+  if (document.readyState !== "loading") bindControls();
+})();
+</script>
   <meta name="description" content="Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-07-26.html">
   <meta property="og:type" content="article">
@@ -23,6 +91,24 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-26"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-26</h1>
 </header>
+  <div class="theme-controls" aria-label="Report display settings">
+  <label>
+    <span>Style</span>
+    <select data-theme-control="theme" aria-label="Report visual style">
+      <option value="aurora-blueprint">Aurora Blueprint</option>
+      <option value="aurora">Aurora Mesh</option>
+      <option value="signal">Signal Stripe</option>
+    </select>
+  </label>
+  <label>
+    <span>Mode</span>
+    <select data-theme-control="mode" aria-label="Report color mode">
+      <option value="system">System</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </label>
+</div>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>
@@ -127,6 +213,8 @@
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>
+    <span class="nav-footer-separator">·</span>
+    <a class="repo-link" href="https://github.com/colorful-tones/wp-trend-watcher">View on GitHub ↗</a>
   </footer>
 </body>
 </html>

--- a/reports/2026-08-03.html
+++ b/reports/2026-08-03.html
@@ -5,6 +5,74 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>WordPress Trend Report — 2026-08-03</title>
   <link rel="stylesheet" href="assets/report.css">
+  <script>
+(function () {
+  var root = document.documentElement;
+  var themeKey = "wp-trend-watcher-theme";
+  var modeKey = "wp-trend-watcher-mode";
+  var themes = ["aurora-blueprint", "aurora", "signal"];
+  var modes = ["system", "light", "dark"];
+
+  function read(key, allowed, fallback) {
+    try {
+      var value = window.localStorage.getItem(key);
+      return allowed.indexOf(value) >= 0 ? value : fallback;
+    } catch (_error) {
+      return fallback;
+    }
+  }
+
+  function persist(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (_error) {
+      // Continue without persistence when storage is unavailable.
+    }
+  }
+
+  function apply(theme, mode, save) {
+    root.dataset.theme = theme;
+    root.dataset.mode = mode;
+    if (save) {
+      persist(themeKey, theme);
+      persist(modeKey, mode);
+    }
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.value = theme;
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.value = mode;
+    });
+  }
+
+  apply(
+    read(themeKey, themes, "aurora-blueprint"),
+    read(modeKey, modes, "system"),
+    false,
+  );
+
+  var controlsBound = false;
+  function bindControls() {
+    if (controlsBound) return;
+    controlsBound = true;
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(event.target.value, root.dataset.mode || "system", true);
+      });
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(root.dataset.theme || "aurora-blueprint", event.target.value, true);
+      });
+    });
+    apply(root.dataset.theme || "aurora-blueprint", root.dataset.mode || "system", false);
+  }
+
+  document.addEventListener("DOMContentLoaded", bindControls);
+  window.addEventListener("load", bindControls);
+  if (document.readyState !== "loading") bindControls();
+})();
+</script>
   <meta name="description" content="Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-08-03.html">
   <meta property="og:type" content="article">
@@ -23,6 +91,24 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-08-03"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-08-03</h1>
 </header>
+  <div class="theme-controls" aria-label="Report display settings">
+  <label>
+    <span>Style</span>
+    <select data-theme-control="theme" aria-label="Report visual style">
+      <option value="aurora-blueprint">Aurora Blueprint</option>
+      <option value="aurora">Aurora Mesh</option>
+      <option value="signal">Signal Stripe</option>
+    </select>
+  </label>
+  <label>
+    <span>Mode</span>
+    <select data-theme-control="mode" aria-label="Report color mode">
+      <option value="system">System</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </label>
+</div>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>
@@ -130,6 +216,8 @@
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>
+    <span class="nav-footer-separator">·</span>
+    <a class="repo-link" href="https://github.com/colorful-tones/wp-trend-watcher">View on GitHub ↗</a>
   </footer>
 </body>
 </html>

--- a/reports/2026-08-10.html
+++ b/reports/2026-08-10.html
@@ -5,6 +5,74 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>WordPress Trend Report — 2026-08-10</title>
   <link rel="stylesheet" href="assets/report.css">
+  <script>
+(function () {
+  var root = document.documentElement;
+  var themeKey = "wp-trend-watcher-theme";
+  var modeKey = "wp-trend-watcher-mode";
+  var themes = ["aurora-blueprint", "aurora", "signal"];
+  var modes = ["system", "light", "dark"];
+
+  function read(key, allowed, fallback) {
+    try {
+      var value = window.localStorage.getItem(key);
+      return allowed.indexOf(value) >= 0 ? value : fallback;
+    } catch (_error) {
+      return fallback;
+    }
+  }
+
+  function persist(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (_error) {
+      // Continue without persistence when storage is unavailable.
+    }
+  }
+
+  function apply(theme, mode, save) {
+    root.dataset.theme = theme;
+    root.dataset.mode = mode;
+    if (save) {
+      persist(themeKey, theme);
+      persist(modeKey, mode);
+    }
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.value = theme;
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.value = mode;
+    });
+  }
+
+  apply(
+    read(themeKey, themes, "aurora-blueprint"),
+    read(modeKey, modes, "system"),
+    false,
+  );
+
+  var controlsBound = false;
+  function bindControls() {
+    if (controlsBound) return;
+    controlsBound = true;
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(event.target.value, root.dataset.mode || "system", true);
+      });
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(root.dataset.theme || "aurora-blueprint", event.target.value, true);
+      });
+    });
+    apply(root.dataset.theme || "aurora-blueprint", root.dataset.mode || "system", false);
+  }
+
+  document.addEventListener("DOMContentLoaded", bindControls);
+  window.addEventListener("load", bindControls);
+  if (document.readyState !== "loading") bindControls();
+})();
+</script>
   <meta name="description" content="Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-08-10.html">
   <meta property="og:type" content="article">
@@ -23,6 +91,24 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-08-10"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-08-10</h1>
 </header>
+  <div class="theme-controls" aria-label="Report display settings">
+  <label>
+    <span>Style</span>
+    <select data-theme-control="theme" aria-label="Report visual style">
+      <option value="aurora-blueprint">Aurora Blueprint</option>
+      <option value="aurora">Aurora Mesh</option>
+      <option value="signal">Signal Stripe</option>
+    </select>
+  </label>
+  <label>
+    <span>Mode</span>
+    <select data-theme-control="mode" aria-label="Report color mode">
+      <option value="system">System</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </label>
+</div>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>
@@ -147,6 +233,8 @@
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>
+    <span class="nav-footer-separator">·</span>
+    <a class="repo-link" href="https://github.com/colorful-tones/wp-trend-watcher">View on GitHub ↗</a>
   </footer>
 </body>
 </html>

--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -250,3 +250,207 @@ details.article-inventory ol {
 .nav-footer a {
   color: #0969da;
 }
+
+/* Theme tokens and user-selectable report presentation */
+:root {
+  --page-bg: #ffffff;
+  --surface: #ffffff;
+  --surface-muted: #f6f8fa;
+  --surface-translucent: rgba(255, 255, 255, 0.72);
+  --text: #17202a;
+  --muted: #425466;
+  --accent: #0969da;
+  --border: #e0e0e0;
+  --border-strong: #d0d0d0;
+  --theme-gradient: none;
+  --theme-grid-x: none;
+  --theme-grid-y: none;
+}
+
+:root[data-theme="aurora-blueprint"] {
+  --accent: #0759b8;
+  --theme-gradient: radial-gradient(circle at 8% 0%, rgba(147, 197, 253, 0.32), transparent 42%), radial-gradient(circle at 92% 85%, rgba(165, 243, 252, 0.28), transparent 45%);
+  --theme-grid-x: linear-gradient(rgba(9, 105, 218, 0.06) 1px, transparent 1px);
+  --theme-grid-y: linear-gradient(90deg, rgba(9, 105, 218, 0.06) 1px, transparent 1px);
+}
+
+:root[data-theme="aurora"] {
+  --accent: #0759b8;
+  --theme-gradient: radial-gradient(circle at 10% 0%, rgba(147, 197, 253, 0.24), transparent 42%), radial-gradient(circle at 90% 85%, rgba(165, 243, 252, 0.2), transparent 45%);
+}
+
+:root[data-theme="signal"] {
+  --accent: #9a5700;
+  --theme-gradient: linear-gradient(135deg, rgba(251, 191, 36, 0.18), transparent 35%);
+}
+
+:root[data-mode="dark"] {
+  --page-bg: #101820;
+  --surface: #17232d;
+  --surface-muted: #1d2b36;
+  --surface-translucent: rgba(23, 35, 45, 0.78);
+  --text: #f4f7f9;
+  --muted: #c0ccd5;
+  --border: #344653;
+  --border-strong: #4a5d6b;
+}
+
+:root[data-theme="aurora-blueprint"][data-mode="dark"] {
+  --accent: #8fc7ff;
+  --theme-gradient: radial-gradient(circle at 8% 0%, rgba(37, 99, 235, 0.3), transparent 42%), radial-gradient(circle at 92% 85%, rgba(8, 145, 178, 0.25), transparent 45%);
+  --theme-grid-x: linear-gradient(rgba(96, 165, 250, 0.12) 1px, transparent 1px);
+  --theme-grid-y: linear-gradient(90deg, rgba(96, 165, 250, 0.12) 1px, transparent 1px);
+}
+
+:root[data-theme="aurora"][data-mode="dark"] {
+  --accent: #8fc7ff;
+  --theme-gradient: radial-gradient(circle at 10% 0%, rgba(37, 99, 235, 0.26), transparent 42%), radial-gradient(circle at 90% 85%, rgba(8, 145, 178, 0.22), transparent 45%);
+}
+
+:root[data-theme="signal"][data-mode="dark"] {
+  --accent: #ffc861;
+  --theme-gradient: linear-gradient(135deg, rgba(180, 113, 0, 0.26), transparent 40%);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-mode="system"] {
+    --page-bg: #101820;
+    --surface: #17232d;
+    --surface-muted: #1d2b36;
+    --surface-translucent: rgba(23, 35, 45, 0.78);
+    --text: #f4f7f9;
+    --muted: #c0ccd5;
+    --border: #344653;
+    --border-strong: #4a5d6b;
+  }
+
+  :root[data-theme="aurora-blueprint"][data-mode="system"] {
+    --accent: #8fc7ff;
+    --theme-gradient: radial-gradient(circle at 8% 0%, rgba(37, 99, 235, 0.3), transparent 42%), radial-gradient(circle at 92% 85%, rgba(8, 145, 178, 0.25), transparent 45%);
+    --theme-grid-x: linear-gradient(rgba(96, 165, 250, 0.12) 1px, transparent 1px);
+    --theme-grid-y: linear-gradient(90deg, rgba(96, 165, 250, 0.12) 1px, transparent 1px);
+  }
+
+  :root[data-theme="aurora"][data-mode="system"] {
+    --accent: #8fc7ff;
+    --theme-gradient: radial-gradient(circle at 10% 0%, rgba(37, 99, 235, 0.26), transparent 42%), radial-gradient(circle at 90% 85%, rgba(8, 145, 178, 0.22), transparent 45%);
+  }
+
+  :root[data-theme="signal"][data-mode="system"] {
+    --accent: #ffc861;
+    --theme-gradient: linear-gradient(135deg, rgba(180, 113, 0, 0.26), transparent 40%);
+  }
+}
+
+body {
+  background-color: var(--page-bg);
+  background-image: var(--theme-gradient), var(--theme-grid-x), var(--theme-grid-y);
+  background-size: auto, 24px 24px, 24px 24px;
+  color: var(--text);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+a,
+.nav-footer a {
+  color: var(--accent);
+}
+
+.meta,
+.prototype-index-meta,
+#build-notes,
+#build-notes ~ *,
+.report-card-copy {
+  color: var(--muted);
+}
+
+code,
+pre,
+.toc,
+details.article-inventory {
+  background: var(--surface-muted);
+  border-color: var(--border);
+  color: var(--text);
+}
+
+hr,
+.nav-footer,
+.report-card,
+.report-card:hover {
+  border-color: var(--border);
+}
+
+.report-body,
+.toc,
+details.article-inventory {
+  background: var(--surface-translucent);
+  backdrop-filter: blur(8px);
+}
+
+.report-body {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0 1.25rem 1.25rem;
+}
+
+.report-card {
+  background: var(--surface-translucent);
+  border-radius: 8px;
+  border-left: 3px solid var(--accent);
+  backdrop-filter: blur(8px);
+  transition: background-color 0.15s, border-color 0.15s, transform 0.15s;
+}
+
+.report-card:hover {
+  background: var(--surface);
+  border-left-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.report-card-label {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.theme-controls {
+  align-items: end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  margin: -0.5rem 0 1.5rem;
+}
+
+.theme-controls label {
+  align-items: center;
+  color: var(--muted);
+  display: flex;
+  font-size: 0.75rem;
+  gap: 0.4rem;
+}
+
+.theme-controls select {
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 5px;
+  color: var(--text);
+  font: inherit;
+  font-size: 0.8rem;
+  min-height: 2rem;
+  padding: 0.25rem 1.75rem 0.25rem 0.5rem;
+}
+
+.theme-controls select:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 560px) {
+  .theme-controls {
+    justify-content: flex-start;
+  }
+
+  .theme-controls label {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/reports/index.html
+++ b/reports/index.html
@@ -5,6 +5,74 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>WP Trend Watcher — Reports</title>
   <link rel="stylesheet" href="assets/report.css">
+  <script>
+(function () {
+  var root = document.documentElement;
+  var themeKey = "wp-trend-watcher-theme";
+  var modeKey = "wp-trend-watcher-mode";
+  var themes = ["aurora-blueprint", "aurora", "signal"];
+  var modes = ["system", "light", "dark"];
+
+  function read(key, allowed, fallback) {
+    try {
+      var value = window.localStorage.getItem(key);
+      return allowed.indexOf(value) >= 0 ? value : fallback;
+    } catch (_error) {
+      return fallback;
+    }
+  }
+
+  function persist(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (_error) {
+      // Continue without persistence when storage is unavailable.
+    }
+  }
+
+  function apply(theme, mode, save) {
+    root.dataset.theme = theme;
+    root.dataset.mode = mode;
+    if (save) {
+      persist(themeKey, theme);
+      persist(modeKey, mode);
+    }
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.value = theme;
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.value = mode;
+    });
+  }
+
+  apply(
+    read(themeKey, themes, "aurora-blueprint"),
+    read(modeKey, modes, "system"),
+    false,
+  );
+
+  var controlsBound = false;
+  function bindControls() {
+    if (controlsBound) return;
+    controlsBound = true;
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(event.target.value, root.dataset.mode || "system", true);
+      });
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(root.dataset.theme || "aurora-blueprint", event.target.value, true);
+      });
+    });
+    apply(root.dataset.theme || "aurora-blueprint", root.dataset.mode || "system", false);
+  }
+
+  document.addEventListener("DOMContentLoaded", bindControls);
+  window.addEventListener("load", bindControls);
+  if (document.readyState !== "loading") bindControls();
+})();
+</script>
   <meta name="description" content="Weekly human-reviewed WordPress ecosystem trend reports.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/index.html">
   <meta property="og:type" content="website">
@@ -23,11 +91,30 @@
     <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
     <h1>WP Trend Watcher — Reports</h1>
   </header>
-  <p class="meta">8 weekly WordPress ecosystem trend reports.</p>
+  <div class="theme-controls" aria-label="Report display settings">
+  <label>
+    <span>Style</span>
+    <select data-theme-control="theme" aria-label="Report visual style">
+      <option value="aurora-blueprint">Aurora Blueprint</option>
+      <option value="aurora">Aurora Mesh</option>
+      <option value="signal">Signal Stripe</option>
+    </select>
+  </label>
+  <label>
+    <span>Mode</span>
+    <select data-theme-control="mode" aria-label="Report color mode">
+      <option value="system">System</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </label>
+</div>
+  <p class="meta">9 weekly WordPress ecosystem trend reports.</p>
   <div class="report-card-grid">
     <a href="2026-08-10.html" class="report-card">
       <span class="report-card-date">August 10, 2026</span>
-      <span class="report-card-label">Latest report</span>
+    <span class="report-card-label">Latest report</span>
+    </a>
     <a href="2026-08-03.html" class="report-card">
       <span class="report-card-date">August 3, 2026</span>
     </a>
@@ -55,6 +142,8 @@
   </div>
   <footer class="nav-footer">
     <p>
+      <a class="repo-link" href="https://github.com/colorful-tones/wp-trend-watcher">View the project on GitHub ↗</a>
+      &nbsp;·&nbsp;
       <a href="https://github.com/colorful-tones/wp-trend-watcher/issues/new?template=source-suggestion.yml">Suggest a source</a>
       &nbsp;·&nbsp;
       <a href="https://github.com/colorful-tones/wp-trend-watcher/issues/new?template=report-feedback.yml">Send feedback</a>

--- a/src/summarize/html.ts
+++ b/src/summarize/html.ts
@@ -35,6 +35,97 @@ const REPORT_OG_IMAGE_SOURCE = new URL(
 // Canonical site base URL for absolute Open Graph / Twitter / canonical URLs.
 // Must match the GitHub Pages deployment root (see README).
 const SITE_BASE_URL = "https://colorful-tones.github.io/wp-trend-watcher/";
+const GITHUB_REPO_URL = "https://github.com/colorful-tones/wp-trend-watcher";
+const DEFAULT_REPORT_THEME = "aurora-blueprint";
+const DEFAULT_REPORT_MODE = "system";
+
+const REPORT_THEME_CONTROLS = `<div class="theme-controls" aria-label="Report display settings">
+  <label>
+    <span>Style</span>
+    <select data-theme-control="theme" aria-label="Report visual style">
+      <option value="aurora-blueprint">Aurora Blueprint</option>
+      <option value="aurora">Aurora Mesh</option>
+      <option value="signal">Signal Stripe</option>
+    </select>
+  </label>
+  <label>
+    <span>Mode</span>
+    <select data-theme-control="mode" aria-label="Report color mode">
+      <option value="system">System</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </label>
+</div>`;
+
+const REPORT_THEME_SCRIPT = `<script>
+(function () {
+  var root = document.documentElement;
+  var themeKey = "wp-trend-watcher-theme";
+  var modeKey = "wp-trend-watcher-mode";
+  var themes = ["aurora-blueprint", "aurora", "signal"];
+  var modes = ["system", "light", "dark"];
+
+  function read(key, allowed, fallback) {
+    try {
+      var value = window.localStorage.getItem(key);
+      return allowed.indexOf(value) >= 0 ? value : fallback;
+    } catch (_error) {
+      return fallback;
+    }
+  }
+
+  function persist(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (_error) {
+      // Continue without persistence when storage is unavailable.
+    }
+  }
+
+  function apply(theme, mode, save) {
+    root.dataset.theme = theme;
+    root.dataset.mode = mode;
+    if (save) {
+      persist(themeKey, theme);
+      persist(modeKey, mode);
+    }
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.value = theme;
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.value = mode;
+    });
+  }
+
+  apply(
+    read(themeKey, themes, "${DEFAULT_REPORT_THEME}"),
+    read(modeKey, modes, "${DEFAULT_REPORT_MODE}"),
+    false,
+  );
+
+  var controlsBound = false;
+  function bindControls() {
+    if (controlsBound) return;
+    controlsBound = true;
+    document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(event.target.value, root.dataset.mode || "${DEFAULT_REPORT_MODE}", true);
+      });
+    });
+    document.querySelectorAll("[data-theme-control='mode']").forEach(function (control) {
+      control.addEventListener("change", function (event) {
+        apply(root.dataset.theme || "${DEFAULT_REPORT_THEME}", event.target.value, true);
+      });
+    });
+    apply(root.dataset.theme || "${DEFAULT_REPORT_THEME}", root.dataset.mode || "${DEFAULT_REPORT_MODE}", false);
+  }
+
+  document.addEventListener("DOMContentLoaded", bindControls);
+  window.addEventListener("load", bindControls);
+  if (document.readyState !== "loading") bindControls();
+})();
+</script>`;
 
 // Shared SEO description for report pages.
 const REPORT_SEO_DESCRIPTION =
@@ -163,6 +254,7 @@ export async function generateHtmlReport(mdPath: string): Promise<string> {
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>WordPress Trend Report — ${date}</title>
   <link rel="stylesheet" href="${stylesheetHref}">
+  ${REPORT_THEME_SCRIPT}
   ${buildSeoMeta({
     title: `WordPress Trend Report — ${date}`,
     description: REPORT_SEO_DESCRIPTION,
@@ -172,12 +264,15 @@ export async function generateHtmlReport(mdPath: string): Promise<string> {
 </head>
 <body class="report-page">
   ${headerHtml}
+  ${REPORT_THEME_CONTROLS}
   ${tocHtml}
   <div class="report-body">
   ${bodyHtml}
 </div>
   <footer class="nav-footer">
     <a href="index.html">← Back to Reports</a>
+    <span class="nav-footer-separator">·</span>
+    <a class="repo-link" href="${GITHUB_REPO_URL}">View on GitHub ↗</a>
   </footer>
 </body>
 </html>`;
@@ -238,6 +333,7 @@ export async function generateIndexPage(reportsDir: string): Promise<string> {
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>WP Trend Watcher — Reports</title>
   <link rel="stylesheet" href="${stylesheetHref}">
+  ${REPORT_THEME_SCRIPT}
   ${buildSeoMeta({
     title: "WP Trend Watcher — Reports",
     description: "Weekly human-reviewed WordPress ecosystem trend reports.",
@@ -250,12 +346,15 @@ export async function generateIndexPage(reportsDir: string): Promise<string> {
     <img class="report-icon" src="${REPORT_ICON_HREF}" alt="" width="40" height="40">
     <h1>WP Trend Watcher — Reports</h1>
   </header>
+  ${REPORT_THEME_CONTROLS}
   <p class="meta">${reportLabel}</p>
   <div class="report-card-grid">
 ${cards}
   </div>
   <footer class="nav-footer">
     <p>
+      <a class="repo-link" href="${GITHUB_REPO_URL}">View the project on GitHub ↗</a>
+      &nbsp;·&nbsp;
       <a href="https://github.com/colorful-tones/wp-trend-watcher/issues/new?template=source-suggestion.yml">Suggest a source</a>
       &nbsp;·&nbsp;
       <a href="https://github.com/colorful-tones/wp-trend-watcher/issues/new?template=report-feedback.yml">Send feedback</a>

--- a/src/summarize/report.css
+++ b/src/summarize/report.css
@@ -250,3 +250,207 @@ details.article-inventory ol {
 .nav-footer a {
   color: #0969da;
 }
+
+/* Theme tokens and user-selectable report presentation */
+:root {
+  --page-bg: #ffffff;
+  --surface: #ffffff;
+  --surface-muted: #f6f8fa;
+  --surface-translucent: rgba(255, 255, 255, 0.72);
+  --text: #17202a;
+  --muted: #425466;
+  --accent: #0969da;
+  --border: #e0e0e0;
+  --border-strong: #d0d0d0;
+  --theme-gradient: none;
+  --theme-grid-x: none;
+  --theme-grid-y: none;
+}
+
+:root[data-theme="aurora-blueprint"] {
+  --accent: #0759b8;
+  --theme-gradient: radial-gradient(circle at 8% 0%, rgba(147, 197, 253, 0.32), transparent 42%), radial-gradient(circle at 92% 85%, rgba(165, 243, 252, 0.28), transparent 45%);
+  --theme-grid-x: linear-gradient(rgba(9, 105, 218, 0.06) 1px, transparent 1px);
+  --theme-grid-y: linear-gradient(90deg, rgba(9, 105, 218, 0.06) 1px, transparent 1px);
+}
+
+:root[data-theme="aurora"] {
+  --accent: #0759b8;
+  --theme-gradient: radial-gradient(circle at 10% 0%, rgba(147, 197, 253, 0.24), transparent 42%), radial-gradient(circle at 90% 85%, rgba(165, 243, 252, 0.2), transparent 45%);
+}
+
+:root[data-theme="signal"] {
+  --accent: #9a5700;
+  --theme-gradient: linear-gradient(135deg, rgba(251, 191, 36, 0.18), transparent 35%);
+}
+
+:root[data-mode="dark"] {
+  --page-bg: #101820;
+  --surface: #17232d;
+  --surface-muted: #1d2b36;
+  --surface-translucent: rgba(23, 35, 45, 0.78);
+  --text: #f4f7f9;
+  --muted: #c0ccd5;
+  --border: #344653;
+  --border-strong: #4a5d6b;
+}
+
+:root[data-theme="aurora-blueprint"][data-mode="dark"] {
+  --accent: #8fc7ff;
+  --theme-gradient: radial-gradient(circle at 8% 0%, rgba(37, 99, 235, 0.3), transparent 42%), radial-gradient(circle at 92% 85%, rgba(8, 145, 178, 0.25), transparent 45%);
+  --theme-grid-x: linear-gradient(rgba(96, 165, 250, 0.12) 1px, transparent 1px);
+  --theme-grid-y: linear-gradient(90deg, rgba(96, 165, 250, 0.12) 1px, transparent 1px);
+}
+
+:root[data-theme="aurora"][data-mode="dark"] {
+  --accent: #8fc7ff;
+  --theme-gradient: radial-gradient(circle at 10% 0%, rgba(37, 99, 235, 0.26), transparent 42%), radial-gradient(circle at 90% 85%, rgba(8, 145, 178, 0.22), transparent 45%);
+}
+
+:root[data-theme="signal"][data-mode="dark"] {
+  --accent: #ffc861;
+  --theme-gradient: linear-gradient(135deg, rgba(180, 113, 0, 0.26), transparent 40%);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-mode="system"] {
+    --page-bg: #101820;
+    --surface: #17232d;
+    --surface-muted: #1d2b36;
+    --surface-translucent: rgba(23, 35, 45, 0.78);
+    --text: #f4f7f9;
+    --muted: #c0ccd5;
+    --border: #344653;
+    --border-strong: #4a5d6b;
+  }
+
+  :root[data-theme="aurora-blueprint"][data-mode="system"] {
+    --accent: #8fc7ff;
+    --theme-gradient: radial-gradient(circle at 8% 0%, rgba(37, 99, 235, 0.3), transparent 42%), radial-gradient(circle at 92% 85%, rgba(8, 145, 178, 0.25), transparent 45%);
+    --theme-grid-x: linear-gradient(rgba(96, 165, 250, 0.12) 1px, transparent 1px);
+    --theme-grid-y: linear-gradient(90deg, rgba(96, 165, 250, 0.12) 1px, transparent 1px);
+  }
+
+  :root[data-theme="aurora"][data-mode="system"] {
+    --accent: #8fc7ff;
+    --theme-gradient: radial-gradient(circle at 10% 0%, rgba(37, 99, 235, 0.26), transparent 42%), radial-gradient(circle at 90% 85%, rgba(8, 145, 178, 0.22), transparent 45%);
+  }
+
+  :root[data-theme="signal"][data-mode="system"] {
+    --accent: #ffc861;
+    --theme-gradient: linear-gradient(135deg, rgba(180, 113, 0, 0.26), transparent 40%);
+  }
+}
+
+body {
+  background-color: var(--page-bg);
+  background-image: var(--theme-gradient), var(--theme-grid-x), var(--theme-grid-y);
+  background-size: auto, 24px 24px, 24px 24px;
+  color: var(--text);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+a,
+.nav-footer a {
+  color: var(--accent);
+}
+
+.meta,
+.prototype-index-meta,
+#build-notes,
+#build-notes ~ *,
+.report-card-copy {
+  color: var(--muted);
+}
+
+code,
+pre,
+.toc,
+details.article-inventory {
+  background: var(--surface-muted);
+  border-color: var(--border);
+  color: var(--text);
+}
+
+hr,
+.nav-footer,
+.report-card,
+.report-card:hover {
+  border-color: var(--border);
+}
+
+.report-body,
+.toc,
+details.article-inventory {
+  background: var(--surface-translucent);
+  backdrop-filter: blur(8px);
+}
+
+.report-body {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0 1.25rem 1.25rem;
+}
+
+.report-card {
+  background: var(--surface-translucent);
+  border-radius: 8px;
+  border-left: 3px solid var(--accent);
+  backdrop-filter: blur(8px);
+  transition: background-color 0.15s, border-color 0.15s, transform 0.15s;
+}
+
+.report-card:hover {
+  background: var(--surface);
+  border-left-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.report-card-label {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.theme-controls {
+  align-items: end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  margin: -0.5rem 0 1.5rem;
+}
+
+.theme-controls label {
+  align-items: center;
+  color: var(--muted);
+  display: flex;
+  font-size: 0.75rem;
+  gap: 0.4rem;
+}
+
+.theme-controls select {
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 5px;
+  color: var(--text);
+  font: inherit;
+  font-size: 0.8rem;
+  min-height: 2rem;
+  padding: 0.25rem 1.75rem 0.25rem 0.5rem;
+}
+
+.theme-controls select:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 560px) {
+  .theme-controls {
+    justify-content: flex-start;
+  }
+
+  .theme-controls label {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/tests/summarize/html.test.ts
+++ b/tests/summarize/html.test.ts
@@ -266,6 +266,10 @@ test("generateHtmlReport includes back-to-index footer link", async () => {
     html.includes('<a href="index.html">← Back to Reports</a>'),
     "report should include back-to-index link",
   );
+  assert.ok(
+    html.includes('href="https://github.com/colorful-tones/wp-trend-watcher"'),
+    "report should include the GitHub repository link",
+  );
 });
 
 test("generateIndexPage includes feedback and source suggestion links", async () => {
@@ -295,6 +299,10 @@ test("generateIndexPage includes feedback and source suggestion links", async ()
     html.includes('<footer class="nav-footer">'),
     "index page should include nav-footer",
   );
+  assert.ok(
+    html.includes('href="https://github.com/colorful-tones/wp-trend-watcher"'),
+    "index page should include the GitHub repository link",
+  );
 });
 
 test("generateHtmlReport links a shared external stylesheet", async () => {
@@ -309,6 +317,9 @@ test("generateHtmlReport links a shared external stylesheet", async () => {
   assert.ok(html.includes('<link rel="stylesheet" href="assets/report.css">'));
   assert.ok(html.includes('<body class="report-page">'));
   assert.ok(!html.includes("<style>"));
+  assert.ok(html.includes('data-theme-control="theme"'));
+  assert.ok(html.includes('data-theme-control="mode"'));
+  assert.ok(html.includes("wp-trend-watcher-theme"));
   assert.ok(css.includes(".report-header"));
 });
 
@@ -323,6 +334,8 @@ test("generateIndexPage links a shared external stylesheet", async () => {
   assert.ok(html.includes('<link rel="stylesheet" href="assets/report.css">'));
   assert.ok(html.includes('<body class="report-index">'));
   assert.ok(!html.includes("<style>"));
+  assert.ok(html.includes('data-theme-control="theme"'));
+  assert.ok(html.includes('data-theme-control="mode"'));
   assert.ok(css.includes(".report-index h1"));
 });
 


### PR DESCRIPTION
## Summary

- Add persistent report style and color-mode controls to the report index and individual reports.
- Add Aurora Blueprint, Aurora Mesh, and Signal Stripe light/dark/system variants with accessible contrast and no-flash initialization.
- Add GitHub repository links to generated report footers.
- Document how to add future themes in `docs/report-themes.md`.
- Remove the temporary prototype tooling while preserving the production theme system.

## Verification

- [x] `pnpm run test` — 201 tests passed
- [x] `pnpm run typecheck`
- [x] `pnpm run regen-html`
- [x] `git diff --check`
- [x] Browser-checked theme persistence and generated index/report controls

## Review focus

- Confirm the theme registration flow is simple enough for future additions.
- Check that the generated reports remain readable in light, dark, and system modes.
- Review whether the three current theme directions should all remain user-selectable or whether one should become the sole production default.
