### PR TITLE
feat(reports): polish header settings control

### DIFF
--- a/reports/2026-06-12.html
+++ b/reports/2026-06-12.html
@@ -118,48 +118,49 @@
   <header class="report-header">
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-06-12"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-06-12</h1>
+  <button
+  class="settings-button"
+  type="button"
+  data-theme-settings-open
+  aria-haspopup="dialog"
+  aria-controls="report-settings"
+  aria-label="Open report settings"
+  title="Open report settings"
+>
+  <span class="settings-icon" aria-hidden="true">⚙️</span>
+  <span class="sr-only">Settings</span>
+</button>
 </header>
   <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
-  <div class="theme-settings">
-  <button
-    class="settings-button"
-    type="button"
-    data-theme-settings-open
-    aria-haspopup="dialog"
-    aria-controls="report-settings"
-  >
-    Settings
-  </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <div>
-      <div class="theme-settings-header">
-        <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
-      </div>
-      <div class="theme-controls" aria-label="Report display settings">
-        <label>
-          <span>Style</span>
-          <select data-theme-control="theme" aria-label="Report visual style">
-            <option value="aurora-blueprint">Aurora Blueprint</option>
-            <option value="aurora">Aurora Mesh</option>
-            <option value="signal">Signal Stripe</option>
-          </select>
-        </label>
-        <label>
-          <span>Mode</span>
-          <select data-theme-control="mode" aria-label="Report color mode">
-            <option value="system">System</option>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-        </label>
-      </div>
-      <div class="theme-settings-actions">
-        <button type="button" data-theme-settings-close>Done</button>
-      </div>
+  <div>
+    <div class="theme-settings-header">
+      <h2 id="report-settings-title">Report settings</h2>
+      <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
     </div>
-  </dialog>
-</div>
+    <div class="theme-controls" aria-label="Report display settings">
+      <label>
+        <span>Style</span>
+        <select data-theme-control="theme" aria-label="Report visual style">
+          <option value="aurora-blueprint">Aurora Blueprint</option>
+          <option value="aurora">Aurora Mesh</option>
+          <option value="signal">Signal Stripe</option>
+        </select>
+      </label>
+      <label>
+        <span>Mode</span>
+        <select data-theme-control="mode" aria-label="Report color mode">
+          <option value="system">System</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
+    </div>
+    <div class="theme-settings-actions">
+      <button type="button" data-theme-settings-close>Done</button>
+    </div>
+  </div>
+</dialog>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>

--- a/reports/2026-06-21.html
+++ b/reports/2026-06-21.html
@@ -118,48 +118,49 @@
   <header class="report-header">
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-06-21"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-06-21</h1>
+  <button
+  class="settings-button"
+  type="button"
+  data-theme-settings-open
+  aria-haspopup="dialog"
+  aria-controls="report-settings"
+  aria-label="Open report settings"
+  title="Open report settings"
+>
+  <span class="settings-icon" aria-hidden="true">⚙️</span>
+  <span class="sr-only">Settings</span>
+</button>
 </header>
   <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
-  <div class="theme-settings">
-  <button
-    class="settings-button"
-    type="button"
-    data-theme-settings-open
-    aria-haspopup="dialog"
-    aria-controls="report-settings"
-  >
-    Settings
-  </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <div>
-      <div class="theme-settings-header">
-        <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
-      </div>
-      <div class="theme-controls" aria-label="Report display settings">
-        <label>
-          <span>Style</span>
-          <select data-theme-control="theme" aria-label="Report visual style">
-            <option value="aurora-blueprint">Aurora Blueprint</option>
-            <option value="aurora">Aurora Mesh</option>
-            <option value="signal">Signal Stripe</option>
-          </select>
-        </label>
-        <label>
-          <span>Mode</span>
-          <select data-theme-control="mode" aria-label="Report color mode">
-            <option value="system">System</option>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-        </label>
-      </div>
-      <div class="theme-settings-actions">
-        <button type="button" data-theme-settings-close>Done</button>
-      </div>
+  <div>
+    <div class="theme-settings-header">
+      <h2 id="report-settings-title">Report settings</h2>
+      <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
     </div>
-  </dialog>
-</div>
+    <div class="theme-controls" aria-label="Report display settings">
+      <label>
+        <span>Style</span>
+        <select data-theme-control="theme" aria-label="Report visual style">
+          <option value="aurora-blueprint">Aurora Blueprint</option>
+          <option value="aurora">Aurora Mesh</option>
+          <option value="signal">Signal Stripe</option>
+        </select>
+      </label>
+      <label>
+        <span>Mode</span>
+        <select data-theme-control="mode" aria-label="Report color mode">
+          <option value="system">System</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
+    </div>
+    <div class="theme-settings-actions">
+      <button type="button" data-theme-settings-close>Done</button>
+    </div>
+  </div>
+</dialog>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>

--- a/reports/2026-06-27.html
+++ b/reports/2026-06-27.html
@@ -118,48 +118,49 @@
   <header class="report-header">
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-06-27"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-06-27</h1>
+  <button
+  class="settings-button"
+  type="button"
+  data-theme-settings-open
+  aria-haspopup="dialog"
+  aria-controls="report-settings"
+  aria-label="Open report settings"
+  title="Open report settings"
+>
+  <span class="settings-icon" aria-hidden="true">⚙️</span>
+  <span class="sr-only">Settings</span>
+</button>
 </header>
   <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
-  <div class="theme-settings">
-  <button
-    class="settings-button"
-    type="button"
-    data-theme-settings-open
-    aria-haspopup="dialog"
-    aria-controls="report-settings"
-  >
-    Settings
-  </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <div>
-      <div class="theme-settings-header">
-        <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
-      </div>
-      <div class="theme-controls" aria-label="Report display settings">
-        <label>
-          <span>Style</span>
-          <select data-theme-control="theme" aria-label="Report visual style">
-            <option value="aurora-blueprint">Aurora Blueprint</option>
-            <option value="aurora">Aurora Mesh</option>
-            <option value="signal">Signal Stripe</option>
-          </select>
-        </label>
-        <label>
-          <span>Mode</span>
-          <select data-theme-control="mode" aria-label="Report color mode">
-            <option value="system">System</option>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-        </label>
-      </div>
-      <div class="theme-settings-actions">
-        <button type="button" data-theme-settings-close>Done</button>
-      </div>
+  <div>
+    <div class="theme-settings-header">
+      <h2 id="report-settings-title">Report settings</h2>
+      <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
     </div>
-  </dialog>
-</div>
+    <div class="theme-controls" aria-label="Report display settings">
+      <label>
+        <span>Style</span>
+        <select data-theme-control="theme" aria-label="Report visual style">
+          <option value="aurora-blueprint">Aurora Blueprint</option>
+          <option value="aurora">Aurora Mesh</option>
+          <option value="signal">Signal Stripe</option>
+        </select>
+      </label>
+      <label>
+        <span>Mode</span>
+        <select data-theme-control="mode" aria-label="Report color mode">
+          <option value="system">System</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
+    </div>
+    <div class="theme-settings-actions">
+      <button type="button" data-theme-settings-close>Done</button>
+    </div>
+  </div>
+</dialog>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>

--- a/reports/2026-07-05.html
+++ b/reports/2026-07-05.html
@@ -118,48 +118,49 @@
   <header class="report-header">
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-05"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-05</h1>
+  <button
+  class="settings-button"
+  type="button"
+  data-theme-settings-open
+  aria-haspopup="dialog"
+  aria-controls="report-settings"
+  aria-label="Open report settings"
+  title="Open report settings"
+>
+  <span class="settings-icon" aria-hidden="true">⚙️</span>
+  <span class="sr-only">Settings</span>
+</button>
 </header>
   <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
-  <div class="theme-settings">
-  <button
-    class="settings-button"
-    type="button"
-    data-theme-settings-open
-    aria-haspopup="dialog"
-    aria-controls="report-settings"
-  >
-    Settings
-  </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <div>
-      <div class="theme-settings-header">
-        <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
-      </div>
-      <div class="theme-controls" aria-label="Report display settings">
-        <label>
-          <span>Style</span>
-          <select data-theme-control="theme" aria-label="Report visual style">
-            <option value="aurora-blueprint">Aurora Blueprint</option>
-            <option value="aurora">Aurora Mesh</option>
-            <option value="signal">Signal Stripe</option>
-          </select>
-        </label>
-        <label>
-          <span>Mode</span>
-          <select data-theme-control="mode" aria-label="Report color mode">
-            <option value="system">System</option>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-        </label>
-      </div>
-      <div class="theme-settings-actions">
-        <button type="button" data-theme-settings-close>Done</button>
-      </div>
+  <div>
+    <div class="theme-settings-header">
+      <h2 id="report-settings-title">Report settings</h2>
+      <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
     </div>
-  </dialog>
-</div>
+    <div class="theme-controls" aria-label="Report display settings">
+      <label>
+        <span>Style</span>
+        <select data-theme-control="theme" aria-label="Report visual style">
+          <option value="aurora-blueprint">Aurora Blueprint</option>
+          <option value="aurora">Aurora Mesh</option>
+          <option value="signal">Signal Stripe</option>
+        </select>
+      </label>
+      <label>
+        <span>Mode</span>
+        <select data-theme-control="mode" aria-label="Report color mode">
+          <option value="system">System</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
+    </div>
+    <div class="theme-settings-actions">
+      <button type="button" data-theme-settings-close>Done</button>
+    </div>
+  </div>
+</dialog>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>

--- a/reports/2026-07-11.html
+++ b/reports/2026-07-11.html
@@ -118,48 +118,49 @@
   <header class="report-header">
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-11"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-11</h1>
+  <button
+  class="settings-button"
+  type="button"
+  data-theme-settings-open
+  aria-haspopup="dialog"
+  aria-controls="report-settings"
+  aria-label="Open report settings"
+  title="Open report settings"
+>
+  <span class="settings-icon" aria-hidden="true">⚙️</span>
+  <span class="sr-only">Settings</span>
+</button>
 </header>
   <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
-  <div class="theme-settings">
-  <button
-    class="settings-button"
-    type="button"
-    data-theme-settings-open
-    aria-haspopup="dialog"
-    aria-controls="report-settings"
-  >
-    Settings
-  </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <div>
-      <div class="theme-settings-header">
-        <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
-      </div>
-      <div class="theme-controls" aria-label="Report display settings">
-        <label>
-          <span>Style</span>
-          <select data-theme-control="theme" aria-label="Report visual style">
-            <option value="aurora-blueprint">Aurora Blueprint</option>
-            <option value="aurora">Aurora Mesh</option>
-            <option value="signal">Signal Stripe</option>
-          </select>
-        </label>
-        <label>
-          <span>Mode</span>
-          <select data-theme-control="mode" aria-label="Report color mode">
-            <option value="system">System</option>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-        </label>
-      </div>
-      <div class="theme-settings-actions">
-        <button type="button" data-theme-settings-close>Done</button>
-      </div>
+  <div>
+    <div class="theme-settings-header">
+      <h2 id="report-settings-title">Report settings</h2>
+      <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
     </div>
-  </dialog>
-</div>
+    <div class="theme-controls" aria-label="Report display settings">
+      <label>
+        <span>Style</span>
+        <select data-theme-control="theme" aria-label="Report visual style">
+          <option value="aurora-blueprint">Aurora Blueprint</option>
+          <option value="aurora">Aurora Mesh</option>
+          <option value="signal">Signal Stripe</option>
+        </select>
+      </label>
+      <label>
+        <span>Mode</span>
+        <select data-theme-control="mode" aria-label="Report color mode">
+          <option value="system">System</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
+    </div>
+    <div class="theme-settings-actions">
+      <button type="button" data-theme-settings-close>Done</button>
+    </div>
+  </div>
+</dialog>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>

--- a/reports/2026-07-19.html
+++ b/reports/2026-07-19.html
@@ -118,48 +118,49 @@
   <header class="report-header">
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-19"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-19</h1>
+  <button
+  class="settings-button"
+  type="button"
+  data-theme-settings-open
+  aria-haspopup="dialog"
+  aria-controls="report-settings"
+  aria-label="Open report settings"
+  title="Open report settings"
+>
+  <span class="settings-icon" aria-hidden="true">⚙️</span>
+  <span class="sr-only">Settings</span>
+</button>
 </header>
   <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
-  <div class="theme-settings">
-  <button
-    class="settings-button"
-    type="button"
-    data-theme-settings-open
-    aria-haspopup="dialog"
-    aria-controls="report-settings"
-  >
-    Settings
-  </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <div>
-      <div class="theme-settings-header">
-        <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
-      </div>
-      <div class="theme-controls" aria-label="Report display settings">
-        <label>
-          <span>Style</span>
-          <select data-theme-control="theme" aria-label="Report visual style">
-            <option value="aurora-blueprint">Aurora Blueprint</option>
-            <option value="aurora">Aurora Mesh</option>
-            <option value="signal">Signal Stripe</option>
-          </select>
-        </label>
-        <label>
-          <span>Mode</span>
-          <select data-theme-control="mode" aria-label="Report color mode">
-            <option value="system">System</option>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-        </label>
-      </div>
-      <div class="theme-settings-actions">
-        <button type="button" data-theme-settings-close>Done</button>
-      </div>
+  <div>
+    <div class="theme-settings-header">
+      <h2 id="report-settings-title">Report settings</h2>
+      <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
     </div>
-  </dialog>
-</div>
+    <div class="theme-controls" aria-label="Report display settings">
+      <label>
+        <span>Style</span>
+        <select data-theme-control="theme" aria-label="Report visual style">
+          <option value="aurora-blueprint">Aurora Blueprint</option>
+          <option value="aurora">Aurora Mesh</option>
+          <option value="signal">Signal Stripe</option>
+        </select>
+      </label>
+      <label>
+        <span>Mode</span>
+        <select data-theme-control="mode" aria-label="Report color mode">
+          <option value="system">System</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
+    </div>
+    <div class="theme-settings-actions">
+      <button type="button" data-theme-settings-close>Done</button>
+    </div>
+  </div>
+</dialog>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>

--- a/reports/2026-07-26.html
+++ b/reports/2026-07-26.html
@@ -118,48 +118,49 @@
   <header class="report-header">
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-07-26"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-07-26</h1>
+  <button
+  class="settings-button"
+  type="button"
+  data-theme-settings-open
+  aria-haspopup="dialog"
+  aria-controls="report-settings"
+  aria-label="Open report settings"
+  title="Open report settings"
+>
+  <span class="settings-icon" aria-hidden="true">⚙️</span>
+  <span class="sr-only">Settings</span>
+</button>
 </header>
   <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
-  <div class="theme-settings">
-  <button
-    class="settings-button"
-    type="button"
-    data-theme-settings-open
-    aria-haspopup="dialog"
-    aria-controls="report-settings"
-  >
-    Settings
-  </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <div>
-      <div class="theme-settings-header">
-        <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
-      </div>
-      <div class="theme-controls" aria-label="Report display settings">
-        <label>
-          <span>Style</span>
-          <select data-theme-control="theme" aria-label="Report visual style">
-            <option value="aurora-blueprint">Aurora Blueprint</option>
-            <option value="aurora">Aurora Mesh</option>
-            <option value="signal">Signal Stripe</option>
-          </select>
-        </label>
-        <label>
-          <span>Mode</span>
-          <select data-theme-control="mode" aria-label="Report color mode">
-            <option value="system">System</option>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-        </label>
-      </div>
-      <div class="theme-settings-actions">
-        <button type="button" data-theme-settings-close>Done</button>
-      </div>
+  <div>
+    <div class="theme-settings-header">
+      <h2 id="report-settings-title">Report settings</h2>
+      <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
     </div>
-  </dialog>
-</div>
+    <div class="theme-controls" aria-label="Report display settings">
+      <label>
+        <span>Style</span>
+        <select data-theme-control="theme" aria-label="Report visual style">
+          <option value="aurora-blueprint">Aurora Blueprint</option>
+          <option value="aurora">Aurora Mesh</option>
+          <option value="signal">Signal Stripe</option>
+        </select>
+      </label>
+      <label>
+        <span>Mode</span>
+        <select data-theme-control="mode" aria-label="Report color mode">
+          <option value="system">System</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
+    </div>
+    <div class="theme-settings-actions">
+      <button type="button" data-theme-settings-close>Done</button>
+    </div>
+  </div>
+</dialog>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>

--- a/reports/2026-08-03.html
+++ b/reports/2026-08-03.html
@@ -118,48 +118,49 @@
   <header class="report-header">
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-08-03"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-08-03</h1>
+  <button
+  class="settings-button"
+  type="button"
+  data-theme-settings-open
+  aria-haspopup="dialog"
+  aria-controls="report-settings"
+  aria-label="Open report settings"
+  title="Open report settings"
+>
+  <span class="settings-icon" aria-hidden="true">⚙️</span>
+  <span class="sr-only">Settings</span>
+</button>
 </header>
   <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
-  <div class="theme-settings">
-  <button
-    class="settings-button"
-    type="button"
-    data-theme-settings-open
-    aria-haspopup="dialog"
-    aria-controls="report-settings"
-  >
-    Settings
-  </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <div>
-      <div class="theme-settings-header">
-        <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
-      </div>
-      <div class="theme-controls" aria-label="Report display settings">
-        <label>
-          <span>Style</span>
-          <select data-theme-control="theme" aria-label="Report visual style">
-            <option value="aurora-blueprint">Aurora Blueprint</option>
-            <option value="aurora">Aurora Mesh</option>
-            <option value="signal">Signal Stripe</option>
-          </select>
-        </label>
-        <label>
-          <span>Mode</span>
-          <select data-theme-control="mode" aria-label="Report color mode">
-            <option value="system">System</option>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-        </label>
-      </div>
-      <div class="theme-settings-actions">
-        <button type="button" data-theme-settings-close>Done</button>
-      </div>
+  <div>
+    <div class="theme-settings-header">
+      <h2 id="report-settings-title">Report settings</h2>
+      <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
     </div>
-  </dialog>
-</div>
+    <div class="theme-controls" aria-label="Report display settings">
+      <label>
+        <span>Style</span>
+        <select data-theme-control="theme" aria-label="Report visual style">
+          <option value="aurora-blueprint">Aurora Blueprint</option>
+          <option value="aurora">Aurora Mesh</option>
+          <option value="signal">Signal Stripe</option>
+        </select>
+      </label>
+      <label>
+        <span>Mode</span>
+        <select data-theme-control="mode" aria-label="Report color mode">
+          <option value="system">System</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
+    </div>
+    <div class="theme-settings-actions">
+      <button type="button" data-theme-settings-close>Done</button>
+    </div>
+  </div>
+</dialog>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>

--- a/reports/2026-08-10.html
+++ b/reports/2026-08-10.html
@@ -118,48 +118,49 @@
   <header class="report-header">
   <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
   <h1 id="wordpress-trend-report-2026-08-10"><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — 2026-08-10</h1>
+  <button
+  class="settings-button"
+  type="button"
+  data-theme-settings-open
+  aria-haspopup="dialog"
+  aria-controls="report-settings"
+  aria-label="Open report settings"
+  title="Open report settings"
+>
+  <span class="settings-icon" aria-hidden="true">⚙️</span>
+  <span class="sr-only">Settings</span>
+</button>
 </header>
   <p class="report-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</p>
-  <div class="theme-settings">
-  <button
-    class="settings-button"
-    type="button"
-    data-theme-settings-open
-    aria-haspopup="dialog"
-    aria-controls="report-settings"
-  >
-    Settings
-  </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <div>
-      <div class="theme-settings-header">
-        <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
-      </div>
-      <div class="theme-controls" aria-label="Report display settings">
-        <label>
-          <span>Style</span>
-          <select data-theme-control="theme" aria-label="Report visual style">
-            <option value="aurora-blueprint">Aurora Blueprint</option>
-            <option value="aurora">Aurora Mesh</option>
-            <option value="signal">Signal Stripe</option>
-          </select>
-        </label>
-        <label>
-          <span>Mode</span>
-          <select data-theme-control="mode" aria-label="Report color mode">
-            <option value="system">System</option>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-        </label>
-      </div>
-      <div class="theme-settings-actions">
-        <button type="button" data-theme-settings-close>Done</button>
-      </div>
+  <div>
+    <div class="theme-settings-header">
+      <h2 id="report-settings-title">Report settings</h2>
+      <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
     </div>
-  </dialog>
-</div>
+    <div class="theme-controls" aria-label="Report display settings">
+      <label>
+        <span>Style</span>
+        <select data-theme-control="theme" aria-label="Report visual style">
+          <option value="aurora-blueprint">Aurora Blueprint</option>
+          <option value="aurora">Aurora Mesh</option>
+          <option value="signal">Signal Stripe</option>
+        </select>
+      </label>
+      <label>
+        <span>Mode</span>
+        <select data-theme-control="mode" aria-label="Report color mode">
+          <option value="system">System</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
+    </div>
+    <div class="theme-settings-actions">
+      <button type="button" data-theme-settings-close>Done</button>
+    </div>
+  </div>
+</dialog>
   <nav class="toc">
   <h2>Contents</h2>
   <ul>

--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -19,7 +19,7 @@ body {
   font-family: "Radio Canada", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   line-height: 1.6;
   margin: 0 auto;
-  max-width: 720px;
+  max-width: 960px;
   padding: 2rem 1.5rem;
 }
 
@@ -101,14 +101,16 @@ hr {
 
 /* Report header */
 .report-header {
-  align-items: center;
+  align-items: flex-start;
   display: flex;
   gap: 0.75rem;
+  justify-content: space-between;
   margin-bottom: 1.5rem;
 }
 
 .report-header h1 {
   border-bottom: none;
+  flex: 1;
   margin-bottom: 0.25rem;
 }
 
@@ -442,12 +444,6 @@ details.article-inventory {
   color: var(--accent);
 }
 
-.theme-settings {
-  display: flex;
-  justify-content: flex-end;
-  margin: -0.5rem 0 1.5rem;
-}
-
 .settings-button,
 .theme-settings-actions button {
   background: var(--surface);
@@ -459,6 +455,28 @@ details.article-inventory {
   font-size: 0.85rem;
   min-height: 2.25rem;
   padding: 0.35rem 0.75rem;
+}
+
+.settings-button {
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+  padding: 0.35rem 0.5rem;
+}
+
+.settings-icon {
+  display: block;
+  font-size: 1.15rem;
+  line-height: 1;
+}
+
+.sr-only {
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
 .settings-button:hover,
@@ -563,8 +581,8 @@ details.article-inventory {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .theme-settings {
-    justify-content: flex-start;
+  .report-header {
+    gap: 0.5rem;
   }
 }
 

--- a/reports/index.html
+++ b/reports/index.html
@@ -118,47 +118,48 @@
   <header class="report-header">
     <img class="report-icon" src="assets/icon.svg" alt="" width="40" height="40">
     <h1>WP Trend Watcher — Reports</h1>
+    <button
+  class="settings-button"
+  type="button"
+  data-theme-settings-open
+  aria-haspopup="dialog"
+  aria-controls="report-settings"
+  aria-label="Open report settings"
+  title="Open report settings"
+>
+  <span class="settings-icon" aria-hidden="true">⚙️</span>
+  <span class="sr-only">Settings</span>
+</button>
   </header>
-  <div class="theme-settings">
-  <button
-    class="settings-button"
-    type="button"
-    data-theme-settings-open
-    aria-haspopup="dialog"
-    aria-controls="report-settings"
-  >
-    Settings
-  </button>
   <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <div>
-      <div class="theme-settings-header">
-        <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
-      </div>
-      <div class="theme-controls" aria-label="Report display settings">
-        <label>
-          <span>Style</span>
-          <select data-theme-control="theme" aria-label="Report visual style">
-            <option value="aurora-blueprint">Aurora Blueprint</option>
-            <option value="aurora">Aurora Mesh</option>
-            <option value="signal">Signal Stripe</option>
-          </select>
-        </label>
-        <label>
-          <span>Mode</span>
-          <select data-theme-control="mode" aria-label="Report color mode">
-            <option value="system">System</option>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-        </label>
-      </div>
-      <div class="theme-settings-actions">
-        <button type="button" data-theme-settings-close>Done</button>
-      </div>
+  <div>
+    <div class="theme-settings-header">
+      <h2 id="report-settings-title">Report settings</h2>
+      <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
     </div>
-  </dialog>
-</div>
+    <div class="theme-controls" aria-label="Report display settings">
+      <label>
+        <span>Style</span>
+        <select data-theme-control="theme" aria-label="Report visual style">
+          <option value="aurora-blueprint">Aurora Blueprint</option>
+          <option value="aurora">Aurora Mesh</option>
+          <option value="signal">Signal Stripe</option>
+        </select>
+      </label>
+      <label>
+        <span>Mode</span>
+        <select data-theme-control="mode" aria-label="Report color mode">
+          <option value="system">System</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
+    </div>
+    <div class="theme-settings-actions">
+      <button type="button" data-theme-settings-close>Done</button>
+    </div>
+  </div>
+</dialog>
   <p class="meta">9 weekly WordPress ecosystem trend reports.</p>
   <div class="report-card-grid">
     <a href="2026-08-10.html" class="report-card">

--- a/src/summarize/html.ts
+++ b/src/summarize/html.ts
@@ -43,46 +43,48 @@ const GITHUB_REPO_URL = "https://github.com/colorful-tones/wp-trend-watcher";
 const DEFAULT_REPORT_THEME = "aurora-blueprint";
 const DEFAULT_REPORT_MODE = "system";
 
-const REPORT_THEME_CONTROLS = `<div class="theme-settings">
-  <button
-    class="settings-button"
-    type="button"
-    data-theme-settings-open
-    aria-haspopup="dialog"
-    aria-controls="report-settings"
-  >
-    Settings
-  </button>
-  <dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
-    <div>
-      <div class="theme-settings-header">
-        <h2 id="report-settings-title">Report settings</h2>
-        <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
-      </div>
-      <div class="theme-controls" aria-label="Report display settings">
-        <label>
-          <span>Style</span>
-          <select data-theme-control="theme" aria-label="Report visual style">
-            <option value="aurora-blueprint">Aurora Blueprint</option>
-            <option value="aurora">Aurora Mesh</option>
-            <option value="signal">Signal Stripe</option>
-          </select>
-        </label>
-        <label>
-          <span>Mode</span>
-          <select data-theme-control="mode" aria-label="Report color mode">
-            <option value="system">System</option>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-        </label>
-      </div>
-      <div class="theme-settings-actions">
-        <button type="button" data-theme-settings-close>Done</button>
-      </div>
+const REPORT_SETTINGS_BUTTON = `<button
+  class="settings-button"
+  type="button"
+  data-theme-settings-open
+  aria-haspopup="dialog"
+  aria-controls="report-settings"
+  aria-label="Open report settings"
+  title="Open report settings"
+>
+  <span class="settings-icon" aria-hidden="true">⚙️</span>
+  <span class="sr-only">Settings</span>
+</button>`;
+
+const REPORT_THEME_CONTROLS = `<dialog class="theme-settings-dialog" id="report-settings" aria-labelledby="report-settings-title">
+  <div>
+    <div class="theme-settings-header">
+      <h2 id="report-settings-title">Report settings</h2>
+      <button class="theme-settings-close" type="button" data-theme-settings-close aria-label="Close report settings">×</button>
     </div>
-  </dialog>
-</div>`;
+    <div class="theme-controls" aria-label="Report display settings">
+      <label>
+        <span>Style</span>
+        <select data-theme-control="theme" aria-label="Report visual style">
+          <option value="aurora-blueprint">Aurora Blueprint</option>
+          <option value="aurora">Aurora Mesh</option>
+          <option value="signal">Signal Stripe</option>
+        </select>
+      </label>
+      <label>
+        <span>Mode</span>
+        <select data-theme-control="mode" aria-label="Report color mode">
+          <option value="system">System</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
+    </div>
+    <div class="theme-settings-actions">
+      <button type="button" data-theme-settings-close>Done</button>
+    </div>
+  </div>
+</dialog>`;
 
 const REPORT_THEME_SCRIPT = `<script>
 (function () {
@@ -310,9 +312,9 @@ export async function generateHtmlReport(mdPath: string): Promise<string> {
     const dashIdx = h1Match[1].indexOf(" — ");
     const linkText = dashIdx >= 0 ? h1Match[1].slice(0, dashIdx) : h1Match[1];
     const restText = dashIdx >= 0 ? h1Match[1].slice(dashIdx) : "";
-    headerHtml = `<header class="report-header">\n  <img class="report-icon" src="${REPORT_ICON_HREF}" alt="" width="40" height="40">\n  <h1 id="${h1Id}"><a href="index.html" title="Back to all reports">${linkText}</a>${restText}</h1>\n</header>`;
+    headerHtml = `<header class="report-header">\n  <img class="report-icon" src="${REPORT_ICON_HREF}" alt="" width="40" height="40">\n  <h1 id="${h1Id}"><a href="index.html" title="Back to all reports">${linkText}</a>${restText}</h1>\n  ${REPORT_SETTINGS_BUTTON}\n</header>`;
   } else {
-    headerHtml = `<header class="report-header">\n  <img class="report-icon" src="${REPORT_ICON_HREF}" alt="" width="40" height="40">\n  <h1><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — ${date}</h1>\n</header>`;
+    headerHtml = `<header class="report-header">\n  <img class="report-icon" src="${REPORT_ICON_HREF}" alt="" width="40" height="40">\n  <h1><a href="index.html" title="Back to all reports">WordPress Trend Report</a> — ${date}</h1>\n  ${REPORT_SETTINGS_BUTTON}\n</header>`;
   }
 
   // Build table of contents from h2 headings (if 2 or more exist)
@@ -444,6 +446,7 @@ export async function generateIndexPage(reportsDir: string): Promise<string> {
   <header class="report-header">
     <img class="report-icon" src="${REPORT_ICON_HREF}" alt="" width="40" height="40">
     <h1>WP Trend Watcher — Reports</h1>
+    ${REPORT_SETTINGS_BUTTON}
   </header>
   ${REPORT_THEME_CONTROLS}
   <p class="meta">${reportLabel}</p>

--- a/src/summarize/report.css
+++ b/src/summarize/report.css
@@ -19,7 +19,7 @@ body {
   font-family: "Radio Canada", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   line-height: 1.6;
   margin: 0 auto;
-  max-width: 720px;
+  max-width: 960px;
   padding: 2rem 1.5rem;
 }
 
@@ -101,14 +101,16 @@ hr {
 
 /* Report header */
 .report-header {
-  align-items: center;
+  align-items: flex-start;
   display: flex;
   gap: 0.75rem;
+  justify-content: space-between;
   margin-bottom: 1.5rem;
 }
 
 .report-header h1 {
   border-bottom: none;
+  flex: 1;
   margin-bottom: 0.25rem;
 }
 
@@ -442,12 +444,6 @@ details.article-inventory {
   color: var(--accent);
 }
 
-.theme-settings {
-  display: flex;
-  justify-content: flex-end;
-  margin: -0.5rem 0 1.5rem;
-}
-
 .settings-button,
 .theme-settings-actions button {
   background: var(--surface);
@@ -459,6 +455,28 @@ details.article-inventory {
   font-size: 0.85rem;
   min-height: 2.25rem;
   padding: 0.35rem 0.75rem;
+}
+
+.settings-button {
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+  padding: 0.35rem 0.5rem;
+}
+
+.settings-icon {
+  display: block;
+  font-size: 1.15rem;
+  line-height: 1;
+}
+
+.sr-only {
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
 .settings-button:hover,
@@ -563,8 +581,8 @@ details.article-inventory {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .theme-settings {
-    justify-content: flex-start;
+  .report-header {
+    gap: 0.5rem;
   }
 }
 

--- a/tests/summarize/html.test.ts
+++ b/tests/summarize/html.test.ts
@@ -358,6 +358,8 @@ test("generateHtmlReport links a shared external stylesheet", async () => {
   assert.ok(html.includes('data-theme-control="theme"'));
   assert.ok(html.includes('data-theme-control="mode"'));
   assert.ok(html.includes("data-theme-settings-open"));
+  assert.ok(html.includes('aria-label="Open report settings"'));
+  assert.ok(html.includes('class="settings-icon" aria-hidden="true">⚙️</span>'));
   assert.ok(html.includes('<dialog class="theme-settings-dialog"'));
   assert.ok(html.includes("wp-trend-watcher-theme"));
   assert.ok(css.includes(".report-header"));
@@ -382,8 +384,11 @@ test("generateIndexPage links a shared external stylesheet", async () => {
   assert.ok(html.includes('data-theme-control="theme"'));
   assert.ok(html.includes('data-theme-control="mode"'));
   assert.ok(html.includes("data-theme-settings-open"));
+  assert.ok(html.includes('aria-label="Open report settings"'));
+  assert.ok(html.includes('class="settings-icon" aria-hidden="true">⚙️</span>'));
   assert.ok(html.includes('<dialog class="theme-settings-dialog"'));
   assert.ok(css.includes(".report-index h1"));
+  assert.ok(css.includes("max-width: 960px"));
   assert.ok(css.includes("grid-template-columns: repeat(3"));
 });
 


### PR DESCRIPTION
## Summary

- Increase the shared report and index content width from 720px to 960px.
- Move the Settings control into the page header on report and index pages.
- Replace the text label with a gear emoji while preserving an explicit accessible name and visually hidden Settings text.
- Keep the existing dialog, keyboard behavior, focus styles, theme persistence, and responsive layout intact.

## Verification

- [x] `pnpm run regen-html`
- [x] `pnpm run test` — 203 tests passed
- [x] `pnpm run typecheck`
- [x] `git diff --check`
- [x] Browser-checked report and index headers, wider layout, and accessible dialog control

## Notes

The preview server used for browser verification has been stopped.