### PR TITLE
feat(reports): add GoatCounter analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,7 @@ WP_TREND_CONCURRENCY=3
 
 # Days back to collect articles (default: 7)
 WP_TREND_DAYS=7
+
+# Optional GoatCounter analytics for generated public reports.
+# Leave blank to keep local previews analytics-free.
+WP_TREND_GOATCOUNTER_URL=https://colorful-tones.goatcounter.com/count

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,6 +29,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Regenerate index page
+        env:
+          WP_TREND_GOATCOUNTER_URL: https://colorful-tones.goatcounter.com/count
         run: pnpm index-page
 
       - name: Upload pages artifact

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Both templates walk you through what's needed — takes about a minute.
 
 ## Changelog
 
+### 0.10.2
+
+- Added optional GoatCounter analytics to generated report pages and the reports index. Configure `WP_TREND_GOATCOUNTER_URL` to enable it; local previews remain analytics-free when unset.
+
 ### 0.10.1
 
 - Bound description requests to compact report context and 512 completion tokens to avoid context-window failures on larger reports.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,

--- a/reports/2026-06-12.html
+++ b/reports/2026-06-12.html
@@ -101,6 +101,7 @@
   if (document.readyState !== "loading") bindControls();
 })();
 </script>
+  <script data-goatcounter="https://colorful-tones.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
   <meta name="description" content="WordPress 7.1&#39;s collaborative editing represents a significant workflow shift, alongside client-side media processing and ACF 6.8.4 updates.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-06-12.html">
   <meta property="og:type" content="article">

--- a/reports/2026-06-21.html
+++ b/reports/2026-06-21.html
@@ -101,6 +101,7 @@
   if (document.readyState !== "loading") bindControls();
 })();
 </script>
+  <script data-goatcounter="https://colorful-tones.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
   <meta name="description" content="WordPress 7.1 development progresses with new Notes feature, emoji reactions, and expanded responsive styling, alongside React 19 testing in Gutenberg 23.4 and">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-06-21.html">
   <meta property="og:type" content="article">

--- a/reports/2026-06-27.html
+++ b/reports/2026-06-27.html
@@ -101,6 +101,7 @@
   if (document.readyState !== "loading") bindControls();
 })();
 </script>
+  <script data-goatcounter="https://colorful-tones.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
   <meta name="description" content="WordPress 7.1 removes the Classic block, introduces `wp_knowledge` for site standards, and features a block-based e-commerce storefront, with feedback sought on">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-06-27.html">
   <meta property="og:type" content="article">

--- a/reports/2026-07-05.html
+++ b/reports/2026-07-05.html
@@ -101,6 +101,7 @@
   if (document.readyState !== "loading") bindControls();
 })();
 </script>
+  <script data-goatcounter="https://colorful-tones.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
   <meta name="description" content="WordPress 7.1 introduces responsive styling, daily bug scrubs, read-only abilities, and security updates, with a general release planned for August 19, 2026.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-07-05.html">
   <meta property="og:type" content="article">

--- a/reports/2026-07-11.html
+++ b/reports/2026-07-11.html
@@ -101,6 +101,7 @@
   if (document.readyState !== "loading") bindControls();
 })();
 </script>
+  <script data-goatcounter="https://colorful-tones.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
   <meta name="description" content="WordPress 7.1, releasing August 19, introduces new blocks, responsive styling, and a redesigned command palette, with betas starting July 15.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-07-11.html">
   <meta property="og:type" content="article">

--- a/reports/2026-07-19.html
+++ b/reports/2026-07-19.html
@@ -101,6 +101,7 @@
   if (document.readyState !== "loading") bindControls();
 })();
 </script>
+  <script data-goatcounter="https://colorful-tones.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
   <meta name="description" content="WordPress 7.1 Beta 1 now available, featuring persistent toolbar, iframed post editor, and enhanced styling controls, with testing encouraged for developers.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-07-19.html">
   <meta property="og:type" content="article">

--- a/reports/2026-07-26.html
+++ b/reports/2026-07-26.html
@@ -101,6 +101,7 @@
   if (document.readyState !== "loading") bindControls();
 })();
 </script>
+  <script data-goatcounter="https://colorful-tones.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
   <meta name="description" content="WordPress 7.1 Beta 3 introduces new block support, client-side media processing, and SVG icon registration ahead of its August 19 release.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-07-26.html">
   <meta property="og:type" content="article">

--- a/reports/2026-08-03.html
+++ b/reports/2026-08-03.html
@@ -101,6 +101,7 @@
   if (document.readyState !== "loading") bindControls();
 })();
 </script>
+  <script data-goatcounter="https://colorful-tones.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
   <meta name="description" content="WordPress 7.1 Beta 4 introduces an always-iframed post editor, Abilities API enhancements, and new JSON schema tools to improve client compatibility and develop">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-08-03.html">
   <meta property="og:type" content="article">

--- a/reports/2026-08-10.html
+++ b/reports/2026-08-10.html
@@ -101,6 +101,7 @@
   if (document.readyState !== "loading") bindControls();
 })();
 </script>
+  <script data-goatcounter="https://colorful-tones.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
   <meta name="description" content="WordPress 7.1 enters Release Candidate phase, introducing client-side media processing and responsive block styles, with final release scheduled for August 19,">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-08-10.html">
   <meta property="og:type" content="article">

--- a/reports/2026-08-18.html
+++ b/reports/2026-08-18.html
@@ -101,6 +101,7 @@
   if (document.readyState !== "loading") bindControls();
 })();
 </script>
+  <script data-goatcounter="https://colorful-tones.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
   <meta name="description" content="WordPress 7.1 finalizes on August 19, 2026, with RC4 available for testing and accessibility improvements highlighted.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/2026-08-18.html">
   <meta property="og:type" content="article">

--- a/reports/index.html
+++ b/reports/index.html
@@ -101,6 +101,7 @@
   if (document.readyState !== "loading") bindControls();
 })();
 </script>
+  <script data-goatcounter="https://colorful-tones.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
   <meta name="description" content="Weekly human-reviewed WordPress ecosystem trend reports.">
   <link rel="canonical" href="https://colorful-tones.github.io/wp-trend-watcher/index.html">
   <meta property="og:type" content="website">
@@ -165,7 +166,7 @@
     <a href="2026-08-18.html" class="report-card">
       <span class="report-card-date">August 18, 2026</span>
       <span class="report-card-title">WordPress 7.1 Release Final Steps and Developer Toolkits for August 20</span>
-      <span class="report-card-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</span>
+      <span class="report-card-description">WordPress 7.1 finalizes on August 19, 2026, with RC4 available for testing and accessibility improvements highlighted.</span>
     <span class="report-card-label">Latest report</span>
     </a>
     <a href="2026-08-10.html" class="report-card">

--- a/src/dev/regen-html.ts
+++ b/src/dev/regen-html.ts
@@ -9,8 +9,10 @@
  */
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
+import { loadEnvFile } from "../env.js";
 import { generateHtmlReport, generateIndexPage } from "../summarize/html.js";
 
+loadEnvFile();
 const reportsDir = join(process.cwd(), "reports");
 const mdFiles = (await readdir(reportsDir)).filter(
   (f) => f.endsWith(".md") && f !== "index.md",

--- a/src/dev/watch.ts
+++ b/src/dev/watch.ts
@@ -16,8 +16,10 @@ import { watch } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { join, extname, resolve } from "node:path";
+import { loadEnvFile } from "../env.js";
 import { generateIndexPage } from "../summarize/html.js";
 
+loadEnvFile();
 const PORT = 3000;
 const REPORTS_DIR = join(process.cwd(), "reports");
 const CSS_SOURCE = join(process.cwd(), "src", "summarize", "report.css");

--- a/src/summarize/html.ts
+++ b/src/summarize/html.ts
@@ -42,6 +42,7 @@ const SITE_BASE_URL = "https://colorful-tones.github.io/wp-trend-watcher/";
 const GITHUB_REPO_URL = "https://github.com/colorful-tones/wp-trend-watcher";
 const DEFAULT_REPORT_THEME = "aurora-blueprint";
 const DEFAULT_REPORT_MODE = "system";
+const GOATCOUNTER_SCRIPT_SRC = "//gc.zgo.at/count.js";
 
 const REPORT_SETTINGS_BUTTON = `<button
   class="settings-button"
@@ -215,6 +216,38 @@ function escapeHtml(value: string): string {
 }
 
 /**
+ * Build the optional GoatCounter analytics script from the configured public
+ * endpoint. Analytics remains disabled when the setting is unset.
+ *
+ * @returns An analytics script tag, or an empty string when disabled.
+ */
+function buildAnalyticsScript(): string {
+  const endpoint = process.env.WP_TREND_GOATCOUNTER_URL?.trim();
+  if (!endpoint) {
+    return "";
+  }
+
+  try {
+    const url = new URL(endpoint);
+    if (
+      url.protocol !== "https:" ||
+      url.pathname !== "/count" ||
+      url.search ||
+      url.hash
+    ) {
+      throw new Error("expected an HTTPS URL ending in /count");
+    }
+  } catch {
+    console.warn(
+      "Invalid WP_TREND_GOATCOUNTER_URL; analytics disabled. Use an HTTPS URL ending in /count.",
+    );
+    return "";
+  }
+
+  return `<script data-goatcounter="${escapeHtml(endpoint)}" async src="${GOATCOUNTER_SCRIPT_SRC}"></script>`;
+}
+
+/**
  * Build standard SEO / social-sharing meta tags for a report or index page.
  *
  * Emits a description, canonical link, Open Graph tags, and Twitter Card tags.
@@ -301,6 +334,7 @@ export async function generateHtmlReport(mdPath: string): Promise<string> {
     description: REPORT_SEO_DESCRIPTION,
   });
   const bodyHtml = renderReportBody(md);
+  const analyticsScript = buildAnalyticsScript();
 
   // Extract the h1 heading for the report header. Only the title portion
   // (before the " — " separator) becomes a link back to the index; the
@@ -338,6 +372,7 @@ export async function generateHtmlReport(mdPath: string): Promise<string> {
   <title>${escapeHtml(seo.title)}</title>
   <link rel="stylesheet" href="${stylesheetHref}">
   ${REPORT_THEME_SCRIPT}
+  ${analyticsScript}
   ${buildSeoMeta({
     title: seo.title,
     description: seo.description,
@@ -377,6 +412,7 @@ export async function generateHtmlReport(mdPath: string): Promise<string> {
  */
 export async function generateIndexPage(reportsDir: string): Promise<string> {
   const stylesheetHref = await ensureReportStylesheet(reportsDir);
+  const analyticsScript = buildAnalyticsScript();
   const files = await readdir(reportsDir);
   const htmlFiles = files
     .filter((f) => f.endsWith(".html") && f !== "index.html")
@@ -435,6 +471,7 @@ export async function generateIndexPage(reportsDir: string): Promise<string> {
   <title>WP Trend Watcher — Reports</title>
   <link rel="stylesheet" href="${stylesheetHref}">
   ${REPORT_THEME_SCRIPT}
+  ${analyticsScript}
   ${buildSeoMeta({
     title: "WP Trend Watcher — Reports",
     description: "Weekly human-reviewed WordPress ecosystem trend reports.",

--- a/src/summarize/index-page.ts
+++ b/src/summarize/index-page.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { loadEnvFile } from "../env.js";
 import { generateIndexPage } from "./html.js";
 
 /**
@@ -7,6 +8,7 @@ import { generateIndexPage } from "./html.js";
  * Scans the reports/ directory for *.html files and produces a listing page.
  */
 async function main(): Promise<void> {
+  loadEnvFile();
   const reportsDir = join(process.cwd(), "reports");
   const indexPath = await generateIndexPage(reportsDir);
   console.log(`Index page written: ${indexPath}`);

--- a/tests/summarize/html.test.ts
+++ b/tests/summarize/html.test.ts
@@ -134,6 +134,39 @@ test("generateHtmlReport does not produce TOC when only 1 heading exists", async
   assert.ok(html.includes('<div class="report-body">'));
 });
 
+test("generated pages include GoatCounter only when explicitly configured", async () => {
+  const previous = process.env.WP_TREND_GOATCOUNTER_URL;
+  const tmpDir = await mkdtemp(join(tmpdir(), "analytics-test-"));
+  const mdPath = join(tmpDir, "2026-06-21.md");
+  await writeFile(mdPath, "# Report\n\nContent.\n", "utf8");
+
+  try {
+    delete process.env.WP_TREND_GOATCOUNTER_URL;
+    const disabledHtml = await readFile(await generateHtmlReport(mdPath), "utf8");
+    assert.ok(!disabledHtml.includes("data-goatcounter"));
+
+    process.env.WP_TREND_GOATCOUNTER_URL =
+      "https://colorful-tones.goatcounter.com/count";
+    const enabledHtml = await readFile(await generateHtmlReport(mdPath), "utf8");
+    assert.ok(
+      enabledHtml.includes(
+        '<script data-goatcounter="https://colorful-tones.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>',
+      ),
+    );
+
+    const indexDir = await mkdtemp(join(tmpdir(), "analytics-index-test-"));
+    await writeFile(join(indexDir, "2026-06-21.html"), "<html></html>", "utf8");
+    const indexHtml = await readFile(await generateIndexPage(indexDir), "utf8");
+    assert.ok(indexHtml.includes("data-goatcounter"));
+  } finally {
+    if (previous === undefined) {
+      delete process.env.WP_TREND_GOATCOUNTER_URL;
+    } else {
+      process.env.WP_TREND_GOATCOUNTER_URL = previous;
+    }
+  }
+});
+
 test("generateHtmlReport wraps report header with h1 inside .report-header", async () => {
   const tmpDir = await mkdtemp(join(tmpdir(), "html-test-"));
   const mdPath = join(tmpDir, "2026-06-21.md");


### PR DESCRIPTION
## Summary
- Add configurable GoatCounter analytics to generated report pages and the reports index.
- Keep analytics disabled for local generation unless `WP_TREND_GOATCOUNTER_URL` is configured.
- Enable the configured endpoint for GitHub Pages and regenerate all committed HTML artifacts.

## Commits
- `feat(reports): add configurable GoatCounter analytics`
- `chore(reports): regenerate pages with GoatCounter`

## Verification
- `pnpm run test` — 216 tests passed
- `pnpm run typecheck` — passed
- `pnpm run regen-html` — passed
- Verified all 11 generated HTML pages contain the expected GoatCounter snippet
- `git diff --check` — passed