### PR TITLE
feat(reports): add grid layout and settings modal

### DIFF
--- a/data/articles/2026-08-11/articles.json
+++ b/data/articles/2026-08-11/articles.json
@@ -1,0 +1,6 @@
+{
+  "date": "2026-08-11",
+  "collectedAt": "2026-08-11T01:02:26.712Z",
+  "articleCount": 0,
+  "articles": []
+}

--- a/reports/2026-06-12.html
+++ b/reports/2026-06-12.html
@@ -55,6 +55,23 @@
   function bindControls() {
     if (controlsBound) return;
     controlsBound = true;
+    var settingsDialog = document.getElementById("report-settings");
+    document.querySelectorAll("[data-theme-settings-open]").forEach(function (control) {
+      control.addEventListener("click", function () {
+        if (settingsDialog && typeof settingsDialog.showModal === "function") {
+          settingsDialog.showModal();
+        } else if (settingsDialog) {
+          settingsDialog.setAttribute("open", "");
+        }
+      });
+    });
+    if (settingsDialog) {
+      settingsDialog.addEventListener("click", function (event) {
+        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
+          settingsDialog.close();
+        }
+      });
+    }
     document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
       control.addEventListener("change", function (event) {
         apply(event.target.value, root.dataset.mode || "system", true);
@@ -91,23 +108,45 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-06-12"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-06-12</h1>
 </header>
-  <div class="theme-controls" aria-label="Report display settings">
-  <label>
-    <span>Style</span>
-    <select data-theme-control="theme" aria-label="Report visual style">
-      <option value="aurora-blueprint">Aurora Blueprint</option>
-      <option value="aurora">Aurora Mesh</option>
-      <option value="signal">Signal Stripe</option>
-    </select>
-  </label>
-  <label>
-    <span>Mode</span>
-    <select data-theme-control="mode" aria-label="Report color mode">
-      <option value="system">System</option>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
-    </select>
-  </label>
+  <div class="theme-settings">
+  <button
+    class="settings-button"
+    type="button"
+    data-theme-settings-open
+    aria-haspopup="dialog"
+    aria-controls="report-settings"
+  >
+    Settings
+  </button>
+  <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
+    <form method="dialog">
+      <div class="theme-settings-header">
+        <h2 id="report-settings-title">Report settings</h2>
+        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+      </div>
+      <div class="theme-controls" aria-label="Report display settings">
+        <label>
+          <span>Style</span>
+          <select data-theme-control="theme" aria-label="Report visual style">
+            <option value="aurora-blueprint">Aurora Blueprint</option>
+            <option value="aurora">Aurora Mesh</option>
+            <option value="signal">Signal Stripe</option>
+          </select>
+        </label>
+        <label>
+          <span>Mode</span>
+          <select data-theme-control="mode" aria-label="Report color mode">
+            <option value="system">System</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </div>
+      <div class="theme-settings-actions">
+        <button type="submit" value="close">Done</button>
+      </div>
+    </form>
+  </dialog>
 </div>
   <nav class="toc">
   <h2>Contents</h2>

--- a/reports/2026-06-21.html
+++ b/reports/2026-06-21.html
@@ -55,6 +55,23 @@
   function bindControls() {
     if (controlsBound) return;
     controlsBound = true;
+    var settingsDialog = document.getElementById("report-settings");
+    document.querySelectorAll("[data-theme-settings-open]").forEach(function (control) {
+      control.addEventListener("click", function () {
+        if (settingsDialog && typeof settingsDialog.showModal === "function") {
+          settingsDialog.showModal();
+        } else if (settingsDialog) {
+          settingsDialog.setAttribute("open", "");
+        }
+      });
+    });
+    if (settingsDialog) {
+      settingsDialog.addEventListener("click", function (event) {
+        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
+          settingsDialog.close();
+        }
+      });
+    }
     document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
       control.addEventListener("change", function (event) {
         apply(event.target.value, root.dataset.mode || "system", true);
@@ -91,23 +108,45 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-06-21"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-06-21</h1>
 </header>
-  <div class="theme-controls" aria-label="Report display settings">
-  <label>
-    <span>Style</span>
-    <select data-theme-control="theme" aria-label="Report visual style">
-      <option value="aurora-blueprint">Aurora Blueprint</option>
-      <option value="aurora">Aurora Mesh</option>
-      <option value="signal">Signal Stripe</option>
-    </select>
-  </label>
-  <label>
-    <span>Mode</span>
-    <select data-theme-control="mode" aria-label="Report color mode">
-      <option value="system">System</option>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
-    </select>
-  </label>
+  <div class="theme-settings">
+  <button
+    class="settings-button"
+    type="button"
+    data-theme-settings-open
+    aria-haspopup="dialog"
+    aria-controls="report-settings"
+  >
+    Settings
+  </button>
+  <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
+    <form method="dialog">
+      <div class="theme-settings-header">
+        <h2 id="report-settings-title">Report settings</h2>
+        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+      </div>
+      <div class="theme-controls" aria-label="Report display settings">
+        <label>
+          <span>Style</span>
+          <select data-theme-control="theme" aria-label="Report visual style">
+            <option value="aurora-blueprint">Aurora Blueprint</option>
+            <option value="aurora">Aurora Mesh</option>
+            <option value="signal">Signal Stripe</option>
+          </select>
+        </label>
+        <label>
+          <span>Mode</span>
+          <select data-theme-control="mode" aria-label="Report color mode">
+            <option value="system">System</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </div>
+      <div class="theme-settings-actions">
+        <button type="submit" value="close">Done</button>
+      </div>
+    </form>
+  </dialog>
 </div>
   <nav class="toc">
   <h2>Contents</h2>

--- a/reports/2026-06-27.html
+++ b/reports/2026-06-27.html
@@ -55,6 +55,23 @@
   function bindControls() {
     if (controlsBound) return;
     controlsBound = true;
+    var settingsDialog = document.getElementById("report-settings");
+    document.querySelectorAll("[data-theme-settings-open]").forEach(function (control) {
+      control.addEventListener("click", function () {
+        if (settingsDialog && typeof settingsDialog.showModal === "function") {
+          settingsDialog.showModal();
+        } else if (settingsDialog) {
+          settingsDialog.setAttribute("open", "");
+        }
+      });
+    });
+    if (settingsDialog) {
+      settingsDialog.addEventListener("click", function (event) {
+        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
+          settingsDialog.close();
+        }
+      });
+    }
     document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
       control.addEventListener("change", function (event) {
         apply(event.target.value, root.dataset.mode || "system", true);
@@ -91,23 +108,45 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-06-27"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-06-27</h1>
 </header>
-  <div class="theme-controls" aria-label="Report display settings">
-  <label>
-    <span>Style</span>
-    <select data-theme-control="theme" aria-label="Report visual style">
-      <option value="aurora-blueprint">Aurora Blueprint</option>
-      <option value="aurora">Aurora Mesh</option>
-      <option value="signal">Signal Stripe</option>
-    </select>
-  </label>
-  <label>
-    <span>Mode</span>
-    <select data-theme-control="mode" aria-label="Report color mode">
-      <option value="system">System</option>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
-    </select>
-  </label>
+  <div class="theme-settings">
+  <button
+    class="settings-button"
+    type="button"
+    data-theme-settings-open
+    aria-haspopup="dialog"
+    aria-controls="report-settings"
+  >
+    Settings
+  </button>
+  <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
+    <form method="dialog">
+      <div class="theme-settings-header">
+        <h2 id="report-settings-title">Report settings</h2>
+        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+      </div>
+      <div class="theme-controls" aria-label="Report display settings">
+        <label>
+          <span>Style</span>
+          <select data-theme-control="theme" aria-label="Report visual style">
+            <option value="aurora-blueprint">Aurora Blueprint</option>
+            <option value="aurora">Aurora Mesh</option>
+            <option value="signal">Signal Stripe</option>
+          </select>
+        </label>
+        <label>
+          <span>Mode</span>
+          <select data-theme-control="mode" aria-label="Report color mode">
+            <option value="system">System</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </div>
+      <div class="theme-settings-actions">
+        <button type="submit" value="close">Done</button>
+      </div>
+    </form>
+  </dialog>
 </div>
   <nav class="toc">
   <h2>Contents</h2>

--- a/reports/2026-07-05.html
+++ b/reports/2026-07-05.html
@@ -55,6 +55,23 @@
   function bindControls() {
     if (controlsBound) return;
     controlsBound = true;
+    var settingsDialog = document.getElementById("report-settings");
+    document.querySelectorAll("[data-theme-settings-open]").forEach(function (control) {
+      control.addEventListener("click", function () {
+        if (settingsDialog && typeof settingsDialog.showModal === "function") {
+          settingsDialog.showModal();
+        } else if (settingsDialog) {
+          settingsDialog.setAttribute("open", "");
+        }
+      });
+    });
+    if (settingsDialog) {
+      settingsDialog.addEventListener("click", function (event) {
+        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
+          settingsDialog.close();
+        }
+      });
+    }
     document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
       control.addEventListener("change", function (event) {
         apply(event.target.value, root.dataset.mode || "system", true);
@@ -91,23 +108,45 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-05"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-05</h1>
 </header>
-  <div class="theme-controls" aria-label="Report display settings">
-  <label>
-    <span>Style</span>
-    <select data-theme-control="theme" aria-label="Report visual style">
-      <option value="aurora-blueprint">Aurora Blueprint</option>
-      <option value="aurora">Aurora Mesh</option>
-      <option value="signal">Signal Stripe</option>
-    </select>
-  </label>
-  <label>
-    <span>Mode</span>
-    <select data-theme-control="mode" aria-label="Report color mode">
-      <option value="system">System</option>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
-    </select>
-  </label>
+  <div class="theme-settings">
+  <button
+    class="settings-button"
+    type="button"
+    data-theme-settings-open
+    aria-haspopup="dialog"
+    aria-controls="report-settings"
+  >
+    Settings
+  </button>
+  <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
+    <form method="dialog">
+      <div class="theme-settings-header">
+        <h2 id="report-settings-title">Report settings</h2>
+        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+      </div>
+      <div class="theme-controls" aria-label="Report display settings">
+        <label>
+          <span>Style</span>
+          <select data-theme-control="theme" aria-label="Report visual style">
+            <option value="aurora-blueprint">Aurora Blueprint</option>
+            <option value="aurora">Aurora Mesh</option>
+            <option value="signal">Signal Stripe</option>
+          </select>
+        </label>
+        <label>
+          <span>Mode</span>
+          <select data-theme-control="mode" aria-label="Report color mode">
+            <option value="system">System</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </div>
+      <div class="theme-settings-actions">
+        <button type="submit" value="close">Done</button>
+      </div>
+    </form>
+  </dialog>
 </div>
   <nav class="toc">
   <h2>Contents</h2>

--- a/reports/2026-07-11.html
+++ b/reports/2026-07-11.html
@@ -55,6 +55,23 @@
   function bindControls() {
     if (controlsBound) return;
     controlsBound = true;
+    var settingsDialog = document.getElementById("report-settings");
+    document.querySelectorAll("[data-theme-settings-open]").forEach(function (control) {
+      control.addEventListener("click", function () {
+        if (settingsDialog && typeof settingsDialog.showModal === "function") {
+          settingsDialog.showModal();
+        } else if (settingsDialog) {
+          settingsDialog.setAttribute("open", "");
+        }
+      });
+    });
+    if (settingsDialog) {
+      settingsDialog.addEventListener("click", function (event) {
+        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
+          settingsDialog.close();
+        }
+      });
+    }
     document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
       control.addEventListener("change", function (event) {
         apply(event.target.value, root.dataset.mode || "system", true);
@@ -91,23 +108,45 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-11"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-11</h1>
 </header>
-  <div class="theme-controls" aria-label="Report display settings">
-  <label>
-    <span>Style</span>
-    <select data-theme-control="theme" aria-label="Report visual style">
-      <option value="aurora-blueprint">Aurora Blueprint</option>
-      <option value="aurora">Aurora Mesh</option>
-      <option value="signal">Signal Stripe</option>
-    </select>
-  </label>
-  <label>
-    <span>Mode</span>
-    <select data-theme-control="mode" aria-label="Report color mode">
-      <option value="system">System</option>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
-    </select>
-  </label>
+  <div class="theme-settings">
+  <button
+    class="settings-button"
+    type="button"
+    data-theme-settings-open
+    aria-haspopup="dialog"
+    aria-controls="report-settings"
+  >
+    Settings
+  </button>
+  <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
+    <form method="dialog">
+      <div class="theme-settings-header">
+        <h2 id="report-settings-title">Report settings</h2>
+        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+      </div>
+      <div class="theme-controls" aria-label="Report display settings">
+        <label>
+          <span>Style</span>
+          <select data-theme-control="theme" aria-label="Report visual style">
+            <option value="aurora-blueprint">Aurora Blueprint</option>
+            <option value="aurora">Aurora Mesh</option>
+            <option value="signal">Signal Stripe</option>
+          </select>
+        </label>
+        <label>
+          <span>Mode</span>
+          <select data-theme-control="mode" aria-label="Report color mode">
+            <option value="system">System</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </div>
+      <div class="theme-settings-actions">
+        <button type="submit" value="close">Done</button>
+      </div>
+    </form>
+  </dialog>
 </div>
   <nav class="toc">
   <h2>Contents</h2>

--- a/reports/2026-07-19.html
+++ b/reports/2026-07-19.html
@@ -55,6 +55,23 @@
   function bindControls() {
     if (controlsBound) return;
     controlsBound = true;
+    var settingsDialog = document.getElementById("report-settings");
+    document.querySelectorAll("[data-theme-settings-open]").forEach(function (control) {
+      control.addEventListener("click", function () {
+        if (settingsDialog && typeof settingsDialog.showModal === "function") {
+          settingsDialog.showModal();
+        } else if (settingsDialog) {
+          settingsDialog.setAttribute("open", "");
+        }
+      });
+    });
+    if (settingsDialog) {
+      settingsDialog.addEventListener("click", function (event) {
+        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
+          settingsDialog.close();
+        }
+      });
+    }
     document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
       control.addEventListener("change", function (event) {
         apply(event.target.value, root.dataset.mode || "system", true);
@@ -91,23 +108,45 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-19"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-19</h1>
 </header>
-  <div class="theme-controls" aria-label="Report display settings">
-  <label>
-    <span>Style</span>
-    <select data-theme-control="theme" aria-label="Report visual style">
-      <option value="aurora-blueprint">Aurora Blueprint</option>
-      <option value="aurora">Aurora Mesh</option>
-      <option value="signal">Signal Stripe</option>
-    </select>
-  </label>
-  <label>
-    <span>Mode</span>
-    <select data-theme-control="mode" aria-label="Report color mode">
-      <option value="system">System</option>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
-    </select>
-  </label>
+  <div class="theme-settings">
+  <button
+    class="settings-button"
+    type="button"
+    data-theme-settings-open
+    aria-haspopup="dialog"
+    aria-controls="report-settings"
+  >
+    Settings
+  </button>
+  <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
+    <form method="dialog">
+      <div class="theme-settings-header">
+        <h2 id="report-settings-title">Report settings</h2>
+        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+      </div>
+      <div class="theme-controls" aria-label="Report display settings">
+        <label>
+          <span>Style</span>
+          <select data-theme-control="theme" aria-label="Report visual style">
+            <option value="aurora-blueprint">Aurora Blueprint</option>
+            <option value="aurora">Aurora Mesh</option>
+            <option value="signal">Signal Stripe</option>
+          </select>
+        </label>
+        <label>
+          <span>Mode</span>
+          <select data-theme-control="mode" aria-label="Report color mode">
+            <option value="system">System</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </div>
+      <div class="theme-settings-actions">
+        <button type="submit" value="close">Done</button>
+      </div>
+    </form>
+  </dialog>
 </div>
   <nav class="toc">
   <h2>Contents</h2>

--- a/reports/2026-07-26.html
+++ b/reports/2026-07-26.html
@@ -55,6 +55,23 @@
   function bindControls() {
     if (controlsBound) return;
     controlsBound = true;
+    var settingsDialog = document.getElementById("report-settings");
+    document.querySelectorAll("[data-theme-settings-open]").forEach(function (control) {
+      control.addEventListener("click", function () {
+        if (settingsDialog && typeof settingsDialog.showModal === "function") {
+          settingsDialog.showModal();
+        } else if (settingsDialog) {
+          settingsDialog.setAttribute("open", "");
+        }
+      });
+    });
+    if (settingsDialog) {
+      settingsDialog.addEventListener("click", function (event) {
+        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
+          settingsDialog.close();
+        }
+      });
+    }
     document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
       control.addEventListener("change", function (event) {
         apply(event.target.value, root.dataset.mode || "system", true);
@@ -91,23 +108,45 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-26"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-26</h1>
 </header>
-  <div class="theme-controls" aria-label="Report display settings">
-  <label>
-    <span>Style</span>
-    <select data-theme-control="theme" aria-label="Report visual style">
-      <option value="aurora-blueprint">Aurora Blueprint</option>
-      <option value="aurora">Aurora Mesh</option>
-      <option value="signal">Signal Stripe</option>
-    </select>
-  </label>
-  <label>
-    <span>Mode</span>
-    <select data-theme-control="mode" aria-label="Report color mode">
-      <option value="system">System</option>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
-    </select>
-  </label>
+  <div class="theme-settings">
+  <button
+    class="settings-button"
+    type="button"
+    data-theme-settings-open
+    aria-haspopup="dialog"
+    aria-controls="report-settings"
+  >
+    Settings
+  </button>
+  <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
+    <form method="dialog">
+      <div class="theme-settings-header">
+        <h2 id="report-settings-title">Report settings</h2>
+        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+      </div>
+      <div class="theme-controls" aria-label="Report display settings">
+        <label>
+          <span>Style</span>
+          <select data-theme-control="theme" aria-label="Report visual style">
+            <option value="aurora-blueprint">Aurora Blueprint</option>
+            <option value="aurora">Aurora Mesh</option>
+            <option value="signal">Signal Stripe</option>
+          </select>
+        </label>
+        <label>
+          <span>Mode</span>
+          <select data-theme-control="mode" aria-label="Report color mode">
+            <option value="system">System</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </div>
+      <div class="theme-settings-actions">
+        <button type="submit" value="close">Done</button>
+      </div>
+    </form>
+  </dialog>
 </div>
   <nav class="toc">
   <h2>Contents</h2>

--- a/reports/2026-08-03.html
+++ b/reports/2026-08-03.html
@@ -55,6 +55,23 @@
   function bindControls() {
     if (controlsBound) return;
     controlsBound = true;
+    var settingsDialog = document.getElementById("report-settings");
+    document.querySelectorAll("[data-theme-settings-open]").forEach(function (control) {
+      control.addEventListener("click", function () {
+        if (settingsDialog && typeof settingsDialog.showModal === "function") {
+          settingsDialog.showModal();
+        } else if (settingsDialog) {
+          settingsDialog.setAttribute("open", "");
+        }
+      });
+    });
+    if (settingsDialog) {
+      settingsDialog.addEventListener("click", function (event) {
+        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
+          settingsDialog.close();
+        }
+      });
+    }
     document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
       control.addEventListener("change", function (event) {
         apply(event.target.value, root.dataset.mode || "system", true);
@@ -91,23 +108,45 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-08-03"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-08-03</h1>
 </header>
-  <div class="theme-controls" aria-label="Report display settings">
-  <label>
-    <span>Style</span>
-    <select data-theme-control="theme" aria-label="Report visual style">
-      <option value="aurora-blueprint">Aurora Blueprint</option>
-      <option value="aurora">Aurora Mesh</option>
-      <option value="signal">Signal Stripe</option>
-    </select>
-  </label>
-  <label>
-    <span>Mode</span>
-    <select data-theme-control="mode" aria-label="Report color mode">
-      <option value="system">System</option>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
-    </select>
-  </label>
+  <div class="theme-settings">
+  <button
+    class="settings-button"
+    type="button"
+    data-theme-settings-open
+    aria-haspopup="dialog"
+    aria-controls="report-settings"
+  >
+    Settings
+  </button>
+  <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
+    <form method="dialog">
+      <div class="theme-settings-header">
+        <h2 id="report-settings-title">Report settings</h2>
+        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+      </div>
+      <div class="theme-controls" aria-label="Report display settings">
+        <label>
+          <span>Style</span>
+          <select data-theme-control="theme" aria-label="Report visual style">
+            <option value="aurora-blueprint">Aurora Blueprint</option>
+            <option value="aurora">Aurora Mesh</option>
+            <option value="signal">Signal Stripe</option>
+          </select>
+        </label>
+        <label>
+          <span>Mode</span>
+          <select data-theme-control="mode" aria-label="Report color mode">
+            <option value="system">System</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </div>
+      <div class="theme-settings-actions">
+        <button type="submit" value="close">Done</button>
+      </div>
+    </form>
+  </dialog>
 </div>
   <nav class="toc">
   <h2>Contents</h2>

--- a/reports/2026-08-10.html
+++ b/reports/2026-08-10.html
@@ -55,6 +55,23 @@
   function bindControls() {
     if (controlsBound) return;
     controlsBound = true;
+    var settingsDialog = document.getElementById("report-settings");
+    document.querySelectorAll("[data-theme-settings-open]").forEach(function (control) {
+      control.addEventListener("click", function () {
+        if (settingsDialog && typeof settingsDialog.showModal === "function") {
+          settingsDialog.showModal();
+        } else if (settingsDialog) {
+          settingsDialog.setAttribute("open", "");
+        }
+      });
+    });
+    if (settingsDialog) {
+      settingsDialog.addEventListener("click", function (event) {
+        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
+          settingsDialog.close();
+        }
+      });
+    }
     document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
       control.addEventListener("change", function (event) {
         apply(event.target.value, root.dataset.mode || "system", true);
@@ -91,23 +108,45 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-08-10"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-08-10</h1>
 </header>
-  <div class="theme-controls" aria-label="Report display settings">
-  <label>
-    <span>Style</span>
-    <select data-theme-control="theme" aria-label="Report visual style">
-      <option value="aurora-blueprint">Aurora Blueprint</option>
-      <option value="aurora">Aurora Mesh</option>
-      <option value="signal">Signal Stripe</option>
-    </select>
-  </label>
-  <label>
-    <span>Mode</span>
-    <select data-theme-control="mode" aria-label="Report color mode">
-      <option value="system">System</option>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
-    </select>
-  </label>
+  <div class="theme-settings">
+  <button
+    class="settings-button"
+    type="button"
+    data-theme-settings-open
+    aria-haspopup="dialog"
+    aria-controls="report-settings"
+  >
+    Settings
+  </button>
+  <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
+    <form method="dialog">
+      <div class="theme-settings-header">
+        <h2 id="report-settings-title">Report settings</h2>
+        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+      </div>
+      <div class="theme-controls" aria-label="Report display settings">
+        <label>
+          <span>Style</span>
+          <select data-theme-control="theme" aria-label="Report visual style">
+            <option value="aurora-blueprint">Aurora Blueprint</option>
+            <option value="aurora">Aurora Mesh</option>
+            <option value="signal">Signal Stripe</option>
+          </select>
+        </label>
+        <label>
+          <span>Mode</span>
+          <select data-theme-control="mode" aria-label="Report color mode">
+            <option value="system">System</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </div>
+      <div class="theme-settings-actions">
+        <button type="submit" value="close">Done</button>
+      </div>
+    </form>
+  </dialog>
 </div>
   <nav class="toc">
   <h2>Contents</h2>

--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -200,16 +200,19 @@ details.article-inventory ol {
 }
 
 .report-card-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+  align-items: stretch;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .report-card {
   border: 1px solid #e0e0e0;
   border-radius: 6px;
   color: inherit;
-  display: block;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   padding: 1rem 1.25rem;
   text-decoration: none;
   transition: background-color 0.15s;
@@ -412,21 +415,88 @@ details.article-inventory {
   color: var(--accent);
 }
 
-.theme-controls {
-  align-items: end;
+.theme-settings {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
   justify-content: flex-end;
   margin: -0.5rem 0 1.5rem;
 }
 
-.theme-controls label {
+.settings-button,
+.theme-settings-actions button {
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 5px;
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.85rem;
+  min-height: 2.25rem;
+  padding: 0.35rem 0.75rem;
+}
+
+.settings-button:hover,
+.theme-settings-actions button:hover {
+  border-color: var(--accent);
+}
+
+.settings-button:focus-visible,
+.theme-settings-close:focus-visible,
+.theme-settings-actions button:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  outline-offset: 2px;
+}
+
+.theme-settings-dialog {
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  color: var(--text);
+  max-width: min(28rem, calc(100vw - 2rem));
+  padding: 0;
+  width: 100%;
+}
+
+.theme-settings-dialog::backdrop {
+  background: rgba(8, 15, 22, 0.58);
+}
+
+.theme-settings-dialog form {
+  padding: 1.25rem;
+}
+
+.theme-settings-header {
   align-items: center;
-  color: var(--muted);
   display: flex;
-  font-size: 0.75rem;
-  gap: 0.4rem;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.theme-settings-header h2 {
+  font-size: 1.2rem;
+  margin: 0;
+  padding: 0;
+}
+
+.theme-settings-close {
+  background: transparent;
+  border: 0;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0.15rem 0.35rem;
+}
+
+.theme-controls {
+  display: grid;
+  gap: 1rem;
+}
+
+.theme-controls label {
+  color: var(--muted);
+  display: grid;
+  font-size: 0.8rem;
+  gap: 0.35rem;
 }
 
 .theme-controls select {
@@ -445,13 +515,24 @@ details.article-inventory {
   outline-offset: 2px;
 }
 
+.theme-settings-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1.25rem;
+}
+
 @media (max-width: 560px) {
-  .theme-controls {
-    justify-content: flex-start;
+  .report-card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .theme-controls label {
-    align-items: flex-start;
-    flex-direction: column;
+  .theme-settings {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 400px) {
+  .report-card-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/reports/index.html
+++ b/reports/index.html
@@ -55,6 +55,23 @@
   function bindControls() {
     if (controlsBound) return;
     controlsBound = true;
+    var settingsDialog = document.getElementById("report-settings");
+    document.querySelectorAll("[data-theme-settings-open]").forEach(function (control) {
+      control.addEventListener("click", function () {
+        if (settingsDialog && typeof settingsDialog.showModal === "function") {
+          settingsDialog.showModal();
+        } else if (settingsDialog) {
+          settingsDialog.setAttribute("open", "");
+        }
+      });
+    });
+    if (settingsDialog) {
+      settingsDialog.addEventListener("click", function (event) {
+        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
+          settingsDialog.close();
+        }
+      });
+    }
     document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
       control.addEventListener("change", function (event) {
         apply(event.target.value, root.dataset.mode || "system", true);
@@ -91,23 +108,45 @@
     <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
     <h1>WP Trend Watcher — Reports</h1>
   </header>
-  <div class="theme-controls" aria-label="Report display settings">
-  <label>
-    <span>Style</span>
-    <select data-theme-control="theme" aria-label="Report visual style">
-      <option value="aurora-blueprint">Aurora Blueprint</option>
-      <option value="aurora">Aurora Mesh</option>
-      <option value="signal">Signal Stripe</option>
-    </select>
-  </label>
-  <label>
-    <span>Mode</span>
-    <select data-theme-control="mode" aria-label="Report color mode">
-      <option value="system">System</option>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
-    </select>
-  </label>
+  <div class="theme-settings">
+  <button
+    class="settings-button"
+    type="button"
+    data-theme-settings-open
+    aria-haspopup="dialog"
+    aria-controls="report-settings"
+  >
+    Settings
+  </button>
+  <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
+    <form method="dialog">
+      <div class="theme-settings-header">
+        <h2 id="report-settings-title">Report settings</h2>
+        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+      </div>
+      <div class="theme-controls" aria-label="Report display settings">
+        <label>
+          <span>Style</span>
+          <select data-theme-control="theme" aria-label="Report visual style">
+            <option value="aurora-blueprint">Aurora Blueprint</option>
+            <option value="aurora">Aurora Mesh</option>
+            <option value="signal">Signal Stripe</option>
+          </select>
+        </label>
+        <label>
+          <span>Mode</span>
+          <select data-theme-control="mode" aria-label="Report color mode">
+            <option value="system">System</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </div>
+      <div class="theme-settings-actions">
+        <button type="submit" value="close">Done</button>
+      </div>
+    </form>
+  </dialog>
 </div>
   <p class="meta">9 weekly WordPress ecosystem trend reports.</p>
   <div class="report-card-grid">

--- a/src/summarize/html.ts
+++ b/src/summarize/html.ts
@@ -39,23 +39,45 @@ const GITHUB_REPO_URL = "https://github.com/colorful-tones/wp-trend-watcher";
 const DEFAULT_REPORT_THEME = "aurora-blueprint";
 const DEFAULT_REPORT_MODE = "system";
 
-const REPORT_THEME_CONTROLS = `<div class="theme-controls" aria-label="Report display settings">
-  <label>
-    <span>Style</span>
-    <select data-theme-control="theme" aria-label="Report visual style">
-      <option value="aurora-blueprint">Aurora Blueprint</option>
-      <option value="aurora">Aurora Mesh</option>
-      <option value="signal">Signal Stripe</option>
-    </select>
-  </label>
-  <label>
-    <span>Mode</span>
-    <select data-theme-control="mode" aria-label="Report color mode">
-      <option value="system">System</option>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
-    </select>
-  </label>
+const REPORT_THEME_CONTROLS = `<div class="theme-settings">
+  <button
+    class="settings-button"
+    type="button"
+    data-theme-settings-open
+    aria-haspopup="dialog"
+    aria-controls="report-settings"
+  >
+    Settings
+  </button>
+  <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
+    <form method="dialog">
+      <div class="theme-settings-header">
+        <h2 id="report-settings-title">Report settings</h2>
+        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+      </div>
+      <div class="theme-controls" aria-label="Report display settings">
+        <label>
+          <span>Style</span>
+          <select data-theme-control="theme" aria-label="Report visual style">
+            <option value="aurora-blueprint">Aurora Blueprint</option>
+            <option value="aurora">Aurora Mesh</option>
+            <option value="signal">Signal Stripe</option>
+          </select>
+        </label>
+        <label>
+          <span>Mode</span>
+          <select data-theme-control="mode" aria-label="Report color mode">
+            <option value="system">System</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </div>
+      <div class="theme-settings-actions">
+        <button type="submit" value="close">Done</button>
+      </div>
+    </form>
+  </dialog>
 </div>`;
 
 const REPORT_THEME_SCRIPT = `<script>
@@ -108,6 +130,23 @@ const REPORT_THEME_SCRIPT = `<script>
   function bindControls() {
     if (controlsBound) return;
     controlsBound = true;
+    var settingsDialog = document.getElementById("report-settings");
+    document.querySelectorAll("[data-theme-settings-open]").forEach(function (control) {
+      control.addEventListener("click", function () {
+        if (settingsDialog && typeof settingsDialog.showModal === "function") {
+          settingsDialog.showModal();
+        } else if (settingsDialog) {
+          settingsDialog.setAttribute("open", "");
+        }
+      });
+    });
+    if (settingsDialog) {
+      settingsDialog.addEventListener("click", function (event) {
+        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
+          settingsDialog.close();
+        }
+      });
+    }
     document.querySelectorAll("[data-theme-control='theme']").forEach(function (control) {
       control.addEventListener("change", function (event) {
         apply(event.target.value, root.dataset.mode || "${DEFAULT_REPORT_MODE}", true);

--- a/src/summarize/html.ts
+++ b/src/summarize/html.ts
@@ -50,10 +50,10 @@ const REPORT_THEME_CONTROLS = `<div class="theme-settings">
     Settings
   </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <form method="dialog">
+    <div>
       <div class="theme-settings-header">
         <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
       </div>
       <div class="theme-controls" aria-label="Report display settings">
         <label>
@@ -74,9 +74,9 @@ const REPORT_THEME_CONTROLS = `<div class="theme-settings">
         </label>
       </div>
       <div class="theme-settings-actions">
-        <button type="submit" value="close">Done</button>
+        <button type="button" data-theme-settings-close>Done</button>
       </div>
-    </form>
+    </div>
   </dialog>
 </div>`;
 
@@ -140,10 +140,21 @@ const REPORT_THEME_SCRIPT = `<script>
         }
       });
     });
+    function closeDialog() {
+      if (!settingsDialog) return;
+      if (typeof settingsDialog.close === "function") {
+        settingsDialog.close();
+      } else {
+        settingsDialog.removeAttribute("open");
+      }
+    }
+    document.querySelectorAll("[data-theme-settings-close]").forEach(function (control) {
+      control.addEventListener("click", closeDialog);
+    });
     if (settingsDialog) {
       settingsDialog.addEventListener("click", function (event) {
-        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
-          settingsDialog.close();
+        if (event.target === settingsDialog) {
+          closeDialog();
         }
       });
     }

--- a/src/summarize/report.css
+++ b/src/summarize/report.css
@@ -200,16 +200,19 @@ details.article-inventory ol {
 }
 
 .report-card-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+  align-items: stretch;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .report-card {
   border: 1px solid #e0e0e0;
   border-radius: 6px;
   color: inherit;
-  display: block;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   padding: 1rem 1.25rem;
   text-decoration: none;
   transition: background-color 0.15s;
@@ -412,21 +415,88 @@ details.article-inventory {
   color: var(--accent);
 }
 
-.theme-controls {
-  align-items: end;
+.theme-settings {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
   justify-content: flex-end;
   margin: -0.5rem 0 1.5rem;
 }
 
-.theme-controls label {
+.settings-button,
+.theme-settings-actions button {
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 5px;
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.85rem;
+  min-height: 2.25rem;
+  padding: 0.35rem 0.75rem;
+}
+
+.settings-button:hover,
+.theme-settings-actions button:hover {
+  border-color: var(--accent);
+}
+
+.settings-button:focus-visible,
+.theme-settings-close:focus-visible,
+.theme-settings-actions button:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  outline-offset: 2px;
+}
+
+.theme-settings-dialog {
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  color: var(--text);
+  max-width: min(28rem, calc(100vw - 2rem));
+  padding: 0;
+  width: 100%;
+}
+
+.theme-settings-dialog::backdrop {
+  background: rgba(8, 15, 22, 0.58);
+}
+
+.theme-settings-dialog form {
+  padding: 1.25rem;
+}
+
+.theme-settings-header {
   align-items: center;
-  color: var(--muted);
   display: flex;
-  font-size: 0.75rem;
-  gap: 0.4rem;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.theme-settings-header h2 {
+  font-size: 1.2rem;
+  margin: 0;
+  padding: 0;
+}
+
+.theme-settings-close {
+  background: transparent;
+  border: 0;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0.15rem 0.35rem;
+}
+
+.theme-controls {
+  display: grid;
+  gap: 1rem;
+}
+
+.theme-controls label {
+  color: var(--muted);
+  display: grid;
+  font-size: 0.8rem;
+  gap: 0.35rem;
 }
 
 .theme-controls select {
@@ -445,13 +515,24 @@ details.article-inventory {
   outline-offset: 2px;
 }
 
+.theme-settings-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1.25rem;
+}
+
 @media (max-width: 560px) {
-  .theme-controls {
-    justify-content: flex-start;
+  .report-card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .theme-controls label {
-    align-items: flex-start;
-    flex-direction: column;
+  .theme-settings {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 400px) {
+  .report-card-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/tests/summarize/html.test.ts
+++ b/tests/summarize/html.test.ts
@@ -319,6 +319,8 @@ test("generateHtmlReport links a shared external stylesheet", async () => {
   assert.ok(!html.includes("<style>"));
   assert.ok(html.includes('data-theme-control="theme"'));
   assert.ok(html.includes('data-theme-control="mode"'));
+  assert.ok(html.includes("data-theme-settings-open"));
+  assert.ok(html.includes('<dialog class="theme-settings-dialog"'));
   assert.ok(html.includes("wp-trend-watcher-theme"));
   assert.ok(css.includes(".report-header"));
   assert.ok(css.includes("repeating-linear-gradient(to bottom"));
@@ -338,7 +340,10 @@ test("generateIndexPage links a shared external stylesheet", async () => {
   assert.ok(!html.includes("<style>"));
   assert.ok(html.includes('data-theme-control="theme"'));
   assert.ok(html.includes('data-theme-control="mode"'));
+  assert.ok(html.includes("data-theme-settings-open"));
+  assert.ok(html.includes('<dialog class="theme-settings-dialog"'));
   assert.ok(css.includes(".report-index h1"));
+  assert.ok(css.includes("grid-template-columns: repeat(3"));
 });
 
 test("ensureReportStylesheet copies the Radio Canada font into assets/", async () => {


### PR DESCRIPTION
## Summary

- Change the report index to a responsive three-column card grid on desktop.
- Keep cards equal-height within each grid row, with responsive two-column and one-column fallbacks.
- Move Style and Mode controls into an accessible native Settings dialog on the index and individual reports.
- Preserve localStorage persistence and no-flash theme initialization.

## Verification

- [x] `pnpm run regen-html`
- [x] `pnpm run test` — 201 tests passed
- [x] `pnpm run typecheck`
- [x] `git diff --check`
- [x] Browser-checked desktop grid, equal-height cards, modal open/close behavior, and theme controls

## Review focus

- Confirm the three-column layout feels appropriate for the current report count.
- Check the native dialog behavior and responsive settings layout.
- Confirm the modal remains readable across the existing visual themes and color modes.