### PR TITLE
fix(reports): center settings dialog

### DIFF
--- a/reports/2026-06-12.html
+++ b/reports/2026-06-12.html
@@ -65,10 +65,21 @@
         }
       });
     });
+    function closeDialog() {
+      if (!settingsDialog) return;
+      if (typeof settingsDialog.close === "function") {
+        settingsDialog.close();
+      } else {
+        settingsDialog.removeAttribute("open");
+      }
+    }
+    document.querySelectorAll("[data-theme-settings-close]").forEach(function (control) {
+      control.addEventListener("click", closeDialog);
+    });
     if (settingsDialog) {
       settingsDialog.addEventListener("click", function (event) {
-        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
-          settingsDialog.close();
+        if (event.target === settingsDialog) {
+          closeDialog();
         }
       });
     }
@@ -119,10 +130,10 @@
     Settings
   </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <form method="dialog">
+    <div>
       <div class="theme-settings-header">
         <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
       </div>
       <div class="theme-controls" aria-label="Report display settings">
         <label>
@@ -143,9 +154,9 @@
         </label>
       </div>
       <div class="theme-settings-actions">
-        <button type="submit" value="close">Done</button>
+        <button type="button" data-theme-settings-close>Done</button>
       </div>
-    </form>
+    </div>
   </dialog>
 </div>
   <nav class="toc">

--- a/reports/2026-06-21.html
+++ b/reports/2026-06-21.html
@@ -65,10 +65,21 @@
         }
       });
     });
+    function closeDialog() {
+      if (!settingsDialog) return;
+      if (typeof settingsDialog.close === "function") {
+        settingsDialog.close();
+      } else {
+        settingsDialog.removeAttribute("open");
+      }
+    }
+    document.querySelectorAll("[data-theme-settings-close]").forEach(function (control) {
+      control.addEventListener("click", closeDialog);
+    });
     if (settingsDialog) {
       settingsDialog.addEventListener("click", function (event) {
-        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
-          settingsDialog.close();
+        if (event.target === settingsDialog) {
+          closeDialog();
         }
       });
     }
@@ -119,10 +130,10 @@
     Settings
   </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <form method="dialog">
+    <div>
       <div class="theme-settings-header">
         <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
       </div>
       <div class="theme-controls" aria-label="Report display settings">
         <label>
@@ -143,9 +154,9 @@
         </label>
       </div>
       <div class="theme-settings-actions">
-        <button type="submit" value="close">Done</button>
+        <button type="button" data-theme-settings-close>Done</button>
       </div>
-    </form>
+    </div>
   </dialog>
 </div>
   <nav class="toc">

--- a/reports/2026-06-27.html
+++ b/reports/2026-06-27.html
@@ -65,10 +65,21 @@
         }
       });
     });
+    function closeDialog() {
+      if (!settingsDialog) return;
+      if (typeof settingsDialog.close === "function") {
+        settingsDialog.close();
+      } else {
+        settingsDialog.removeAttribute("open");
+      }
+    }
+    document.querySelectorAll("[data-theme-settings-close]").forEach(function (control) {
+      control.addEventListener("click", closeDialog);
+    });
     if (settingsDialog) {
       settingsDialog.addEventListener("click", function (event) {
-        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
-          settingsDialog.close();
+        if (event.target === settingsDialog) {
+          closeDialog();
         }
       });
     }
@@ -119,10 +130,10 @@
     Settings
   </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <form method="dialog">
+    <div>
       <div class="theme-settings-header">
         <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
       </div>
       <div class="theme-controls" aria-label="Report display settings">
         <label>
@@ -143,9 +154,9 @@
         </label>
       </div>
       <div class="theme-settings-actions">
-        <button type="submit" value="close">Done</button>
+        <button type="button" data-theme-settings-close>Done</button>
       </div>
-    </form>
+    </div>
   </dialog>
 </div>
   <nav class="toc">

--- a/reports/2026-07-05.html
+++ b/reports/2026-07-05.html
@@ -65,10 +65,21 @@
         }
       });
     });
+    function closeDialog() {
+      if (!settingsDialog) return;
+      if (typeof settingsDialog.close === "function") {
+        settingsDialog.close();
+      } else {
+        settingsDialog.removeAttribute("open");
+      }
+    }
+    document.querySelectorAll("[data-theme-settings-close]").forEach(function (control) {
+      control.addEventListener("click", closeDialog);
+    });
     if (settingsDialog) {
       settingsDialog.addEventListener("click", function (event) {
-        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
-          settingsDialog.close();
+        if (event.target === settingsDialog) {
+          closeDialog();
         }
       });
     }
@@ -119,10 +130,10 @@
     Settings
   </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <form method="dialog">
+    <div>
       <div class="theme-settings-header">
         <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
       </div>
       <div class="theme-controls" aria-label="Report display settings">
         <label>
@@ -143,9 +154,9 @@
         </label>
       </div>
       <div class="theme-settings-actions">
-        <button type="submit" value="close">Done</button>
+        <button type="button" data-theme-settings-close>Done</button>
       </div>
-    </form>
+    </div>
   </dialog>
 </div>
   <nav class="toc">

--- a/reports/2026-07-11.html
+++ b/reports/2026-07-11.html
@@ -65,10 +65,21 @@
         }
       });
     });
+    function closeDialog() {
+      if (!settingsDialog) return;
+      if (typeof settingsDialog.close === "function") {
+        settingsDialog.close();
+      } else {
+        settingsDialog.removeAttribute("open");
+      }
+    }
+    document.querySelectorAll("[data-theme-settings-close]").forEach(function (control) {
+      control.addEventListener("click", closeDialog);
+    });
     if (settingsDialog) {
       settingsDialog.addEventListener("click", function (event) {
-        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
-          settingsDialog.close();
+        if (event.target === settingsDialog) {
+          closeDialog();
         }
       });
     }
@@ -119,10 +130,10 @@
     Settings
   </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <form method="dialog">
+    <div>
       <div class="theme-settings-header">
         <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
       </div>
       <div class="theme-controls" aria-label="Report display settings">
         <label>
@@ -143,9 +154,9 @@
         </label>
       </div>
       <div class="theme-settings-actions">
-        <button type="submit" value="close">Done</button>
+        <button type="button" data-theme-settings-close>Done</button>
       </div>
-    </form>
+    </div>
   </dialog>
 </div>
   <nav class="toc">

--- a/reports/2026-07-19.html
+++ b/reports/2026-07-19.html
@@ -65,10 +65,21 @@
         }
       });
     });
+    function closeDialog() {
+      if (!settingsDialog) return;
+      if (typeof settingsDialog.close === "function") {
+        settingsDialog.close();
+      } else {
+        settingsDialog.removeAttribute("open");
+      }
+    }
+    document.querySelectorAll("[data-theme-settings-close]").forEach(function (control) {
+      control.addEventListener("click", closeDialog);
+    });
     if (settingsDialog) {
       settingsDialog.addEventListener("click", function (event) {
-        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
-          settingsDialog.close();
+        if (event.target === settingsDialog) {
+          closeDialog();
         }
       });
     }
@@ -119,10 +130,10 @@
     Settings
   </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <form method="dialog">
+    <div>
       <div class="theme-settings-header">
         <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
       </div>
       <div class="theme-controls" aria-label="Report display settings">
         <label>
@@ -143,9 +154,9 @@
         </label>
       </div>
       <div class="theme-settings-actions">
-        <button type="submit" value="close">Done</button>
+        <button type="button" data-theme-settings-close>Done</button>
       </div>
-    </form>
+    </div>
   </dialog>
 </div>
   <nav class="toc">

--- a/reports/2026-07-26.html
+++ b/reports/2026-07-26.html
@@ -65,10 +65,21 @@
         }
       });
     });
+    function closeDialog() {
+      if (!settingsDialog) return;
+      if (typeof settingsDialog.close === "function") {
+        settingsDialog.close();
+      } else {
+        settingsDialog.removeAttribute("open");
+      }
+    }
+    document.querySelectorAll("[data-theme-settings-close]").forEach(function (control) {
+      control.addEventListener("click", closeDialog);
+    });
     if (settingsDialog) {
       settingsDialog.addEventListener("click", function (event) {
-        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
-          settingsDialog.close();
+        if (event.target === settingsDialog) {
+          closeDialog();
         }
       });
     }
@@ -119,10 +130,10 @@
     Settings
   </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <form method="dialog">
+    <div>
       <div class="theme-settings-header">
         <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
       </div>
       <div class="theme-controls" aria-label="Report display settings">
         <label>
@@ -143,9 +154,9 @@
         </label>
       </div>
       <div class="theme-settings-actions">
-        <button type="submit" value="close">Done</button>
+        <button type="button" data-theme-settings-close>Done</button>
       </div>
-    </form>
+    </div>
   </dialog>
 </div>
   <nav class="toc">

--- a/reports/2026-08-03.html
+++ b/reports/2026-08-03.html
@@ -65,10 +65,21 @@
         }
       });
     });
+    function closeDialog() {
+      if (!settingsDialog) return;
+      if (typeof settingsDialog.close === "function") {
+        settingsDialog.close();
+      } else {
+        settingsDialog.removeAttribute("open");
+      }
+    }
+    document.querySelectorAll("[data-theme-settings-close]").forEach(function (control) {
+      control.addEventListener("click", closeDialog);
+    });
     if (settingsDialog) {
       settingsDialog.addEventListener("click", function (event) {
-        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
-          settingsDialog.close();
+        if (event.target === settingsDialog) {
+          closeDialog();
         }
       });
     }
@@ -119,10 +130,10 @@
     Settings
   </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <form method="dialog">
+    <div>
       <div class="theme-settings-header">
         <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
       </div>
       <div class="theme-controls" aria-label="Report display settings">
         <label>
@@ -143,9 +154,9 @@
         </label>
       </div>
       <div class="theme-settings-actions">
-        <button type="submit" value="close">Done</button>
+        <button type="button" data-theme-settings-close>Done</button>
       </div>
-    </form>
+    </div>
   </dialog>
 </div>
   <nav class="toc">

--- a/reports/2026-08-10.html
+++ b/reports/2026-08-10.html
@@ -65,10 +65,21 @@
         }
       });
     });
+    function closeDialog() {
+      if (!settingsDialog) return;
+      if (typeof settingsDialog.close === "function") {
+        settingsDialog.close();
+      } else {
+        settingsDialog.removeAttribute("open");
+      }
+    }
+    document.querySelectorAll("[data-theme-settings-close]").forEach(function (control) {
+      control.addEventListener("click", closeDialog);
+    });
     if (settingsDialog) {
       settingsDialog.addEventListener("click", function (event) {
-        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
-          settingsDialog.close();
+        if (event.target === settingsDialog) {
+          closeDialog();
         }
       });
     }
@@ -119,10 +130,10 @@
     Settings
   </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <form method="dialog">
+    <div>
       <div class="theme-settings-header">
         <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
       </div>
       <div class="theme-controls" aria-label="Report display settings">
         <label>
@@ -143,9 +154,9 @@
         </label>
       </div>
       <div class="theme-settings-actions">
-        <button type="submit" value="close">Done</button>
+        <button type="button" data-theme-settings-close>Done</button>
       </div>
-    </form>
+    </div>
   </dialog>
 </div>
   <nav class="toc">

--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -450,18 +450,25 @@ details.article-inventory {
   background: var(--surface);
   border: 1px solid var(--border-strong);
   border-radius: 10px;
+  box-sizing: border-box;
   color: var(--text);
-  max-width: min(28rem, calc(100vw - 2rem));
+  height: auto;
+  left: 50%;
+  max-height: calc(100vh - 2rem);
+  max-width: calc(100vw - 2rem);
   padding: 0;
-  width: 100%;
+  position: fixed;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: min(28rem, calc(100vw - 2rem));
 }
 
 .theme-settings-dialog::backdrop {
   background: rgba(8, 15, 22, 0.58);
 }
 
-.theme-settings-dialog form {
-  padding: 1.25rem;
+.theme-settings-dialog > div {
+  padding: 1.25rem 1.5rem 1.5rem;
 }
 
 .theme-settings-header {
@@ -490,6 +497,7 @@ details.article-inventory {
 .theme-controls {
   display: grid;
   gap: 1rem;
+  padding-inline: 0.25rem;
 }
 
 .theme-controls label {
@@ -503,11 +511,13 @@ details.article-inventory {
   background: var(--surface);
   border: 1px solid var(--border-strong);
   border-radius: 5px;
+  box-sizing: border-box;
   color: var(--text);
   font: inherit;
   font-size: 0.8rem;
   min-height: 2rem;
   padding: 0.25rem 1.75rem 0.25rem 0.5rem;
+  width: 100%;
 }
 
 .theme-controls select:focus-visible {
@@ -532,6 +542,10 @@ details.article-inventory {
 }
 
 @media (max-width: 400px) {
+  .theme-settings-dialog > div {
+    padding-inline: 1rem;
+  }
+
   .report-card-grid {
     grid-template-columns: 1fr;
   }

--- a/reports/index.html
+++ b/reports/index.html
@@ -65,10 +65,21 @@
         }
       });
     });
+    function closeDialog() {
+      if (!settingsDialog) return;
+      if (typeof settingsDialog.close === "function") {
+        settingsDialog.close();
+      } else {
+        settingsDialog.removeAttribute("open");
+      }
+    }
+    document.querySelectorAll("[data-theme-settings-close]").forEach(function (control) {
+      control.addEventListener("click", closeDialog);
+    });
     if (settingsDialog) {
       settingsDialog.addEventListener("click", function (event) {
-        if (event.target === settingsDialog && typeof settingsDialog.close === "function") {
-          settingsDialog.close();
+        if (event.target === settingsDialog) {
+          closeDialog();
         }
       });
     }
@@ -119,10 +130,10 @@
     Settings
   </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <form method="dialog">
+    <div>
       <div class="theme-settings-header">
         <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="submit" value="close" aria-label="Close report settings">×</button>
+        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
       </div>
       <div class="theme-controls" aria-label="Report display settings">
         <label>
@@ -143,9 +154,9 @@
         </label>
       </div>
       <div class="theme-settings-actions">
-        <button type="submit" value="close">Done</button>
+        <button type="button" data-theme-settings-close>Done</button>
       </div>
-    </form>
+    </div>
   </dialog>
 </div>
   <p class="meta">9 weekly WordPress ecosystem trend reports.</p>

--- a/src/summarize/report.css
+++ b/src/summarize/report.css
@@ -450,18 +450,25 @@ details.article-inventory {
   background: var(--surface);
   border: 1px solid var(--border-strong);
   border-radius: 10px;
+  box-sizing: border-box;
   color: var(--text);
-  max-width: min(28rem, calc(100vw - 2rem));
+  height: auto;
+  left: 50%;
+  max-height: calc(100vh - 2rem);
+  max-width: calc(100vw - 2rem);
   padding: 0;
-  width: 100%;
+  position: fixed;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: min(28rem, calc(100vw - 2rem));
 }
 
 .theme-settings-dialog::backdrop {
   background: rgba(8, 15, 22, 0.58);
 }
 
-.theme-settings-dialog form {
-  padding: 1.25rem;
+.theme-settings-dialog > div {
+  padding: 1.25rem 1.5rem 1.5rem;
 }
 
 .theme-settings-header {
@@ -490,6 +497,7 @@ details.article-inventory {
 .theme-controls {
   display: grid;
   gap: 1rem;
+  padding-inline: 0.25rem;
 }
 
 .theme-controls label {
@@ -503,11 +511,13 @@ details.article-inventory {
   background: var(--surface);
   border: 1px solid var(--border-strong);
   border-radius: 5px;
+  box-sizing: border-box;
   color: var(--text);
   font: inherit;
   font-size: 0.8rem;
   min-height: 2rem;
   padding: 0.25rem 1.75rem 0.25rem 0.5rem;
+  width: 100%;
 }
 
 .theme-controls select:focus-visible {
@@ -532,6 +542,10 @@ details.article-inventory {
 }
 
 @media (max-width: 400px) {
+  .theme-settings-dialog > div {
+    padding-inline: 1rem;
+  }
+
   .report-card-grid {
     grid-template-columns: 1fr;
   }

--- a/tests/summarize/html.test.ts
+++ b/tests/summarize/html.test.ts
@@ -325,6 +325,9 @@ test("generateHtmlReport links a shared external stylesheet", async () => {
   assert.ok(css.includes(".report-header"));
   assert.ok(css.includes("repeating-linear-gradient(to bottom"));
   assert.ok(css.includes("background-repeat: no-repeat"));
+  assert.ok(css.includes("position: fixed"));
+  assert.ok(css.includes("width: min(28rem, calc(100vw - 2rem))"));
+  assert.ok(css.includes("padding-inline: 0.25rem"));
 });
 
 test("generateIndexPage links a shared external stylesheet", async () => {


### PR DESCRIPTION
## Summary

- Explicitly center the report Settings dialog in the viewport.
- Constrain it to a responsive maximum width and viewport-safe height.
- Add consistent horizontal padding around the dialog content and select controls.
- Keep controls full-width within the padded content area on narrow screens.

## Verification

- [x] `pnpm run regen-html`
- [x] `pnpm run test` — 201 tests passed
- [x] `pnpm run typecheck`
- [x] `git diff --check`
- [x] Browser-checked centered dialog, dimmed backdrop, select side padding, and responsive sizing

## Review focus

The previous dialog could render too close to the viewport edge and allow controls to stretch awkwardly. This change makes the positioning and content inset explicit rather than relying on native dialog defaults.