### PR TITLE
fix(reports): prevent description backfill context failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ Both templates walk you through what's needed — takes about a minute.
 
 ## Changelog
 
+### 0.10.1
+
+- Bound description requests to compact report context and 512 completion tokens to avoid context-window failures on larger reports.
+- Report per-date backfill failures with sanitized provider error messages.
+
 ### 0.10.0
 
 - Moved SEO description generation to the post-review workflow so descriptions include final human notes.

--- a/docs/weekly-workflow.md
+++ b/docs/weekly-workflow.md
@@ -96,7 +96,7 @@ pnpm generate-descriptions --all
 pnpm generate-descriptions --date 2026-08-10
 ```
 
-The command changes only the report Markdown's invisible `SEO_DESCRIPTION` metadata and generated presentation files (`reports/*.html` and `reports/index.html`). It does not recollect articles, resummarize articles, or alter human-written report sections. Review the generated Markdown and HTML diffs before committing a backfill.
+The command changes only the report Markdown's invisible `SEO_DESCRIPTION` metadata and generated presentation files (`reports/*.html` and `reports/index.html`). It does not recollect articles, resummarize articles, or alter human-written report sections. Description requests use the report title, analytical sections, human notes, and source titles; long article inventories and Build Notes are excluded to keep the model context bounded. Each failure is reported with its report date and a sanitized provider error. Review the generated Markdown and HTML diffs before committing a backfill.
 
 ### 7. Regenerate (if needed)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,

--- a/src/generate-descriptions/index.ts
+++ b/src/generate-descriptions/index.ts
@@ -78,6 +78,10 @@ async function main(): Promise<void> {
   console.log(`Skipped: ${result.skipped}`);
   console.log(`Failed: ${result.failed}`);
 
+  for (const failure of result.failures) {
+    console.error(`  ${failure.date}: ${failure.reason}`);
+  }
+
   if (result.failed > 0) {
     process.exitCode = 1;
   }

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -22,8 +22,18 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 export interface SummarizeProvider {
   name: string;
   model: string;
-  summarize(systemPrompt: string, userPrompt: string): Promise<SummarizeResult>;
+  summarize(
+    systemPrompt: string,
+    userPrompt: string,
+    options?: SummarizeOptions,
+  ): Promise<SummarizeResult>;
   costFor(result: SummarizeResult): number;
+}
+
+/** Optional controls for an individual provider request. */
+export interface SummarizeOptions {
+  /** Maximum number of completion tokens requested from the provider. */
+  maxTokens?: number;
 }
 
 export function createProvider(): SummarizeProvider {
@@ -58,7 +68,7 @@ function createOllamaProvider(): SummarizeProvider {
     name: "ollama",
     model,
 
-    async summarize(systemPrompt, userPrompt) {
+    async summarize(systemPrompt, userPrompt, requestOptions) {
       const body = JSON.stringify({
         model,
         messages: [
@@ -66,7 +76,12 @@ function createOllamaProvider(): SummarizeProvider {
           { role: "user", content: userPrompt },
         ],
         stream: false,
-        options: { temperature: 0.3 },
+        options: {
+          temperature: 0.3,
+          ...(requestOptions?.maxTokens === undefined
+            ? {}
+            : { num_predict: requestOptions.maxTokens }),
+        },
       });
 
       let response: Response;
@@ -139,7 +154,7 @@ function createOpenAiCompatibleProvider(): SummarizeProvider {
     name: "openai-compatible",
     model,
 
-    async summarize(systemPrompt, userPrompt) {
+    async summarize(systemPrompt, userPrompt, requestOptions) {
       const requestBody: OpenAiChatRequestBody = {
         model,
         messages: [
@@ -154,8 +169,9 @@ function createOpenAiCompatibleProvider(): SummarizeProvider {
         temperature: 0.3,
       };
 
-      if (maxTokens !== undefined) {
-        requestBody.max_tokens = maxTokens;
+      const requestMaxTokens = requestOptions?.maxTokens ?? maxTokens;
+      if (requestMaxTokens !== undefined) {
+        requestBody.max_tokens = requestMaxTokens;
       }
 
       const body = JSON.stringify(requestBody);

--- a/src/summarize/description-backfill.ts
+++ b/src/summarize/description-backfill.ts
@@ -25,6 +25,13 @@ export interface DescriptionBackfillResult {
   generated: number;
   skipped: number;
   failed: number;
+  failures: DescriptionBackfillFailure[];
+}
+
+/** A report-specific provider failure from a backfill run. */
+export interface DescriptionBackfillFailure {
+  date: string;
+  reason: string;
 }
 
 const REPORT_FILE_PATTERN = /^(\d{4}-\d{2}-\d{2})\.md$/;
@@ -60,6 +67,7 @@ export async function generateDescriptionsForReports(
     generated: 0,
     skipped: 0,
     failed: 0,
+    failures: [],
   };
 
   for (const { file, match } of files) {
@@ -85,13 +93,31 @@ export async function generateDescriptionsForReports(
       );
       await generateHtmlReport(reportPath);
       result.generated++;
-    } catch {
+    } catch (error) {
       result.failed++;
+      result.failures.push({
+        date,
+        reason: sanitizeBackfillError(error),
+      });
     }
   }
 
   await generateIndexPage(reportsDir);
   return result;
+}
+
+/**
+ * Format provider errors for CLI output without exposing credentials or long payloads.
+ *
+ * @param error - Provider failure value
+ * @returns Sanitized, bounded error message
+ */
+function sanitizeBackfillError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message
+    .replace(/Bearer\s+\S+/gi, "Bearer [REDACTED]")
+    .replace(/https?:\/\/[^\s)]+/gi, "[endpoint]")
+    .slice(0, 300);
 }
 
 

--- a/src/summarize/description.ts
+++ b/src/summarize/description.ts
@@ -1,5 +1,41 @@
 import type { SummarizeProvider } from "../providers.js";
 import { DEFAULT_REPORT_SEO_DESCRIPTION } from "./report.js";
+import { extractReportSections } from "./renderer.js";
+
+const DESCRIPTION_MAX_TOKENS = 512;
+
+/**
+ * Build the compact report context used for SEO description generation.
+ *
+ * @param reportMarkdown - Canonical Markdown report after human notes are saved
+ * @returns Analysis, human notes, and source titles without long inventories or build metadata
+ */
+export function buildReportDescriptionInput(reportMarkdown: string): string {
+  const sections = extractReportSections(reportMarkdown);
+  const reportHeading = reportMarkdown.match(/^# .+$/m)?.[0];
+  const selected = [
+    sections.get("weekly-summary")?.replace(
+      /### Article Inventory[\s\S]*?(?=### |$)/,
+      "",
+    ),
+    sections.get("since-last-report"),
+    sections.get("what-i-m-watching"),
+  ].filter((section): section is string => Boolean(section?.trim()));
+
+  if (reportHeading) {
+    selected.unshift(reportHeading);
+  }
+
+  const sourceTitles = [...(sections.get("source-articles") ?? "").matchAll(
+    /\[([^\]]+)\]\([^)]*\)/g,
+  )].map((match) => match[1]);
+
+  if (sourceTitles.length > 0) {
+    selected.push(`Source titles:\n${sourceTitles.map((title) => `- ${title}`).join("\n")}`);
+  }
+
+  return selected.join("\n\n");
+}
 
 /**
  * System instructions for generating a post-review report description.
@@ -21,7 +57,7 @@ Rules:
 export function buildReportDescriptionPrompt(reportMarkdown: string): string {
   return `Create one factual sentence of 140-160 characters for the SEO description of this final reviewed report. Return the description only, with no label or quotation marks.
 
-${reportMarkdown}`;
+${buildReportDescriptionInput(reportMarkdown)}`;
 }
 
 /**
@@ -39,6 +75,7 @@ export async function generateReportDescription(
   const result = await provider.summarize(
     REPORT_DESCRIPTION_SYSTEM_PROMPT,
     buildReportDescriptionPrompt(reportMarkdown),
+    { maxTokens: DESCRIPTION_MAX_TOKENS },
   );
   const description = normalizeDescription(result.text);
   if (!description) {

--- a/tests/providers/index.test.ts
+++ b/tests/providers/index.test.ts
@@ -238,3 +238,30 @@ test("ollama model-specific env var takes precedence over generic model env var"
     restoreEnv();
   }
 });
+
+test("openai-compatible provider allows a per-request max token override", async () => {
+  const restoreEnv = withCleanEnv();
+  const originalFetch = globalThis.fetch;
+
+  try {
+    process.env.WP_TREND_PROVIDER = "openai-compatible";
+    process.env.WP_TREND_MAX_TOKENS = "6400";
+    let requestBody: { max_tokens?: number } = {};
+
+    globalThis.fetch = async (_input, init) => {
+      requestBody = JSON.parse(String(init?.body)) as { max_tokens?: number };
+      return new Response(
+        JSON.stringify({ choices: [{ message: { content: "description" } }] }),
+        { status: 200 },
+      );
+    };
+
+    const provider = createProvider();
+    await provider.summarize("system prompt", "user prompt", { maxTokens: 512 });
+
+    assert.equal(requestBody.max_tokens, 512);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreEnv();
+  }
+});

--- a/tests/summarize/description-backfill.test.ts
+++ b/tests/summarize/description-backfill.test.ts
@@ -38,7 +38,12 @@ test("generateDescriptionsForReports fills reports without descriptions and rebu
 
   const result = await generateDescriptionsForReports(reportsDir, makeProvider());
 
-  assert.deepEqual(result, { generated: 1, skipped: 1, failed: 0 });
+  assert.deepEqual(result, {
+    generated: 1,
+    skipped: 1,
+    failed: 0,
+    failures: [],
+  });
   assert.ok(
     (await readFile(join(reportsDir, "2026-01-01.md"), "utf8")).includes(
       "<!-- SEO_DESCRIPTION: Description for the first report. -->",
@@ -60,10 +65,41 @@ test("generateDescriptionsForReports force-regenerates existing descriptions", a
     force: true,
   });
 
-  assert.deepEqual(result, { generated: 1, skipped: 0, failed: 0 });
+  assert.deepEqual(result, {
+    generated: 1,
+    skipped: 0,
+    failed: 0,
+    failures: [],
+  });
   assert.ok(
     (await readFile(join(reportsDir, "2026-01-08.md"), "utf8")).includes(
       "Description for the second report.",
     ),
   );
+});
+
+test("generateDescriptionsForReports records the date and reason for provider failures", async () => {
+  const reportsDir = await mkdtemp(join(tmpdir(), "description-backfill-failure-"));
+  await writeFile(
+    join(reportsDir, "2026-01-15.md"),
+    "# WordPress Trend Report — 2026-01-15\n",
+    "utf8",
+  );
+  const provider: SummarizeProvider = {
+    name: "stub",
+    model: "test-model",
+    summarize: async () => {
+      throw new Error("context length exceeded");
+    },
+    costFor: () => 0,
+  };
+
+  const result = await generateDescriptionsForReports(reportsDir, provider);
+
+  assert.deepEqual(result, {
+    generated: 0,
+    skipped: 0,
+    failed: 1,
+    failures: [{ date: "2026-01-15", reason: "context length exceeded" }],
+  });
 });

--- a/tests/summarize/description.test.ts
+++ b/tests/summarize/description.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildReportDescriptionInput,
   buildReportDescriptionPrompt,
   generateReportDescription,
 } from "../../src/summarize/description.js";
@@ -10,7 +11,8 @@ function makeProvider(text: string): SummarizeProvider {
   return {
     name: "stub",
     model: "test-model",
-    summarize: async (_systemPrompt, userPrompt) => {
+    summarize: async (_systemPrompt, userPrompt, options) => {
+      assert.equal(options?.maxTokens, 512);
       assert.ok(userPrompt.includes("Human notes: This week's testing notes."));
       return { text, promptTokens: 10, completionTokens: 5 };
     },
@@ -27,6 +29,20 @@ test("buildReportDescriptionPrompt asks for a factual description from the final
   assert.ok(prompt.includes("140-160 characters"));
   assert.ok(prompt.includes("Human notes: This week's testing notes."));
   assert.ok(!prompt.includes("SEO_DESCRIPTION:"));
+});
+
+test("buildReportDescriptionInput keeps analysis, human notes, and source titles only", () => {
+  const input = buildReportDescriptionInput(
+    "# Report\n\n## Weekly Summary\n\n### Emerging Trends\n\nTrend details.\n\n## Developer Implications\n\nImplications.\n\n## What I'm Watching\n\nHuman notes.\n\n## Source Articles\n\n1. [Source title](https://example.com/source) — Long source detail.\n\n## Build Notes\n\nProvider: secret-model\n",
+  );
+
+  assert.ok(input.includes("Trend details."));
+  assert.ok(input.includes("Implications."));
+  assert.ok(input.includes("Human notes."));
+  assert.ok(input.includes("Source title"));
+  assert.ok(!input.includes("https://example.com/source"));
+  assert.ok(!input.includes("Long source detail."));
+  assert.ok(!input.includes("secret-model"));
 });
 
 test("generateReportDescription returns a normalized model description", async () => {


### PR DESCRIPTION
## Summary

- Bound SEO description prompts to compact, relevant report context.
- Exclude long Article Inventory details and Build Notes while retaining the report title, analytical sections, human notes, and source titles.
- Add a description-specific 512-token completion limit, overriding the general report-generation token setting for both OpenAI-compatible and Ollama providers.
- Report each failed report date and a sanitized provider error instead of returning only an aggregate failure count.
- Add regression coverage for compact prompts, per-request token overrides, and report-specific failure diagnostics.
- Bump the package version to 0.10.1 and document the behavior.

## Verification

- [x] Focused description/provider tests pass
- [x] `pnpm run test` — 215 tests passed
- [x] `pnpm run typecheck`
- [x] `git diff --check`

## Expected effect

The historical backfill should no longer fail solely because the general `WP_TREND_MAX_TOKENS=6400` setting reserves too much context for larger reports. If a provider still rejects a report, the CLI will identify the report date and print a bounded, sanitized error message.