### PR TITLE
feat(reports): generate SEO descriptions after review

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ pnpm generate-report # Regenerate the report from saved article summaries
 pnpm index-page      # Regenerate the reports index.html listing page
 pnpm doctor          # Check environment readiness before first summarize
 pnpm review          # Review checklist for the latest report
+pnpm generate-descriptions # Fill or regenerate SEO descriptions
 pnpm weekly          # Run the full weekly workflow (doctor → collect → summarize → review → review server)
 ```
 
-`pnpm weekly` is the recommended single-command workflow. It runs doctor, collect, summarize, and review sequentially, then starts a local review server at http://127.0.0.1:3001/review where you can view automated checks, read the rendered report, and save your "What I'm Watching" observations. Saved edits update both the canonical Markdown report and regenerated HTML. Press Ctrl-C to stop the server when you're done.
+`pnpm weekly` is the recommended single-command workflow. It runs doctor, collect, summarize, and review sequentially, then starts a local review server at http://127.0.0.1:3001/review where you can view automated checks, read the rendered report, and save your "What I'm Watching" observations. Saving through the review page updates the canonical Markdown report, asks the configured LLM to generate the final SEO description from the reviewed report, and regenerates HTML. Press Ctrl-C to stop the server when you're done.
 
 Use `pnpm weekly -- --no-open` to skip the automatic browser launch.
 
@@ -63,7 +64,9 @@ Individual commands remain available for diagnosis and recovery — for example,
 
 Generated report pages include Style and Mode controls for Aurora Blueprint, Aurora Mesh, and Signal Stripe, with Light, Dark, and System modes. The selected preferences are saved in the browser's local storage and reused across the report index and individual reports.
 
-Generated reports also include concise SEO metadata in the canonical Markdown source. The metadata is used for page titles, descriptions, Open Graph/Twitter cards, the visible report introduction, and report index-card summaries. If older reports do not contain generated metadata, the HTML generator uses a safe generic fallback.
+Generated reports also include concise SEO metadata in the canonical Markdown source. The title is created during report synthesis; the description is created after human review notes are saved. The description is used for page metadata, Open Graph/Twitter cards, the visible report introduction, and report index-card summaries. If generation is unavailable, the human save still succeeds and HTML uses a safe generic fallback.
+
+To backfill historical reports, run `pnpm generate-descriptions` to fill reports without descriptions, or `pnpm generate-descriptions --all` to regenerate every report. Use `pnpm generate-descriptions --date YYYY-MM-DD` to target one report.
 
 See [Summarization](docs/summarization.md) for provider configuration, model options, and synthesis strategy.
 
@@ -96,6 +99,11 @@ Both templates walk you through what's needed — takes about a minute.
 
 ## Changelog
 
+### 0.10.0
+
+- Moved SEO description generation to the post-review workflow so descriptions include final human notes.
+- Added `pnpm generate-descriptions` for filling or regenerating historical report descriptions.
+
 ### 0.9.0
 
 - Added generated SEO titles and descriptions to reports, including visible report introductions and concise descriptions on index cards.
@@ -105,36 +113,5 @@ Both templates walk you through what's needed — takes about a minute.
 
 - Added GitHub project links to the report index and individual report footers.
 - Added persistent report style and color-mode controls with accessible light and dark variants for all three visual directions.
-
-### 0.7.0
-
-- Added `markdown-it` dependency; report HTML generation and the local review server now share one Markdown renderer (`src/summarize/renderer.ts`) instead of two bespoke converters.
-- Renderer keeps raw HTML disabled and strips unsafe link schemes (`javascript:`, `data:`, `vbscript:`) so generated pages stay safe even from untrusted feeds.
-- Article Inventory now renders inside a collapsible `<details>` element (closed by default) with a visible article count, de-emphasizing long vertical lists without removing the data.
-- Report sections render in a configurable presentation order (`DEFAULT_PRESENTATION_ORDER`), so generated HTML layout can change without rewriting report history. Canonical Markdown data stays the source of truth.
-- Added a free-form **Review time** field to the local review page (`Build Notes`) and the review API; it persists to the `Review time:` line in the canonical Markdown.
-- `pnpm regen-html` now refreshes all report HTML from existing Markdown with no LLM calls; historical report data is unchanged.
-- Added the Radio Canada variable font to generated HTML reports: the shared stylesheet declares a `@font-face` rule and uses it as the primary `body` font, with system fonts as fallback. The font file is copied into `reports/assets/` at generation time (alongside `report.css` and `icon.svg`) so it ships with GitHub Pages deployments.
-- Added standard SEO and social-sharing meta to generated HTML reports and the index page: description, canonical link, Open Graph tags, and a `summary_large_image` Twitter card. The shared `assets/WP-Trend-Watcher_1200x630.png` is copied into `reports/assets/` so the Open Graph image resolves on GitHub Pages deployments. All meta URLs are absolute to the `colorful-tones.github.io/wp-trend-watcher/` site root.
-- Bumped package version to 0.7.0.
-
-### 0.6.0
-
-- Added `pnpm weekly` single-command workflow: doctor → collect → summarize → review → local review server.
-- Added localhost-only review server (http://127.0.0.1:3001/review) for browser-based human review.
-- Review page displays automated checks, rendered report, and an editable "What I'm Watching" textarea.
-- Saving via the review page updates the canonical Markdown report and regenerates matching HTML atomically.
-- Human-authored "What I'm Watching" content is now preserved during same-date report regeneration (`pnpm summarize` and `pnpm generate-report`).
-- Added pure Markdown section helpers (`src/review/report-edit.ts`) for extracting and replacing the "What I'm Watching" section.
-- New `docs/human-review.md` updated to mention the local review page.
-- Added 36 new tests for report editing, preservation behaviour, and review server request handling.
-- No new runtime dependencies — uses Node.js native HTTP server.
-
-### 0.5.0
-
-- Added `pnpm watch` zero-dependency live-reload dev server with SSE browser reload.
-- Added project icon to report headers and index page (flexbox-aligned with h1).
-- Added `pnpm regen-html` command to batch-regenerate all report HTML from existing Markdown — no LLM calls.
-- Refined report CSS: cleaned-up header, horizontal table-of-contents layout, tighter spacing on build notes and footer.
 
 For older releases, see the [GitHub Releases page](https://github.com/colorful-tones/wp-trend-watcher/releases).

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Generated report pages include Style and Mode controls for Aurora Blueprint, Aur
 
 Generated reports also include concise SEO metadata in the canonical Markdown source. The title is created during report synthesis; the description is created after human review notes are saved. The description is used for page metadata, Open Graph/Twitter cards, the visible report introduction, and report index-card summaries. If generation is unavailable, the human save still succeeds and HTML uses a safe generic fallback.
 
-To backfill historical reports, run `pnpm generate-descriptions` to fill reports without descriptions, or `pnpm generate-descriptions --all` to regenerate every report. Use `pnpm generate-descriptions --date YYYY-MM-DD` to target one report.
+To backfill historical or existing reports, run `pnpm generate-descriptions` to fill only reports still using the generic fallback. Use `pnpm generate-descriptions --date YYYY-MM-DD` to target one report without overwriting a valid description, `pnpm generate-descriptions --all --date YYYY-MM-DD` to force-regenerate one report, or `pnpm generate-descriptions --all` to force-regenerate every report. These commands modify only invisible Markdown SEO metadata and generated HTML/index files; they do not change article data or human-written report sections. See [Weekly Workflow](docs/weekly-workflow.md) for the full backfill procedure and review guidance.
 
 See [Summarization](docs/summarization.md) for provider configuration, model options, and synthesis strategy.
 

--- a/docs/human-review.md
+++ b/docs/human-review.md
@@ -44,7 +44,7 @@ The `pnpm weekly` command starts a local review server at http://127.0.0.1:3001/
 - An editable textarea for the "What I'm Watching" section
 - A free-form "Review time" field that records how long you spent reviewing and publishing the report
 
-Saving your observations via the review page updates the canonical Markdown report atomically and regenerates the matching HTML. Press Ctrl-C to stop the server when you're done reviewing.
+Saving your observations via the review page updates the canonical Markdown report atomically. After the human content is saved, the configured LLM generates the final SEO description from the complete reviewed report, then the matching HTML is regenerated. Press Ctrl-C to stop the server when you're done reviewing. If description generation fails, the human save is retained and can be retried with `pnpm generate-descriptions`.
 
 You can also review the report manually in your editor — the Markdown file at `reports/YYYY-MM-DD.md` is the canonical source of truth. The review server is an optional convenience, not a required step.
 

--- a/docs/weekly-workflow.md
+++ b/docs/weekly-workflow.md
@@ -78,7 +78,25 @@ To fill historical reports that do not yet have a post-review description:
 pnpm generate-descriptions
 ```
 
-Use `pnpm generate-descriptions --all` to regenerate every report, or `pnpm generate-descriptions --date 2026-08-10` for one report. This also rebuilds the report index.
+This scans `reports/YYYY-MM-DD.md`, skips reports that already contain a custom description, and generates descriptions only for reports still using the deterministic fallback. Each changed Markdown report gets matching HTML regenerated, and the report index is rebuilt at the end. The command uses the provider and model configured through the normal `.env` settings documented in [Summarization](summarization.md).
+
+For existing and past reports, choose the narrowest command that matches the intended change:
+
+```bash
+# Fill only reports that are missing a generated description.
+pnpm generate-descriptions
+
+# Fill or replace descriptions for one report, even if it already has one.
+pnpm generate-descriptions --all --date 2026-08-10
+
+# Replace descriptions for every report, including valid custom descriptions.
+pnpm generate-descriptions --all
+
+# Inspect a single report without overwriting an existing custom description.
+pnpm generate-descriptions --date 2026-08-10
+```
+
+The command changes only the report Markdown's invisible `SEO_DESCRIPTION` metadata and generated presentation files (`reports/*.html` and `reports/index.html`). It does not recollect articles, resummarize articles, or alter human-written report sections. Review the generated Markdown and HTML diffs before committing a backfill.
 
 ### 7. Regenerate (if needed)
 

--- a/docs/weekly-workflow.md
+++ b/docs/weekly-workflow.md
@@ -8,7 +8,7 @@ The sequence of commands to go from zero to a published weekly report.
 pnpm weekly
 ```
 
-Runs the entire pipeline in one command: doctor → collect → summarize → review → opens a local review page. After reviewing and saving your observations, press Ctrl-C to stop the server.
+Runs the entire pipeline in one command: doctor → collect → summarize → review → opens a local review page. After reviewing and saving your observations, the server generates the SEO description from the final report and rebuilds HTML. Then press Ctrl-C to stop the server.
 
 Use `pnpm weekly -- --no-open` to skip the automatic browser launch.
 
@@ -68,7 +68,19 @@ Open `reports/YYYY-MM-DD.md` and:
 
 See [Human Review](human-review.md) for the full checklist.
 
-### 6. Regenerate (if needed)
+### 6. Generate the SEO Description
+
+Saving the review page is the normal final workflow step. It writes the human notes first, then asks the configured LLM to create one concise description from the final reviewed Markdown, and finally regenerates the matching HTML. If the provider is unavailable, the report remains saved and can be retried later.
+
+To fill historical reports that do not yet have a post-review description:
+
+```bash
+pnpm generate-descriptions
+```
+
+Use `pnpm generate-descriptions --all` to regenerate every report, or `pnpm generate-descriptions --date 2026-08-10` for one report. This also rebuilds the report index.
+
+### 7. Regenerate (if needed)
 
 ```bash
 pnpm generate-report
@@ -84,7 +96,7 @@ pnpm regen-html
 
 This rewrites all `reports/*.html` from the existing `reports/*.md` files. Report Markdown and article data are never changed — only the generated presentation.
 
-### 7. Index Page (if needed)
+### 8. Index Page (if needed)
 
 ```bash
 pnpm index-page
@@ -100,6 +112,7 @@ Regenerates `reports/index.html` independently. Normally `pnpm summarize` alread
 | Collect | `pnpm collect` (or `-- --days 7` to override) | No | Yes (merges) |
 | Summarize | `pnpm summarize` | Yes | Yes (cached) |
 | Review | `pnpm review` | No | Yes |
+| Descriptions | `pnpm generate-descriptions` | Yes | Yes |
 | Regenerate | `pnpm generate-report` | Yes | Yes |
 | Index | `pnpm index-page` | No | Yes |
 
@@ -111,7 +124,7 @@ pnpm collect -- --days 7
 pnpm summarize
 pnpm review
 # … human review and edits …
-pnpm generate-report   # rebuild HTML after edits
+# Saving in the review page generates the final SEO description and HTML
 ```
 
 If the summarization step fails (timeout, model error), fix the issue and just re-run `pnpm summarize`. Cached summaries are preserved — only new articles trigger LLM calls.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,
@@ -8,6 +8,7 @@
     "collect": "tsx src/collect/index.ts",
     "summarize": "tsx src/summarize/index.ts",
     "generate-report": "tsx src/generate-report/index.ts",
+    "generate-descriptions": "tsx src/generate-descriptions/index.ts",
     "index-page": "tsx src/summarize/index-page.ts",
     "doctor": "tsx src/doctor/index.ts",
     "review": "tsx src/review/index.ts",

--- a/src/generate-descriptions/index.ts
+++ b/src/generate-descriptions/index.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+/**
+ * Generate SEO descriptions for reviewed reports.
+ *
+ * Usage:
+ *   pnpm generate-descriptions       # Fill missing descriptions
+ *   pnpm generate-descriptions --all # Regenerate every report
+ *   pnpm generate-descriptions --date 2026-08-10
+ */
+
+import { join } from "node:path";
+import { loadEnvFile } from "../env.js";
+import { createProvider } from "../providers.js";
+import { generateDescriptionsForReports } from "../summarize/description-backfill.js";
+
+/** Parse the supported description backfill command-line arguments. */
+function parseArgs(args: string[]): { force: boolean; dates: string[] } {
+  let force = false;
+  const dates: string[] = [];
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === "--all") {
+      force = true;
+      continue;
+    }
+
+    if (arg === "--date") {
+      const date = args[++index];
+      if (!date) {
+        throw new Error("--date requires a YYYY-MM-DD value");
+      }
+      dates.push(date);
+      continue;
+    }
+
+    if (arg.startsWith("--date=")) {
+      dates.push(arg.slice("--date=".length));
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  for (const date of dates) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      throw new Error(`Invalid report date: ${date}`);
+    }
+  }
+
+  return { force, dates };
+}
+
+async function main(): Promise<void> {
+  loadEnvFile();
+
+  const { force, dates } = parseArgs(process.argv.slice(2));
+  const provider = createProvider();
+  const reportsDir = join(process.cwd(), "reports");
+
+  console.log("WP Trend Watcher — generate descriptions\n");
+  console.log(`Provider: ${provider.name}/${provider.model}`);
+  console.log(
+    dates.length > 0
+      ? `Reports: ${dates.join(", ")}`
+      : force
+        ? "Reports: all"
+        : "Reports: missing descriptions",
+  );
+
+  const result = await generateDescriptionsForReports(reportsDir, provider, {
+    force,
+    dates: dates.length > 0 ? dates : undefined,
+  });
+
+  console.log(`\nGenerated: ${result.generated}`);
+  console.log(`Skipped: ${result.skipped}`);
+  console.log(`Failed: ${result.failed}`);
+
+  if (result.failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/src/review/server.ts
+++ b/src/review/server.ts
@@ -34,8 +34,18 @@ import {
   extname,
 } from "node:path";
 import { randomBytes } from "node:crypto";
+import { loadEnvFile } from "../env.js";
+import { createProvider } from "../providers.js";
 import { generateHtmlReport } from "../summarize/html.js";
 import { renderReportBody } from "../summarize/renderer.js";
+import {
+  generateReportDescription,
+} from "../summarize/description.js";
+import {
+  DEFAULT_REPORT_SEO_DESCRIPTION,
+  extractReportSeoMetadata,
+  updateReportSeoDescription,
+} from "../summarize/report.js";
 import {
   findWatchingSection,
   replaceWatchingSection,
@@ -69,7 +79,13 @@ export interface ReviewData {
   summary: string;
   reviewTime: string;
   checks: ReviewCheck[];
+  descriptionStatus: "generated" | "fallback";
 }
+
+/** Generate an SEO description from a final reviewed report. */
+export type ReportDescriptionGenerator = (
+  reportMarkdown: string,
+) => Promise<string>;
 
 /** Convenience type for route handler functions. */
 type RouteHandler = (
@@ -91,6 +107,8 @@ export interface ReviewServerOptions {
   port?: number;
   /** Host to bind to. Defaults to 127.0.0.1. */
   hostname?: string;
+  /** Optional description generator, primarily for deterministic tests. */
+  descriptionGenerator?: ReportDescriptionGenerator;
 }
 
 /**
@@ -108,9 +126,19 @@ export function createReviewServer(
   const reportsDir = options.reportsDir ?? join(process.cwd(), "reports");
   const port = options.port ?? DEFAULT_PORT;
   const hostname = options.hostname ?? BIND_ADDRESS;
+  loadEnvFile();
+  const descriptionGenerator =
+    options.descriptionGenerator ??
+    ((markdown: string) =>
+      generateReportDescription(markdown, createProvider()));
 
   return createServer((req, res) =>
-    handleRequest(req, res, { reportsDir, port, hostname }),
+    handleRequest(req, res, {
+      reportsDir,
+      port,
+      hostname,
+      descriptionGenerator,
+    }),
   );
 }
 
@@ -120,6 +148,7 @@ interface RequestContext {
   reportsDir: string;
   port: number;
   hostname: string;
+  descriptionGenerator: ReportDescriptionGenerator;
 }
 
 // --- Route table ---
@@ -383,7 +412,7 @@ function reviewPageHtml(): string {
 
 <section class="editor-section">
   <h2>Your Review Summary</h2>
-  <p class="meta">Edit the <em>What I'm Watching</em> section below. Saving updates the canonical Markdown report and regenerates the matching HTML.</p>
+  <p class="meta">Edit the <em>What I'm Watching</em> section below. Saving updates the canonical Markdown report, generates its SEO description, and regenerates the matching HTML.</p>
   <label class="editor-label" for="summary-textarea">What I'm Watching</label>
   <textarea id="summary-textarea" placeholder="Add your observations here…"></textarea>
   <label class="editor-label" for="review-time-input">Review time</label>
@@ -448,7 +477,9 @@ async function saveSummary() {
 
     const data = await res.json();
     statusEl.className = 'status success';
-    statusEl.textContent = '✓ Saved successfully — Markdown and HTML updated.';
+    statusEl.textContent = data.descriptionStatus === 'generated'
+      ? '✓ Saved and generated SEO description — Markdown and HTML updated.'
+      : '✓ Saved — Markdown and HTML updated. SEO description generation was unavailable.';
     document.getElementById('report-container').innerHTML = data.html;
     document.getElementById('summary-textarea').value = data.summary;
     document.getElementById('review-time-input').value = data.reviewTime || '';
@@ -623,7 +654,20 @@ async function serveReviewData(
       checkHtmlReport(htmlExists, htmlPath),
     ];
 
-    const data: ReviewData = { date, html, summary, reviewTime, checks };
+    const data: ReviewData = {
+      date,
+      html,
+      summary,
+      reviewTime,
+      checks,
+      descriptionStatus:
+        extractReportSeoMetadata(report, {
+          title: `WordPress Trend Report — ${date}`,
+          description: DEFAULT_REPORT_SEO_DESCRIPTION,
+        }).description === DEFAULT_REPORT_SEO_DESCRIPTION
+          ? "fallback"
+          : "generated",
+    };
 
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(data) + "\n");
@@ -746,6 +790,30 @@ async function handleSaveSummary(
     return;
   }
 
+  // Generate the description only after the human-authored report is saved.
+  let descriptionStatus: ReviewData["descriptionStatus"] = "fallback";
+  let descriptionTmpPath: string | null = null;
+  try {
+    const description = await ctx.descriptionGenerator(finalReport);
+    const describedReport = updateReportSeoDescription(finalReport, description);
+    descriptionTmpPath =
+      reportPath + "." + randomBytes(8).toString("hex") + ".tmp";
+    await writeFile(descriptionTmpPath, describedReport, "utf8");
+    await rename(descriptionTmpPath, reportPath);
+    descriptionTmpPath = null;
+    finalReport = describedReport;
+    descriptionStatus = "generated";
+  } catch {
+    if (descriptionTmpPath) {
+      try {
+        await unlink(descriptionTmpPath);
+      } catch {
+        // ignore cleanup failures
+      }
+    }
+    // Human notes remain saved; HTML will use the deterministic fallback.
+  }
+
   // Regenerate HTML
   try {
     await generateHtmlReport(reportPath);
@@ -779,7 +847,14 @@ async function handleSaveSummary(
     checkHtmlReport(htmlExists, htmlPath),
   ];
 
-  const data: ReviewData = { date, html, summary, reviewTime, checks };
+  const data: ReviewData = {
+    date,
+    html,
+    summary,
+    reviewTime,
+    checks,
+    descriptionStatus,
+  };
 
   res.writeHead(200, { "Content-Type": "application/json" });
   res.end(JSON.stringify(data) + "\n");

--- a/src/summarize/description-backfill.ts
+++ b/src/summarize/description-backfill.ts
@@ -1,0 +1,97 @@
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { SummarizeProvider } from "../providers.js";
+import { generateHtmlReport, generateIndexPage } from "./html.js";
+import {
+  generateReportDescription,
+  isFallbackReportDescription,
+} from "./description.js";
+import {
+  DEFAULT_REPORT_SEO_DESCRIPTION,
+  extractReportSeoMetadata,
+  updateReportSeoDescription,
+} from "./report.js";
+
+/** Options for historical SEO description generation. */
+export interface DescriptionBackfillOptions {
+  /** Regenerate descriptions even when a custom description already exists. */
+  force?: boolean;
+  /** Restrict generation to these YYYY-MM-DD report dates. */
+  dates?: string[];
+}
+
+/** Counts returned by a historical description generation run. */
+export interface DescriptionBackfillResult {
+  generated: number;
+  skipped: number;
+  failed: number;
+}
+
+const REPORT_FILE_PATTERN = /^(\d{4}-\d{2}-\d{2})\.md$/;
+
+/**
+ * Generate descriptions for selected Markdown reports and rebuild their HTML.
+ *
+ * Reports with an existing non-fallback description are skipped unless force is
+ * enabled. A failed provider call leaves that report unchanged and processing
+ * continues for the remaining reports.
+ *
+ * @param reportsDir - Directory containing Markdown reports
+ * @param provider - Configured LLM provider
+ * @param options - Selection and overwrite behavior
+ * @returns Counts for generated, skipped, and failed reports
+ */
+export async function generateDescriptionsForReports(
+  reportsDir: string,
+  provider: SummarizeProvider,
+  options: DescriptionBackfillOptions = {},
+): Promise<DescriptionBackfillResult> {
+  const requestedDates = options.dates ? new Set(options.dates) : null;
+  const files = (await readdir(reportsDir))
+    .map((file) => ({ file, match: file.match(REPORT_FILE_PATTERN) }))
+    .filter(
+      (entry): entry is { file: string; match: RegExpMatchArray } =>
+        entry.match !== null &&
+        (requestedDates === null || requestedDates.has(entry.match[1])),
+    )
+    .sort((a, b) => a.match[1].localeCompare(b.match[1]));
+
+  const result: DescriptionBackfillResult = {
+    generated: 0,
+    skipped: 0,
+    failed: 0,
+  };
+
+  for (const { file, match } of files) {
+    const date = match[1];
+    const reportPath = join(reportsDir, file);
+    const report = await readFile(reportPath, "utf8");
+    const metadata = extractReportSeoMetadata(report, {
+      title: `WordPress Trend Report — ${date}`,
+      description: DEFAULT_REPORT_SEO_DESCRIPTION,
+    });
+
+    if (!options.force && !isFallbackReportDescription(metadata.description)) {
+      result.skipped++;
+      continue;
+    }
+
+    try {
+      const description = await generateReportDescription(report, provider);
+      await writeFile(
+        reportPath,
+        updateReportSeoDescription(report, description),
+        "utf8",
+      );
+      await generateHtmlReport(reportPath);
+      result.generated++;
+    } catch {
+      result.failed++;
+    }
+  }
+
+  await generateIndexPage(reportsDir);
+  return result;
+}
+
+

--- a/src/summarize/description.ts
+++ b/src/summarize/description.ts
@@ -1,0 +1,82 @@
+import type { SummarizeProvider } from "../providers.js";
+import { DEFAULT_REPORT_SEO_DESCRIPTION } from "./report.js";
+
+/**
+ * System instructions for generating a post-review report description.
+ */
+export const REPORT_DESCRIPTION_SYSTEM_PROMPT = `You write concise SEO descriptions for weekly WordPress trend reports.
+Rules:
+- Return one factual sentence only.
+- Aim for 140-160 characters, but prefer clarity over filling the limit.
+- Use the most important signals from the report and its human review notes.
+- Do not use hype, generic marketing language, or unsupported claims.
+- Do not mention AI, the generation process, or these instructions.`;
+
+/**
+ * Build the prompt for generating a description from the final reviewed report.
+ *
+ * @param reportMarkdown - Canonical Markdown report after human notes are saved
+ * @returns Prompt text for the summarization provider
+ */
+export function buildReportDescriptionPrompt(reportMarkdown: string): string {
+  return `Create one factual sentence of 140-160 characters for the SEO description of this final reviewed report. Return the description only, with no label or quotation marks.
+
+${reportMarkdown}`;
+}
+
+/**
+ * Generate and normalize a report description through the configured provider.
+ *
+ * @param reportMarkdown - Canonical Markdown report after human notes are saved
+ * @param provider - Configured LLM provider
+ * @returns A single-line SEO description
+ * @throws If the provider returns no usable description
+ */
+export async function generateReportDescription(
+  reportMarkdown: string,
+  provider: SummarizeProvider,
+): Promise<string> {
+  const result = await provider.summarize(
+    REPORT_DESCRIPTION_SYSTEM_PROMPT,
+    buildReportDescriptionPrompt(reportMarkdown),
+  );
+  const description = normalizeDescription(result.text);
+  if (!description) {
+    throw new Error("Provider returned an empty description");
+  }
+
+  return description;
+}
+
+/**
+ * Normalize provider output while accepting a labelled response from a model.
+ *
+ * @param value - Raw provider response
+ * @returns Safe single-line description, or an empty string
+ */
+function normalizeDescription(value: string): string {
+  const normalized = value
+    .replace(/^\s*SEO_DESCRIPTION:\s*/i, "")
+    .replace(/[\r\n]+/g, " ")
+    .replace(/^['"]|['"]$/g, "")
+    .replace(/\s+/g, " ")
+    .replace(/--/g, "—")
+    .trim()
+    .slice(0, 160);
+
+  if (!normalized) {
+    return "";
+  }
+
+  return /[.!?]$/.test(normalized) ? normalized : `${normalized}.`;
+}
+
+/**
+ * Determine whether a report still has the generic fallback description.
+ *
+ * @param description - Existing extracted description
+ * @returns True when a post-review description has not been generated
+ */
+export function isFallbackReportDescription(description: string): boolean {
+  return description === DEFAULT_REPORT_SEO_DESCRIPTION;
+}

--- a/src/summarize/report.ts
+++ b/src/summarize/report.ts
@@ -222,10 +222,9 @@ export function buildReportPrompt(
 
   return `Week ending ${date}. ${summaries.length} articles from WordPress developer sources.
 
-Before the report sections, output exactly two metadata lines:
+Before the report sections, output exactly one metadata line:
 SEO_TITLE: A concise, specific title for this week's report (50-65 characters when possible).
-SEO_DESCRIPTION: A factual one-sentence description of the week's most important signals (140-160 characters when possible).
-Use only information from the source inventory. Do not use hype or generic marketing language.
+Use only information from the source inventory. Do not use hype or generic marketing language. The SEO description is generated later, after human review notes are saved.
 
 ## Source Inventory
 
@@ -301,7 +300,7 @@ export interface ReportSeoMetadata {
   description: string;
 }
 
-const DEFAULT_REPORT_SEO_DESCRIPTION =
+export const DEFAULT_REPORT_SEO_DESCRIPTION =
   "Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.";
 
 /**
@@ -316,12 +315,8 @@ function parseGeneratedSeoMetadata(
   fallbackTitle: string,
 ): { metadata: ReportSeoMetadata; content: string } {
   const titleMatch = synthesis.match(/^SEO_TITLE:\s*(.+)$/im);
-  const descriptionMatch = synthesis.match(/^SEO_DESCRIPTION:\s*(.+)$/im);
   const title = sanitizeSeoValue(titleMatch?.[1] ?? fallbackTitle, 70);
-  const description = sanitizeSeoValue(
-    descriptionMatch?.[1] ?? DEFAULT_REPORT_SEO_DESCRIPTION,
-    160,
-  );
+  const description = DEFAULT_REPORT_SEO_DESCRIPTION;
   const content = synthesis
     .replace(/^SEO_TITLE:\s*.+$/im, "")
     .replace(/^SEO_DESCRIPTION:\s*.+$/im, "")
@@ -368,6 +363,31 @@ function sanitizeSeoValue(value: string, maxLength: number): string {
     .slice(0, maxLength);
 }
 
+/**
+ * Update or insert the post-review SEO description in a Markdown report.
+ *
+ * @param markdown - Canonical Markdown report source
+ * @param description - Generated description text
+ * @returns Markdown with exactly one SEO description comment
+ */
+export function updateReportSeoDescription(
+  markdown: string,
+  description: string,
+): string {
+  const comment = `<!-- SEO_DESCRIPTION: ${sanitizeSeoValue(description, 160)} -->`;
+  const descriptionPattern = /^<!-- SEO_DESCRIPTION:\s*.*?\s*-->\n?/m;
+  if (descriptionPattern.test(markdown)) {
+    return markdown.replace(descriptionPattern, `${comment}\n`);
+  }
+
+  const titlePattern = /^(<!-- SEO_TITLE:.*?-->\n)/m;
+  if (titlePattern.test(markdown)) {
+    return markdown.replace(titlePattern, `$1${comment}\n`);
+  }
+
+  return `${comment}\n${markdown}`;
+}
+
 // --- Report assembly ---
 
 /**
@@ -407,10 +427,17 @@ export function assembleReport(
   existingReportMd?: string | null,
 ): string {
   const articleInventory = buildArticleInventorySection(summaries);
-  const { metadata, content: synthesisWithoutMetadata } = parseGeneratedSeoMetadata(
+  const { metadata: generatedMetadata, content: synthesisWithoutMetadata } = parseGeneratedSeoMetadata(
     synthesis,
     `WordPress Trend Report — ${date}`,
   );
+  const existingMetadata = existingReportMd
+    ? extractReportSeoMetadata(existingReportMd, generatedMetadata)
+    : generatedMetadata;
+  const metadata: ReportSeoMetadata = {
+    title: generatedMetadata.title,
+    description: existingMetadata.description,
+  };
   const synthesisWithoutInventory = stripGeneratedArticleInventory(
     synthesisWithoutMetadata,
   );

--- a/tests/review/server.test.ts
+++ b/tests/review/server.test.ts
@@ -61,7 +61,14 @@ async function setupFixture(
   reportMd: string | null = FIXTURE_REPORT,
 ): Promise<{ reportsDir: string; server: Server; baseUrl: string }> {
   const reportsDir = await mkdtemp(join(tmpdir(), "wp-trend-review-test-"));
-  const server = createReviewServer({ reportsDir, port: 0 });
+  const server = createReviewServer({
+    reportsDir,
+    port: 0,
+    descriptionGenerator: async (reportMarkdown) => {
+      assert.ok(reportMarkdown.includes("## What I'm Watching"));
+      return "Generated from the final reviewed report.";
+    },
+  });
 
   await new Promise<void>((resolve, reject) => {
     server.listen(0, "127.0.0.1", () => resolve());
@@ -170,6 +177,7 @@ test("GET /api/review returns JSON with date, html, summary, checks", async () =
     assert.ok(data.html.length > 0);
     assert.ok(data.summary.includes("Human-authored"));
     assert.equal(data.reviewTime, "~15 minutes");
+    assert.equal(data.descriptionStatus, "fallback");
     assert.ok(Array.isArray(data.checks));
     assert.ok(data.checks.length >= 7);
   } finally {
@@ -238,6 +246,7 @@ test("POST /api/review-summary saves summary and returns updated state", async (
     assert.ok(data.summary.includes("Updated observation"));
     assert.ok(!data.summary.includes("Human-authored"));
     assert.ok(data.html.includes("Updated observation"));
+    assert.equal(data.descriptionStatus, "generated");
     assert.equal(data.date, "2026-07-18");
   } finally {
     await teardownFixture(fixture);
@@ -261,6 +270,7 @@ test("POST /api/review-summary actually writes to the Markdown file", async () =
     assert.ok(!md.includes("Human-authored: add your observations here"));
     assert.ok(md.includes("## Source Articles"));
     assert.ok(md.includes("## Build Notes"));
+    assert.ok(md.includes("<!-- SEO_DESCRIPTION: Generated from the final reviewed report. -->"));
   } finally {
     await teardownFixture(fixture);
   }

--- a/tests/summarize/description-backfill.test.ts
+++ b/tests/summarize/description-backfill.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  generateDescriptionsForReports,
+} from "../../src/summarize/description-backfill.js";
+import type { SummarizeProvider } from "../../src/providers.js";
+
+function makeProvider(): SummarizeProvider {
+  return {
+    name: "stub",
+    model: "test-model",
+    summarize: async (_systemPrompt, userPrompt) => ({
+      text: userPrompt.includes("2026-01-01")
+        ? "Description for the first report."
+        : "Description for the second report.",
+      promptTokens: 10,
+      completionTokens: 5,
+    }),
+    costFor: () => 0,
+  };
+}
+
+test("generateDescriptionsForReports fills reports without descriptions and rebuilds HTML/index", async () => {
+  const reportsDir = await mkdtemp(join(tmpdir(), "description-backfill-"));
+  await writeFile(
+    join(reportsDir, "2026-01-01.md"),
+    "# WordPress Trend Report — 2026-01-01\n\n## What I'm Watching\n\nNotes.\n",
+    "utf8",
+  );
+  await writeFile(
+    join(reportsDir, "2026-01-08.md"),
+    "<!-- SEO_DESCRIPTION: Existing description. -->\n# WordPress Trend Report — 2026-01-08\n",
+    "utf8",
+  );
+
+  const result = await generateDescriptionsForReports(reportsDir, makeProvider());
+
+  assert.deepEqual(result, { generated: 1, skipped: 1, failed: 0 });
+  assert.ok(
+    (await readFile(join(reportsDir, "2026-01-01.md"), "utf8")).includes(
+      "<!-- SEO_DESCRIPTION: Description for the first report. -->",
+    ),
+  );
+  assert.ok(await readFile(join(reportsDir, "2026-01-01.html"), "utf8"));
+  assert.ok(await readFile(join(reportsDir, "index.html"), "utf8"));
+});
+
+test("generateDescriptionsForReports force-regenerates existing descriptions", async () => {
+  const reportsDir = await mkdtemp(join(tmpdir(), "description-backfill-force-"));
+  await writeFile(
+    join(reportsDir, "2026-01-08.md"),
+    "<!-- SEO_DESCRIPTION: Existing description. -->\n# WordPress Trend Report — 2026-01-08\n",
+    "utf8",
+  );
+
+  const result = await generateDescriptionsForReports(reportsDir, makeProvider(), {
+    force: true,
+  });
+
+  assert.deepEqual(result, { generated: 1, skipped: 0, failed: 0 });
+  assert.ok(
+    (await readFile(join(reportsDir, "2026-01-08.md"), "utf8")).includes(
+      "Description for the second report.",
+    ),
+  );
+});

--- a/tests/summarize/description.test.ts
+++ b/tests/summarize/description.test.ts
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildReportDescriptionPrompt,
+  generateReportDescription,
+} from "../../src/summarize/description.js";
+import type { SummarizeProvider } from "../../src/providers.js";
+
+function makeProvider(text: string): SummarizeProvider {
+  return {
+    name: "stub",
+    model: "test-model",
+    summarize: async (_systemPrompt, userPrompt) => {
+      assert.ok(userPrompt.includes("Human notes: This week's testing notes."));
+      return { text, promptTokens: 10, completionTokens: 5 };
+    },
+    costFor: () => 0,
+  };
+}
+
+test("buildReportDescriptionPrompt asks for a factual description from the final report", () => {
+  const prompt = buildReportDescriptionPrompt(
+    "# Report\n\n## What I'm Watching\n\nHuman notes: This week's testing notes.",
+  );
+
+  assert.ok(prompt.includes("one factual sentence"));
+  assert.ok(prompt.includes("140-160 characters"));
+  assert.ok(prompt.includes("Human notes: This week's testing notes."));
+  assert.ok(!prompt.includes("SEO_DESCRIPTION:"));
+});
+
+test("generateReportDescription returns a normalized model description", async () => {
+  const description = await generateReportDescription(
+    "# Report\n\n## What I'm Watching\n\nHuman notes: This week's testing notes.",
+    makeProvider('SEO_DESCRIPTION:  WordPress 7.1 testing and API changes shape upcoming client work.  '),
+  );
+
+  assert.equal(
+    description,
+    "WordPress 7.1 testing and API changes shape upcoming client work.",
+  );
+});
+
+test("generateReportDescription rejects an empty model response", async () => {
+  const emptyProvider: SummarizeProvider = {
+    name: "stub",
+    model: "test-model",
+    summarize: async () => ({
+      text: "SEO_DESCRIPTION:",
+      promptTokens: 0,
+      completionTokens: 0,
+    }),
+    costFor: () => 0,
+  };
+
+  await assert.rejects(
+    generateReportDescription("# Report", emptyProvider),
+    /empty description/i,
+  );
+});

--- a/tests/summarize/report.test.ts
+++ b/tests/summarize/report.test.ts
@@ -167,7 +167,7 @@ test("buildReportPrompt includes expected section headings", () => {
   assert.ok(prompt.includes("### Emerging Trends"));
   assert.ok(prompt.includes("### Developer Implications"));
   assert.ok(prompt.includes("SEO_TITLE:"));
-  assert.ok(prompt.includes("SEO_DESCRIPTION:"));
+  assert.ok(prompt.includes("SEO description is generated later"));
 });
 
 test("buildReportPrompt truncates summaries to first sentence", () => {
@@ -279,7 +279,7 @@ test("assembleReport produces a complete Markdown report", () => {
 
   assert.ok(report.includes("# WordPress Trend Report — 2026-06-20"));
   assert.ok(report.includes("<!-- SEO_TITLE: WordPress workflow changes -->"));
-  assert.ok(report.includes("<!-- SEO_DESCRIPTION: This week's WordPress changes affect testing and client work. -->"));
+  assert.ok(report.includes("<!-- SEO_DESCRIPTION: Weekly human-reviewed analysis"));
   assert.ok(!report.includes("SEO_TITLE: WordPress workflow changes\nSEO_DESCRIPTION:"));
   assert.ok(report.includes("## Weekly Summary"));
   assert.ok(report.includes("### Article Inventory"));
@@ -552,6 +552,29 @@ The design system proposal is worth monitoring closely.
 
   assert.ok(report.includes("The design system proposal is worth monitoring closely."));
   assert.ok(!report.includes("Human-authored: add your observations here"));
+});
+
+test("assembleReport preserves an existing post-review SEO description", () => {
+  const existingReport =
+    "<!-- SEO_TITLE: Existing title -->\n" +
+    "<!-- SEO_DESCRIPTION: Existing reviewed description. -->\n" +
+    "# WordPress Trend Report — 2026-06-20\n";
+
+  const report = assembleReport(
+    "2026-06-20",
+    [makeArticle()],
+    "### Emerging Trends\n\nNone.\n\n### Developer Implications\n\nNone.",
+    [makeSummary()],
+    stubProvider,
+    200,
+    100,
+    null,
+    existingReport,
+  );
+
+  assert.ok(
+    report.includes("<!-- SEO_DESCRIPTION: Existing reviewed description. -->"),
+  );
 });
 
 test("assembleReport does not preserve placeholder content from existing report", () => {

--- a/tests/summarize/seo-metadata.test.ts
+++ b/tests/summarize/seo-metadata.test.ts
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_REPORT_SEO_DESCRIPTION,
+  extractReportSeoMetadata,
+  updateReportSeoDescription,
+} from "../../src/summarize/report.js";
+
+test("updateReportSeoDescription inserts metadata after the title comment", () => {
+  const report = "<!-- SEO_TITLE: A report title -->\n# Report\n";
+  const updated = updateReportSeoDescription(
+    report,
+    "A specific description from the final reviewed report.",
+  );
+
+  assert.equal(
+    updated,
+    "<!-- SEO_TITLE: A report title -->\n<!-- SEO_DESCRIPTION: A specific description from the final reviewed report. -->\n# Report\n",
+  );
+});
+
+test("updateReportSeoDescription replaces an existing description", () => {
+  const report =
+    "<!-- SEO_TITLE: A report title -->\n<!-- SEO_DESCRIPTION: Old description. -->\n# Report\n";
+
+  assert.ok(
+    updateReportSeoDescription(report, "New description.").includes(
+      "<!-- SEO_DESCRIPTION: New description. -->",
+    ),
+  );
+  assert.equal(
+    updateReportSeoDescription(report, "New description.").match(
+      /SEO_DESCRIPTION/g,
+    )?.length,
+    1,
+  );
+});
+
+test("extractReportSeoMetadata uses the deterministic fallback before description generation", () => {
+  const metadata = extractReportSeoMetadata("# Report\n", {
+    title: "Fallback title",
+    description: DEFAULT_REPORT_SEO_DESCRIPTION,
+  });
+
+  assert.equal(metadata.description, DEFAULT_REPORT_SEO_DESCRIPTION);
+});


### PR DESCRIPTION
## Summary

- Generate the final SEO description after human review notes are saved.
- Store the description in canonical Markdown metadata and reuse it for report meta tags, visible report intros, and index cards.
- Preserve existing generated descriptions during later report regeneration.
- Add `pnpm generate-descriptions` for safe historical backfills and explicit forced regeneration.
- Document the normal weekly flow and past/existing report procedures.

## Backfill commands

```bash
# Fill only reports still using the generic fallback
pnpm generate-descriptions

# Force-regenerate one report
pnpm generate-descriptions --all --date YYYY-MM-DD

# Force-regenerate every report
pnpm generate-descriptions --all
```

The backfill changes only invisible `SEO_DESCRIPTION` metadata and generated HTML/index files; it does not recollect articles, resummarize articles, or change human-written report sections.

## Verification

- [x] `pnpm run test` — 212 tests passed
- [x] `pnpm run typecheck`
- [x] `pnpm run regen-html`
- [x] `pnpm run review`
- [x] `git diff --check`

## Review notes

The historical backfill itself was not run because it performs live LLM calls and would intentionally modify historical report files. The command is documented and ready for a deliberate reviewed run after merge.