### PR TITLE
fix: improve report card layout on phones

### DIFF
--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -1127,6 +1127,18 @@ body.report-index {
   line-height: 1.02;
 }
 
+/* The archive becomes a single readable column on phone-width screens. */
+@media (max-width: 680px) {
+  .report-card-grid {
+    gap: 1rem;
+    grid-template-columns: 1fr;
+  }
+
+  .report-card {
+    min-height: auto;
+  }
+}
+
 /* Keep display controls available without competing with report content. */
 .report-hero .settings-button {
   align-items: center;

--- a/src/summarize/report.css
+++ b/src/summarize/report.css
@@ -1127,6 +1127,18 @@ body.report-index {
   line-height: 1.02;
 }
 
+/* The archive becomes a single readable column on phone-width screens. */
+@media (max-width: 680px) {
+  .report-card-grid {
+    gap: 1rem;
+    grid-template-columns: 1fr;
+  }
+
+  .report-card {
+    min-height: auto;
+  }
+}
+
 /* Keep display controls available without competing with report content. */
 .report-hero .settings-button {
   align-items: center;


### PR DESCRIPTION
## Summary
- Stack report archive cards into a single column below 680px.
- Increase the mobile card gap and remove the fixed card minimum height on phone-width screens.
- Keep wider tablet and desktop layouts unchanged.

## Verification
- `pnpm run regen-html` passed.
- `pnpm run test` passed: 216 tests.
- `pnpm run typecheck` passed.
- Direct CSS breakpoint probe passed.
- `git diff --check` passed.