### PR TITLE
fix: align report header with content layout

### DIFF
--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -1139,6 +1139,20 @@ body.report-index {
   }
 }
 
+/* Keep the hero aligned with the archive and report content boundaries. */
+.report-hero,
+.report-index-archive,
+.report-layout {
+  margin-inline: 0;
+  max-width: 100%;
+  width: 100%;
+}
+
+.report-hero {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 /* Keep display controls available without competing with report content. */
 .report-hero .settings-button {
   align-items: center;

--- a/src/summarize/report.css
+++ b/src/summarize/report.css
@@ -1139,6 +1139,20 @@ body.report-index {
   }
 }
 
+/* Keep the hero aligned with the archive and report content boundaries. */
+.report-hero,
+.report-index-archive,
+.report-layout {
+  margin-inline: 0;
+  max-width: 100%;
+  width: 100%;
+}
+
+.report-hero {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 /* Keep display controls available without competing with report content. */
 .report-hero .settings-button {
   align-items: center;


### PR DESCRIPTION
## Summary
- Align `.report-header` / `.report-hero` with the same inner content boundary as `.report-index-archive` and `.report-layout`.
- Remove the hero’s negative horizontal margin and internal horizontal padding that made it wider than the content below.
- Preserve the existing responsive layout behavior at phone widths.

## Verification
- `pnpm run regen-html` passed.
- `pnpm run test` passed: 216 tests.
- `pnpm run typecheck` passed.
- Direct width-alignment contract probe passed.
- `git diff --check` passed.