### PR TITLE
feat(reports): add generated SEO metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Individual commands remain available for diagnosis and recovery — for example,
 
 Generated report pages include Style and Mode controls for Aurora Blueprint, Aurora Mesh, and Signal Stripe, with Light, Dark, and System modes. The selected preferences are saved in the browser's local storage and reused across the report index and individual reports.
 
+Generated reports also include concise SEO metadata in the canonical Markdown source. The metadata is used for page titles, descriptions, Open Graph/Twitter cards, the visible report introduction, and report index-card summaries. If older reports do not contain generated metadata, the HTML generator uses a safe generic fallback.
+
 See [Summarization](docs/summarization.md) for provider configuration, model options, and synthesis strategy.
 
 ## Project Principles
@@ -93,6 +95,11 @@ Want to suggest a new RSS source? [Open a source suggestion issue](https://githu
 Both templates walk you through what's needed — takes about a minute.
 
 ## Changelog
+
+### 0.9.0
+
+- Added generated SEO titles and descriptions to reports, including visible report introductions and concise descriptions on index cards.
+- Reused generated metadata for report page titles, descriptions, canonical social metadata, and index-card headings.
 
 ### 0.8.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,

--- a/reports/2026-06-12.html
+++ b/reports/2026-06-12.html
@@ -119,6 +119,7 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-06-12"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-06-12</h1>
 </header>
+  <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
   <div class="theme-settings">
   <button
     class="settings-button"

--- a/reports/2026-06-21.html
+++ b/reports/2026-06-21.html
@@ -119,6 +119,7 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-06-21"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-06-21</h1>
 </header>
+  <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
   <div class="theme-settings">
   <button
     class="settings-button"

--- a/reports/2026-06-27.html
+++ b/reports/2026-06-27.html
@@ -119,6 +119,7 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-06-27"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-06-27</h1>
 </header>
+  <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
   <div class="theme-settings">
   <button
     class="settings-button"

--- a/reports/2026-07-05.html
+++ b/reports/2026-07-05.html
@@ -119,6 +119,7 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-05"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-05</h1>
 </header>
+  <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
   <div class="theme-settings">
   <button
     class="settings-button"

--- a/reports/2026-07-11.html
+++ b/reports/2026-07-11.html
@@ -119,6 +119,7 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-11"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-11</h1>
 </header>
+  <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
   <div class="theme-settings">
   <button
     class="settings-button"

--- a/reports/2026-07-19.html
+++ b/reports/2026-07-19.html
@@ -119,6 +119,7 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-19"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-19</h1>
 </header>
+  <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
   <div class="theme-settings">
   <button
     class="settings-button"

--- a/reports/2026-07-26.html
+++ b/reports/2026-07-26.html
@@ -119,6 +119,7 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-26"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-26</h1>
 </header>
+  <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
   <div class="theme-settings">
   <button
     class="settings-button"

--- a/reports/2026-08-03.html
+++ b/reports/2026-08-03.html
@@ -119,6 +119,7 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-08-03"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-08-03</h1>
 </header>
+  <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
   <div class="theme-settings">
   <button
     class="settings-button"

--- a/reports/2026-08-10.html
+++ b/reports/2026-08-10.html
@@ -119,6 +119,7 @@
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-08-10"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-08-10</h1>
 </header>
+  <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
   <div class="theme-settings">
   <button
     class="settings-button"

--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -230,6 +230,24 @@ details.article-inventory ol {
   margin-bottom: 0.15rem;
 }
 
+.report-card-title {
+  display: block;
+  font-weight: 700;
+  line-height: 1.3;
+  margin-top: 0.35rem;
+}
+
+.report-card-description {
+  color: var(--muted);
+  display: -webkit-box;
+  font-size: 0.9rem;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-height: 1.45;
+  margin-top: 0.45rem;
+  overflow: hidden;
+}
+
 .report-card-label {
   border: 1px solid #ddd;
   border-radius: 3px;
@@ -237,8 +255,17 @@ details.article-inventory ol {
   display: inline-block;
   font-size: 0.7rem;
   letter-spacing: 0.5px;
+  margin-top: auto;
   padding: 0.1em 0.5em;
   text-transform: uppercase;
+}
+
+.report-description {
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.55;
+  margin: -0.75rem 0 1.5rem;
+  max-width: 48rem;
 }
 
 /* Navigation footer */

--- a/reports/index.html
+++ b/reports/index.html
@@ -163,31 +163,49 @@
   <div class="report-card-grid">
     <a href="2026-08-10.html" class="report-card">
       <span class="report-card-date">August 10, 2026</span>
+      <span class="report-card-title">WordPress Trend Report — 2026-08-10</span>
+      <span class="report-card-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</span>
     <span class="report-card-label">Latest report</span>
     </a>
     <a href="2026-08-03.html" class="report-card">
       <span class="report-card-date">August 3, 2026</span>
+      <span class="report-card-title">WordPress Trend Report — 2026-08-03</span>
+      <span class="report-card-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</span>
     </a>
     <a href="2026-07-26.html" class="report-card">
       <span class="report-card-date">July 26, 2026</span>
+      <span class="report-card-title">WordPress Trend Report — 2026-07-26</span>
+      <span class="report-card-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</span>
     </a>
     <a href="2026-07-19.html" class="report-card">
       <span class="report-card-date">July 19, 2026</span>
+      <span class="report-card-title">WordPress Trend Report — 2026-07-19</span>
+      <span class="report-card-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</span>
     </a>
     <a href="2026-07-11.html" class="report-card">
       <span class="report-card-date">July 11, 2026</span>
+      <span class="report-card-title">WordPress Trend Report — 2026-07-11</span>
+      <span class="report-card-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</span>
     </a>
     <a href="2026-07-05.html" class="report-card">
       <span class="report-card-date">July 5, 2026</span>
+      <span class="report-card-title">WordPress Trend Report — 2026-07-05</span>
+      <span class="report-card-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</span>
     </a>
     <a href="2026-06-27.html" class="report-card">
       <span class="report-card-date">June 27, 2026</span>
+      <span class="report-card-title">WordPress Trend Report — 2026-06-27</span>
+      <span class="report-card-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</span>
     </a>
     <a href="2026-06-21.html" class="report-card">
       <span class="report-card-date">June 21, 2026</span>
+      <span class="report-card-title">WordPress Trend Report — 2026-06-21</span>
+      <span class="report-card-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</span>
     </a>
     <a href="2026-06-12.html" class="report-card">
       <span class="report-card-date">June 12, 2026</span>
+      <span class="report-card-title">WordPress Trend Report — 2026-06-12</span>
+      <span class="report-card-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</span>
     </a>
   </div>
   <footer class="nav-footer">

--- a/src/summarize/html.ts
+++ b/src/summarize/html.ts
@@ -1,6 +1,10 @@
 import { mkdir, readFile, writeFile, readdir } from "node:fs/promises";
 import { join, basename, dirname } from "node:path";
 import {
+  extractReportSeoMetadata,
+  type ReportSeoMetadata,
+} from "./report.js";
+import {
   renderMarkdown,
   renderReportBody,
   extractToc,
@@ -189,6 +193,26 @@ function dateFromFilename(filePath: string): string {
 }
 
 /**
+ * Escape text inserted into generated HTML.
+ *
+ * @param value - Text value to escape
+ * @returns HTML-safe text
+ */
+function escapeHtml(value: string): string {
+  return value.replace(
+    /[&<>"']/g,
+    (character) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      })[character]!,
+  );
+}
+
+/**
  * Build standard SEO / social-sharing meta tags for a report or index page.
  *
  * Emits a description, canonical link, Open Graph tags, and Twitter Card tags.
@@ -208,18 +232,21 @@ function buildSeoMeta(opts: {
   type: string;
 }): string {
   const image = `${SITE_BASE_URL}assets/${REPORT_OG_IMAGE_FILE}`;
+  const title = escapeHtml(opts.title);
+  const description = escapeHtml(opts.description);
+  const url = escapeHtml(opts.url);
   return [
-    `<meta name="description" content="${opts.description}">`,
-    `<link rel="canonical" href="${opts.url}">`,
+    `<meta name="description" content="${description}">`,
+    `<link rel="canonical" href="${url}">`,
     `<meta property="og:type" content="${opts.type}">`,
     `<meta property="og:site_name" content="WP Trend Watcher">`,
-    `<meta property="og:title" content="${opts.title}">`,
-    `<meta property="og:description" content="${opts.description}">`,
+    `<meta property="og:title" content="${title}">`,
+    `<meta property="og:description" content="${description}">`,
     `<meta property="og:image" content="${image}">`,
-    `<meta property="og:url" content="${opts.url}">`,
+    `<meta property="og:url" content="${url}">`,
     `<meta name="twitter:card" content="summary_large_image">`,
-    `<meta name="twitter:title" content="${opts.title}">`,
-    `<meta name="twitter:description" content="${opts.description}">`,
+    `<meta name="twitter:title" content="${title}">`,
+    `<meta name="twitter:description" content="${description}">`,
     `<meta name="twitter:image" content="${image}">`,
   ].join("\n  ");
 }
@@ -267,6 +294,10 @@ export async function generateHtmlReport(mdPath: string): Promise<string> {
   const md = await readFile(mdPath, "utf8");
   const date = dateFromFilename(mdPath);
   const stylesheetHref = await ensureReportStylesheet(dirname(mdPath));
+  const seo = extractReportSeoMetadata(md, {
+    title: `WordPress Trend Report — ${date}`,
+    description: REPORT_SEO_DESCRIPTION,
+  });
   const bodyHtml = renderReportBody(md);
 
   // Extract the h1 heading for the report header. Only the title portion
@@ -302,18 +333,19 @@ export async function generateHtmlReport(mdPath: string): Promise<string> {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>WordPress Trend Report — ${date}</title>
+  <title>${escapeHtml(seo.title)}</title>
   <link rel="stylesheet" href="${stylesheetHref}">
   ${REPORT_THEME_SCRIPT}
   ${buildSeoMeta({
-    title: `WordPress Trend Report — ${date}`,
-    description: REPORT_SEO_DESCRIPTION,
+    title: seo.title,
+    description: seo.description,
     url: `${SITE_BASE_URL}${date}.html`,
     type: "article",
   })}
 </head>
 <body class="report-page">
   ${headerHtml}
+  <p class="report-description">${escapeHtml(seo.description)}</p>
   ${REPORT_THEME_CONTROLS}
   ${tocHtml}
   <div class="report-body">
@@ -355,9 +387,23 @@ export async function generateIndexPage(reportsDir: string): Promise<string> {
       ? "1 weekly WordPress ecosystem trend report."
       : `${reportCount} weekly WordPress ecosystem trend reports.`;
 
-  const cards = htmlFiles
-    .map((f, i) => {
+  const cards = (
+    await Promise.all(
+      htmlFiles.map(async (f, i) => {
       const dateStr = f.replace(".html", "");
+      const fallback: ReportSeoMetadata = {
+        title: `WordPress Trend Report — ${dateStr}`,
+        description: REPORT_SEO_DESCRIPTION,
+      };
+      let seo = fallback;
+      try {
+        seo = extractReportSeoMetadata(
+          await readFile(join(reportsDir, `${dateStr}.md`), "utf8"),
+          fallback,
+        );
+      } catch {
+        // Older generated reports may not have a Markdown source beside them.
+      }
       // Parse YYYY-MM-DD into a Date object for locale formatting
       const [year, month, day] = dateStr.split("-").map(Number);
       const dateObj = new Date(year, month - 1, day);
@@ -371,10 +417,13 @@ export async function generateIndexPage(reportsDir: string): Promise<string> {
           ? `\n    <span class="report-card-label">Latest report</span>`
           : "";
       return `    <a href="${f}" class="report-card">
-      <span class="report-card-date">${formattedDate}</span>${labelHtml}
+      <span class="report-card-date">${formattedDate}</span>
+      <span class="report-card-title">${escapeHtml(seo.title)}</span>
+      <span class="report-card-description">${escapeHtml(seo.description)}</span>${labelHtml}
     </a>`;
-    })
-    .join("\n");
+      }),
+    )
+  ).join("\n");
 
   const indexHtml = `<!DOCTYPE html>
 <html lang="en">

--- a/src/summarize/report.css
+++ b/src/summarize/report.css
@@ -230,6 +230,24 @@ details.article-inventory ol {
   margin-bottom: 0.15rem;
 }
 
+.report-card-title {
+  display: block;
+  font-weight: 700;
+  line-height: 1.3;
+  margin-top: 0.35rem;
+}
+
+.report-card-description {
+  color: var(--muted);
+  display: -webkit-box;
+  font-size: 0.9rem;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-height: 1.45;
+  margin-top: 0.45rem;
+  overflow: hidden;
+}
+
 .report-card-label {
   border: 1px solid #ddd;
   border-radius: 3px;
@@ -237,8 +255,17 @@ details.article-inventory ol {
   display: inline-block;
   font-size: 0.7rem;
   letter-spacing: 0.5px;
+  margin-top: auto;
   padding: 0.1em 0.5em;
   text-transform: uppercase;
+}
+
+.report-description {
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.55;
+  margin: -0.75rem 0 1.5rem;
+  max-width: 48rem;
 }
 
 /* Navigation footer */

--- a/src/summarize/report.ts
+++ b/src/summarize/report.ts
@@ -222,6 +222,11 @@ export function buildReportPrompt(
 
   return `Week ending ${date}. ${summaries.length} articles from WordPress developer sources.
 
+Before the report sections, output exactly two metadata lines:
+SEO_TITLE: A concise, specific title for this week's report (50-65 characters when possible).
+SEO_DESCRIPTION: A factual one-sentence description of the week's most important signals (140-160 characters when possible).
+Use only information from the source inventory. Do not use hype or generic marketing language.
+
 ## Source Inventory
 
 Use this inventory as source material for trend and implication synthesis. The final report's Article Inventory section is assembled separately, so do not write an Article Inventory section in your response.
@@ -288,6 +293,81 @@ function stripGeneratedArticleInventory(synthesis: string): string {
     .trim();
 }
 
+/**
+ * SEO metadata stored with a generated report.
+ */
+export interface ReportSeoMetadata {
+  title: string;
+  description: string;
+}
+
+const DEFAULT_REPORT_SEO_DESCRIPTION =
+  "Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.";
+
+/**
+ * Parse the two metadata lines emitted by the report synthesis prompt.
+ *
+ * @param synthesis - Raw synthesis returned by the summarization provider
+ * @param fallbackTitle - Date-specific fallback title
+ * @returns Parsed metadata and synthesis content with metadata removed
+ */
+function parseGeneratedSeoMetadata(
+  synthesis: string,
+  fallbackTitle: string,
+): { metadata: ReportSeoMetadata; content: string } {
+  const titleMatch = synthesis.match(/^SEO_TITLE:\s*(.+)$/im);
+  const descriptionMatch = synthesis.match(/^SEO_DESCRIPTION:\s*(.+)$/im);
+  const title = sanitizeSeoValue(titleMatch?.[1] ?? fallbackTitle, 70);
+  const description = sanitizeSeoValue(
+    descriptionMatch?.[1] ?? DEFAULT_REPORT_SEO_DESCRIPTION,
+    160,
+  );
+  const content = synthesis
+    .replace(/^SEO_TITLE:\s*.+$/im, "")
+    .replace(/^SEO_DESCRIPTION:\s*.+$/im, "")
+    .trim();
+  return { metadata: { title, description }, content };
+}
+
+/**
+ * Extract SEO metadata stored in a Markdown report's leading comments.
+ *
+ * @param markdown - Markdown report source
+ * @param fallback - Metadata used when comments are absent
+ * @returns Report metadata suitable for HTML generation
+ */
+export function extractReportSeoMetadata(
+  markdown: string,
+  fallback: ReportSeoMetadata,
+): ReportSeoMetadata {
+  const titleMatch = markdown.match(/^<!-- SEO_TITLE:\s*(.*?)\s*-->$/m);
+  const descriptionMatch = markdown.match(
+    /^<!-- SEO_DESCRIPTION:\s*(.*?)\s*-->$/m,
+  );
+  return {
+    title: sanitizeSeoValue(titleMatch?.[1] ?? fallback.title, 70),
+    description: sanitizeSeoValue(
+      descriptionMatch?.[1] ?? fallback.description,
+      160,
+    ),
+  };
+}
+
+/**
+ * Normalize generated metadata for safe, compact page presentation.
+ *
+ * @param value - Candidate metadata value
+ * @param maxLength - Maximum output length
+ * @returns Single-line trimmed metadata value
+ */
+function sanitizeSeoValue(value: string, maxLength: number): string {
+  return value
+    .replace(/\s+/g, " ")
+    .replace(/--/g, "—")
+    .trim()
+    .slice(0, maxLength);
+}
+
 // --- Report assembly ---
 
 /**
@@ -327,7 +407,13 @@ export function assembleReport(
   existingReportMd?: string | null,
 ): string {
   const articleInventory = buildArticleInventorySection(summaries);
-  const synthesisWithoutInventory = stripGeneratedArticleInventory(synthesis);
+  const { metadata, content: synthesisWithoutMetadata } = parseGeneratedSeoMetadata(
+    synthesis,
+    `WordPress Trend Report — ${date}`,
+  );
+  const synthesisWithoutInventory = stripGeneratedArticleInventory(
+    synthesisWithoutMetadata,
+  );
   const weeklySummary = ensureSourceReferences(
     `## Weekly Summary\n\n${articleInventory}\n\n${synthesisWithoutInventory}`,
     articles,
@@ -387,7 +473,9 @@ export function assembleReport(
     }
   }
 
-  return `# WordPress Trend Report — ${date}
+  return `<!-- SEO_TITLE: ${metadata.title} -->
+<!-- SEO_DESCRIPTION: ${metadata.description} -->
+# WordPress Trend Report — ${date}
 
 ${weeklySummary}${sinceLastReportBlock}
 

--- a/tests/summarize/html.test.ts
+++ b/tests/summarize/html.test.ts
@@ -96,6 +96,26 @@ test("generateHtmlReport produces valid HTML with .report-header and .toc when e
   assert.ok(html.includes('<a href="#build-notes">'));
 });
 
+test("generateHtmlReport renders report SEO metadata in the head and intro", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "html-test-"));
+  const mdPath = join(tmpDir, "2026-06-21.md");
+  await writeFile(
+    mdPath,
+    "<!-- SEO_TITLE: WordPress workflow changes -->\n" +
+      "<!-- SEO_DESCRIPTION: This week's changes affect testing and client work. -->\n" +
+      "# WordPress Trend Report — 2026-06-21\n\n" +
+      "## Weekly Summary\n\nSummary here.",
+    "utf8",
+  );
+
+  const htmlPath = await generateHtmlReport(mdPath);
+  const html = await readFile(htmlPath, "utf8");
+
+  assert.ok(html.includes("<title>WordPress workflow changes</title>"));
+  assert.ok(html.includes('name="description" content="This week&#39;s changes affect testing and client work."'));
+  assert.ok(html.includes('<p class="report-description">This week&#39;s changes affect testing and client work.</p>'));
+});
+
 test("generateHtmlReport does not produce TOC when only 1 heading exists", async () => {
   const tmpDir = await mkdtemp(join(tmpdir(), "html-test-"));
   const mdPath = join(tmpDir, "2026-06-21.md");
@@ -181,6 +201,24 @@ test("generateIndexPage renders report cards sorted by date descending", async (
   assert.equal(matches[0], "2026-07-01.html");
   assert.equal(matches[1], "2026-06-21.html");
   assert.equal(matches[2], "2026-06-14.html");
+});
+
+test("generateIndexPage renders generated report titles and descriptions on cards", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "index-test-"));
+  await writeFile(join(tmpDir, "2026-07-01.html"), "<html></html>", "utf8");
+  await writeFile(
+    join(tmpDir, "2026-07-01.md"),
+    "<!-- SEO_TITLE: Block editor workflow changes -->\n" +
+      "<!-- SEO_DESCRIPTION: This week's changes affect editor testing and client delivery. -->\n" +
+      "# WordPress Trend Report — 2026-07-01\n",
+    "utf8",
+  );
+
+  const indexPath = await generateIndexPage(tmpDir);
+  const html = await readFile(indexPath, "utf8");
+
+  assert.ok(html.includes('<span class="report-card-title">Block editor workflow changes</span>'));
+  assert.ok(html.includes('<span class="report-card-description">This week&#39;s changes affect editor testing and client delivery.</span>'));
 });
 
 test("generateIndexPage marks the newest report as Latest report", async () => {

--- a/tests/summarize/report.test.ts
+++ b/tests/summarize/report.test.ts
@@ -166,6 +166,8 @@ test("buildReportPrompt includes expected section headings", () => {
   assert.ok(!prompt.includes("### Article Inventory"));
   assert.ok(prompt.includes("### Emerging Trends"));
   assert.ok(prompt.includes("### Developer Implications"));
+  assert.ok(prompt.includes("SEO_TITLE:"));
+  assert.ok(prompt.includes("SEO_DESCRIPTION:"));
 });
 
 test("buildReportPrompt truncates summaries to first sentence", () => {
@@ -263,7 +265,7 @@ test("assembleReport produces a complete Markdown report", () => {
   const summaries = [
     makeSummary({ title: "Article One" }),
   ];
-  const synthesis = "### Article Inventory\n\n1. Article One.\n\n### Emerging Trends\n\nNone this week.\n\n### Developer Implications\n\nNothing specific.";
+  const synthesis = "SEO_TITLE: WordPress workflow changes\nSEO_DESCRIPTION: This week's WordPress changes affect testing and client work.\n\n### Article Inventory\n\n1. Article One.\n\n### Emerging Trends\n\nNone this week.\n\n### Developer Implications\n\nNothing specific.";
 
   const report = assembleReport(
     "2026-06-20",
@@ -276,6 +278,9 @@ test("assembleReport produces a complete Markdown report", () => {
   );
 
   assert.ok(report.includes("# WordPress Trend Report — 2026-06-20"));
+  assert.ok(report.includes("<!-- SEO_TITLE: WordPress workflow changes -->"));
+  assert.ok(report.includes("<!-- SEO_DESCRIPTION: This week's WordPress changes affect testing and client work. -->"));
+  assert.ok(!report.includes("SEO_TITLE: WordPress workflow changes\nSEO_DESCRIPTION:"));
   assert.ok(report.includes("## Weekly Summary"));
   assert.ok(report.includes("### Article Inventory"));
   assert.ok(report.includes("### Emerging Trends"));


### PR DESCRIPTION
## Summary

- Generate concise SEO titles and descriptions as part of report synthesis.
- Store the metadata in the canonical Markdown report source.
- Use it for report titles, meta descriptions, Open Graph/Twitter metadata, and index-card content.
- Render the description below the unchanged report H1.
- Clamp index-card descriptions to preserve the equal-height responsive grid.
- Use safe generic fallbacks for older reports without metadata.

## Verification

- [x] `pnpm run regen-html`
- [x] `pnpm run test` — 203 tests passed
- [x] `pnpm run typecheck`
- [x] `git diff --check`
- [x] Browser-checked report intro and index-card layout

## Notes

This PR does not add analytics. Privacy-first analytics provider selection remains a separate follow-up.