### PR TITLE
feat: dial in report theme surfaces and rhythm

### DIFF
--- a/docs/report-themes.md
+++ b/docs/report-themes.md
@@ -14,6 +14,8 @@ All styles share the same editorial report shell: the index uses an archive-and-
 
 Heading sizes, line heights, and letter-spacing are calibrated per display face rather than shared globally, so the wide geometric, serif, and compact display fonts retain their intended rhythm.
 
+The surface language is also intentionally different: Civic Brutalist uses hard offset shadows and decisive borders, Ink Editorial stays airy with hairline rules and no card shadows, and Neon Observatory uses rounded surfaces with restrained glow shadows.
+
 The current theme system is defined in:
 
 - `src/summarize/html.ts` — theme names, selector options, and the small pre-paint persistence script.

--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -303,7 +303,7 @@ details.article-inventory ol {
   --font-display: "Bricolage Grotesque", sans-serif;
   --font-body: "IBM Plex Mono", monospace;
   --font-mono: "IBM Plex Mono", monospace;
-  --theme-hero-padding: 3.5rem 0 3rem;
+  --theme-hero-padding: 3.5rem clamp(1.25rem, 4vw, 3rem) 3rem;
   --theme-layout-gap: clamp(2rem, 6vw, 5rem);
   --theme-layout-top: 3rem;
   --theme-card-gap: 0.75rem;
@@ -335,7 +335,7 @@ details.article-inventory ol {
   --font-display: "Instrument Serif", Georgia, serif;
   --font-body: "Space Grotesk", sans-serif;
   --font-mono: "Space Grotesk", sans-serif;
-  --theme-hero-padding: 4.5rem 0 4rem;
+  --theme-hero-padding: 4.5rem clamp(1.5rem, 6vw, 5rem) 4rem;
   --theme-layout-gap: clamp(3rem, 8vw, 6rem);
   --theme-layout-top: 4rem;
   --theme-card-gap: 1.25rem;
@@ -367,7 +367,7 @@ details.article-inventory ol {
   --font-display: "Syne", sans-serif;
   --font-body: "DM Mono", monospace;
   --font-mono: "DM Mono", monospace;
-  --theme-hero-padding: 3rem 0 2.75rem;
+  --theme-hero-padding: 3rem clamp(1rem, 3vw, 2.5rem) 2.75rem;
   --theme-layout-gap: clamp(2rem, 5vw, 4rem);
   --theme-layout-top: 2.5rem;
   --theme-card-gap: 0.75rem;
@@ -1196,11 +1196,6 @@ body.report-index {
   margin-inline: 0;
   max-width: 100%;
   width: 100%;
-}
-
-.report-hero {
-  padding-left: 0;
-  padding-right: 0;
 }
 
 /* Theme rhythm and surface application */

--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -315,7 +315,7 @@ details.article-inventory ol {
   --theme-card-shadow: none;
   --theme-card-hover-shadow: 8px 8px 0 var(--accent);
   --theme-hero-shadow: none;
-  --theme-section-space: 4rem;
+  --theme-section-space: 2rem;
   --theme-body-size: 0.95rem;
   --theme-body-leading: 1.6;
   --theme-card-leading: 1;
@@ -867,7 +867,7 @@ body.report-index {
 
 .report-index-count strong {
   font: 800 clamp(4rem, 8vw, 7rem) / 0.8 var(--font-display);
-  letter-spacing: -0.08em;
+  letter-spacing: 0.01em;
 }
 
 .report-index-count span {
@@ -1122,59 +1122,60 @@ body.report-index {
    x-height, so shared size/spacing values make the styles feel inconsistent. */
 :root[data-theme="civic-brutalist"] .report-hero h1 {
   font-size: clamp(3.8rem, 9vw, 8rem);
-  letter-spacing: -0.09em;
+  letter-spacing: -0.04em;
   line-height: 0.78;
 }
 
 :root[data-theme="civic-brutalist"] .report-body > h2,
 :root[data-theme="civic-brutalist"] .report-index-heading h2 {
   font-size: clamp(2.4rem, 5vw, 4.6rem);
-  letter-spacing: -0.08em;
+  letter-spacing: -0.03em;
   line-height: 0.86;
 }
 
 :root[data-theme="civic-brutalist"] .report-card-title {
   font-size: 1.45rem;
-  letter-spacing: -0.04em;
+  letter-spacing: -0.02em;
   line-height: 1;
 }
 
 :root[data-theme="ink-editorial"] .report-hero h1 {
   font-size: clamp(4rem, 10vw, 8.8rem);
-  letter-spacing: -0.045em;
-  line-height: 0.82;
+  letter-spacing: -0.01em;
+  line-height: 0.98;
 }
 
 :root[data-theme="ink-editorial"] .report-body > h2,
 :root[data-theme="ink-editorial"] .report-index-heading h2 {
   font-size: clamp(2.8rem, 6vw, 5.2rem);
-  letter-spacing: -0.025em;
+  letter-spacing: -0.01em;
   line-height: 0.82;
 }
 
 :root[data-theme="ink-editorial"] .report-card-title {
   font-size: 1.7rem;
-  letter-spacing: -0.025em;
+  letter-spacing: 0;
   line-height: 0.98;
 }
 
 :root[data-theme="neon-observatory"] .report-hero h1 {
-  font-size: clamp(3.3rem, 8vw, 7.7rem);
-  letter-spacing: -0.08em;
-  line-height: 0.88;
+  font-size: clamp(3.3rem, 8vw, 5rem);
+  letter-spacing: -0.03em;
+  line-height: 0.94;
 }
 
 :root[data-theme="neon-observatory"] .report-body > h2,
 :root[data-theme="neon-observatory"] .report-index-heading h2 {
-  font-size: clamp(2.2rem, 5vw, 4.2rem);
-  letter-spacing: -0.075em;
+  font-size: clamp(2.2rem, 5vw, 3rem);
+  font-weight: 600;
+  letter-spacing: -0.02em;
   line-height: 0.88;
 }
 
 :root[data-theme="neon-observatory"] .report-card-title {
   font-size: 1.35rem;
-  letter-spacing: -0.05em;
-  line-height: 1.02;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
 }
 
 /* The archive becomes a single readable column on phone-width screens. */
@@ -1225,7 +1226,7 @@ body.report-index {
 }
 
 .report-body > h2 {
-  border-top-width: var(--theme-border-width);
+  border-top-width: 0;
 }
 
 .report-body > h2:not(:first-child) {

--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -303,6 +303,22 @@ details.article-inventory ol {
   --font-display: "Bricolage Grotesque", sans-serif;
   --font-body: "IBM Plex Mono", monospace;
   --font-mono: "IBM Plex Mono", monospace;
+  --theme-hero-padding: 3.5rem 0 3rem;
+  --theme-layout-gap: clamp(2rem, 6vw, 5rem);
+  --theme-layout-top: 3rem;
+  --theme-card-gap: 0.75rem;
+  --theme-card-padding: 1.25rem;
+  --theme-card-radius: 0;
+  --theme-border-width: 2px;
+  --theme-hero-border-width: 8px;
+  --theme-toc-border-width: 2px;
+  --theme-card-shadow: none;
+  --theme-card-hover-shadow: 6px 6px 0 var(--text);
+  --theme-hero-shadow: none;
+  --theme-section-space: 4rem;
+  --theme-body-size: 0.95rem;
+  --theme-body-leading: 1.6;
+  --theme-card-leading: 1;
 }
 
 :root[data-theme="ink-editorial"] {
@@ -319,6 +335,22 @@ details.article-inventory ol {
   --font-display: "Instrument Serif", Georgia, serif;
   --font-body: "Space Grotesk", sans-serif;
   --font-mono: "Space Grotesk", sans-serif;
+  --theme-hero-padding: 4.5rem 0 4rem;
+  --theme-layout-gap: clamp(3rem, 8vw, 6rem);
+  --theme-layout-top: 4rem;
+  --theme-card-gap: 1.25rem;
+  --theme-card-padding: 1.5rem;
+  --theme-card-radius: 0;
+  --theme-border-width: 1px;
+  --theme-hero-border-width: 2px;
+  --theme-toc-border-width: 1px;
+  --theme-card-shadow: none;
+  --theme-card-hover-shadow: none;
+  --theme-hero-shadow: none;
+  --theme-section-space: 5rem;
+  --theme-body-size: 1.02rem;
+  --theme-body-leading: 1.75;
+  --theme-card-leading: 0.98;
 }
 
 :root[data-theme="neon-observatory"] {
@@ -335,6 +367,22 @@ details.article-inventory ol {
   --font-display: "Syne", sans-serif;
   --font-body: "DM Mono", monospace;
   --font-mono: "DM Mono", monospace;
+  --theme-hero-padding: 3rem 0 2.75rem;
+  --theme-layout-gap: clamp(2rem, 5vw, 4rem);
+  --theme-layout-top: 2.5rem;
+  --theme-card-gap: 0.75rem;
+  --theme-card-padding: 1.1rem;
+  --theme-card-radius: 10px;
+  --theme-border-width: 1px;
+  --theme-hero-border-width: 1px;
+  --theme-toc-border-width: 1px;
+  --theme-card-shadow: 0 0 1.5rem rgba(117, 228, 255, 0.08);
+  --theme-card-hover-shadow: 0 0 2rem rgba(255, 107, 169, 0.3);
+  --theme-hero-shadow: 0 0 0 1px var(--accent), 0 0 3rem rgba(117, 228, 255, 0.12);
+  --theme-section-space: 3.5rem;
+  --theme-body-size: 0.9rem;
+  --theme-body-leading: 1.55;
+  --theme-card-leading: 1.02;
 }
 
 :root[data-mode="dark"] {
@@ -351,6 +399,7 @@ details.article-inventory ol {
 :root[data-theme="civic-brutalist"][data-mode="dark"] {
   --accent: #f06b4d;
   --theme-gradient: linear-gradient(135deg, rgba(245, 213, 71, 0.16), transparent 36%);
+  --theme-card-hover-shadow: 6px 6px 0 var(--accent);
 }
 
 :root[data-theme="ink-editorial"][data-mode="dark"] {
@@ -378,6 +427,7 @@ details.article-inventory ol {
   :root[data-theme="civic-brutalist"][data-mode="system"] {
     --accent: #f06b4d;
     --theme-gradient: linear-gradient(135deg, rgba(245, 213, 71, 0.16), transparent 36%);
+    --theme-card-hover-shadow: 6px 6px 0 var(--accent);
   }
 
   :root[data-theme="ink-editorial"][data-mode="system"] {
@@ -1151,6 +1201,74 @@ body.report-index {
 .report-hero {
   padding-left: 0;
   padding-right: 0;
+}
+
+/* Theme rhythm and surface application */
+.report-hero {
+  border-bottom-width: var(--theme-hero-border-width);
+  box-shadow: var(--theme-hero-shadow);
+  gap: var(--theme-layout-gap);
+  padding: var(--theme-hero-padding);
+}
+
+.report-layout {
+  gap: var(--theme-layout-gap);
+  padding-top: var(--theme-layout-top);
+}
+
+.report-index-archive {
+  margin-top: var(--theme-layout-top);
+}
+
+.report-rail .toc {
+  border-left-width: var(--theme-toc-border-width);
+}
+
+.report-body {
+  font-size: var(--theme-body-size);
+  line-height: var(--theme-body-leading);
+}
+
+.report-body > h2 {
+  border-top-width: var(--theme-border-width);
+}
+
+.report-body > h2:not(:first-child) {
+  margin-top: var(--theme-section-space);
+}
+
+.report-body details.article-inventory {
+  border-width: var(--theme-border-width);
+  border-radius: var(--theme-card-radius);
+  padding: var(--theme-card-padding);
+}
+
+.report-index-heading {
+  margin-bottom: var(--theme-card-gap);
+}
+
+.report-card-grid {
+  gap: var(--theme-card-gap);
+}
+
+.report-card {
+  border-radius: var(--theme-card-radius);
+  border-width: var(--theme-border-width);
+  border-left-width: var(--theme-border-width);
+  box-shadow: var(--theme-card-shadow);
+  padding: var(--theme-card-padding);
+}
+
+.report-card:hover {
+  box-shadow: var(--theme-card-hover-shadow);
+}
+
+.report-card-title {
+  line-height: var(--theme-card-leading);
+}
+
+.report-hero .settings-button {
+  box-shadow: var(--theme-card-shadow);
 }
 
 /* Keep display controls available without competing with report content. */

--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -313,7 +313,7 @@ details.article-inventory ol {
   --theme-hero-border-width: 8px;
   --theme-toc-border-width: 2px;
   --theme-card-shadow: none;
-  --theme-card-hover-shadow: 6px 6px 0 var(--text);
+  --theme-card-hover-shadow: 8px 8px 0 var(--accent);
   --theme-hero-shadow: none;
   --theme-section-space: 4rem;
   --theme-body-size: 0.95rem;
@@ -344,8 +344,8 @@ details.article-inventory ol {
   --theme-border-width: 1px;
   --theme-hero-border-width: 2px;
   --theme-toc-border-width: 1px;
-  --theme-card-shadow: none;
-  --theme-card-hover-shadow: none;
+  --theme-card-shadow: 0 6px 18px rgba(23, 33, 31, 0.06);
+  --theme-card-hover-shadow: 0 14px 30px rgba(23, 33, 31, 0.12);
   --theme-hero-shadow: none;
   --theme-section-space: 5rem;
   --theme-body-size: 1.02rem;
@@ -376,8 +376,8 @@ details.article-inventory ol {
   --theme-border-width: 1px;
   --theme-hero-border-width: 1px;
   --theme-toc-border-width: 1px;
-  --theme-card-shadow: 0 0 1.5rem rgba(117, 228, 255, 0.08);
-  --theme-card-hover-shadow: 0 0 2rem rgba(255, 107, 169, 0.3);
+  --theme-card-shadow: 0 0 18px rgba(117, 228, 255, 0.12), inset 0 0 0 1px rgba(117, 228, 255, 0.08);
+  --theme-card-hover-shadow: 0 0 28px rgba(255, 107, 169, 0.35), 0 0 8px rgba(117, 228, 255, 0.18);
   --theme-hero-shadow: 0 0 0 1px var(--accent), 0 0 3rem rgba(117, 228, 255, 0.12);
   --theme-section-space: 3.5rem;
   --theme-body-size: 0.9rem;
@@ -399,7 +399,7 @@ details.article-inventory ol {
 :root[data-theme="civic-brutalist"][data-mode="dark"] {
   --accent: #f06b4d;
   --theme-gradient: linear-gradient(135deg, rgba(245, 213, 71, 0.16), transparent 36%);
-  --theme-card-hover-shadow: 6px 6px 0 var(--accent);
+  --theme-card-hover-shadow: 8px 8px 0 var(--accent);
 }
 
 :root[data-theme="ink-editorial"][data-mode="dark"] {
@@ -427,7 +427,7 @@ details.article-inventory ol {
   :root[data-theme="civic-brutalist"][data-mode="system"] {
     --accent: #f06b4d;
     --theme-gradient: linear-gradient(135deg, rgba(245, 213, 71, 0.16), transparent 36%);
-    --theme-card-hover-shadow: 6px 6px 0 var(--accent);
+    --theme-card-hover-shadow: 8px 8px 0 var(--accent);
   }
 
   :root[data-theme="ink-editorial"][data-mode="system"] {

--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -1266,6 +1266,30 @@ body.report-index {
   box-shadow: var(--theme-card-shadow);
 }
 
+:root[data-theme="civic-brutalist"][data-mode="light"] .report-hero {
+  background: var(--page-bg);
+  border-top: 2px solid var(--text);
+  color: var(--text);
+}
+
+:root[data-theme="civic-brutalist"][data-mode="light"] .report-hero .report-description,
+:root[data-theme="civic-brutalist"][data-mode="light"] .report-index-count span {
+  color: var(--muted);
+}
+
+@media (prefers-color-scheme: light) {
+  :root[data-theme="civic-brutalist"][data-mode="system"] .report-hero {
+    background: var(--page-bg);
+    border-top: 2px solid var(--text);
+    color: var(--text);
+  }
+
+  :root[data-theme="civic-brutalist"][data-mode="system"] .report-hero .report-description,
+  :root[data-theme="civic-brutalist"][data-mode="system"] .report-index-count span {
+    color: var(--muted);
+  }
+}
+
 /* Keep display controls available without competing with report content. */
 .report-hero .settings-button {
   align-items: center;

--- a/src/summarize/report.css
+++ b/src/summarize/report.css
@@ -303,7 +303,7 @@ details.article-inventory ol {
   --font-display: "Bricolage Grotesque", sans-serif;
   --font-body: "IBM Plex Mono", monospace;
   --font-mono: "IBM Plex Mono", monospace;
-  --theme-hero-padding: 3.5rem 0 3rem;
+  --theme-hero-padding: 3.5rem clamp(1.25rem, 4vw, 3rem) 3rem;
   --theme-layout-gap: clamp(2rem, 6vw, 5rem);
   --theme-layout-top: 3rem;
   --theme-card-gap: 0.75rem;
@@ -335,7 +335,7 @@ details.article-inventory ol {
   --font-display: "Instrument Serif", Georgia, serif;
   --font-body: "Space Grotesk", sans-serif;
   --font-mono: "Space Grotesk", sans-serif;
-  --theme-hero-padding: 4.5rem 0 4rem;
+  --theme-hero-padding: 4.5rem clamp(1.5rem, 6vw, 5rem) 4rem;
   --theme-layout-gap: clamp(3rem, 8vw, 6rem);
   --theme-layout-top: 4rem;
   --theme-card-gap: 1.25rem;
@@ -367,7 +367,7 @@ details.article-inventory ol {
   --font-display: "Syne", sans-serif;
   --font-body: "DM Mono", monospace;
   --font-mono: "DM Mono", monospace;
-  --theme-hero-padding: 3rem 0 2.75rem;
+  --theme-hero-padding: 3rem clamp(1rem, 3vw, 2.5rem) 2.75rem;
   --theme-layout-gap: clamp(2rem, 5vw, 4rem);
   --theme-layout-top: 2.5rem;
   --theme-card-gap: 0.75rem;
@@ -1196,11 +1196,6 @@ body.report-index {
   margin-inline: 0;
   max-width: 100%;
   width: 100%;
-}
-
-.report-hero {
-  padding-left: 0;
-  padding-right: 0;
 }
 
 /* Theme rhythm and surface application */

--- a/src/summarize/report.css
+++ b/src/summarize/report.css
@@ -315,7 +315,7 @@ details.article-inventory ol {
   --theme-card-shadow: none;
   --theme-card-hover-shadow: 8px 8px 0 var(--accent);
   --theme-hero-shadow: none;
-  --theme-section-space: 4rem;
+  --theme-section-space: 2rem;
   --theme-body-size: 0.95rem;
   --theme-body-leading: 1.6;
   --theme-card-leading: 1;
@@ -867,7 +867,7 @@ body.report-index {
 
 .report-index-count strong {
   font: 800 clamp(4rem, 8vw, 7rem) / 0.8 var(--font-display);
-  letter-spacing: -0.08em;
+  letter-spacing: 0.01em;
 }
 
 .report-index-count span {
@@ -1122,59 +1122,60 @@ body.report-index {
    x-height, so shared size/spacing values make the styles feel inconsistent. */
 :root[data-theme="civic-brutalist"] .report-hero h1 {
   font-size: clamp(3.8rem, 9vw, 8rem);
-  letter-spacing: -0.09em;
+  letter-spacing: -0.04em;
   line-height: 0.78;
 }
 
 :root[data-theme="civic-brutalist"] .report-body > h2,
 :root[data-theme="civic-brutalist"] .report-index-heading h2 {
   font-size: clamp(2.4rem, 5vw, 4.6rem);
-  letter-spacing: -0.08em;
+  letter-spacing: -0.03em;
   line-height: 0.86;
 }
 
 :root[data-theme="civic-brutalist"] .report-card-title {
   font-size: 1.45rem;
-  letter-spacing: -0.04em;
+  letter-spacing: -0.02em;
   line-height: 1;
 }
 
 :root[data-theme="ink-editorial"] .report-hero h1 {
   font-size: clamp(4rem, 10vw, 8.8rem);
-  letter-spacing: -0.045em;
-  line-height: 0.82;
+  letter-spacing: -0.01em;
+  line-height: 0.98;
 }
 
 :root[data-theme="ink-editorial"] .report-body > h2,
 :root[data-theme="ink-editorial"] .report-index-heading h2 {
   font-size: clamp(2.8rem, 6vw, 5.2rem);
-  letter-spacing: -0.025em;
+  letter-spacing: -0.01em;
   line-height: 0.82;
 }
 
 :root[data-theme="ink-editorial"] .report-card-title {
   font-size: 1.7rem;
-  letter-spacing: -0.025em;
+  letter-spacing: 0;
   line-height: 0.98;
 }
 
 :root[data-theme="neon-observatory"] .report-hero h1 {
-  font-size: clamp(3.3rem, 8vw, 7.7rem);
-  letter-spacing: -0.08em;
-  line-height: 0.88;
+  font-size: clamp(3.3rem, 8vw, 5rem);
+  letter-spacing: -0.03em;
+  line-height: 0.94;
 }
 
 :root[data-theme="neon-observatory"] .report-body > h2,
 :root[data-theme="neon-observatory"] .report-index-heading h2 {
-  font-size: clamp(2.2rem, 5vw, 4.2rem);
-  letter-spacing: -0.075em;
+  font-size: clamp(2.2rem, 5vw, 3rem);
+  font-weight: 600;
+  letter-spacing: -0.02em;
   line-height: 0.88;
 }
 
 :root[data-theme="neon-observatory"] .report-card-title {
   font-size: 1.35rem;
-  letter-spacing: -0.05em;
-  line-height: 1.02;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
 }
 
 /* The archive becomes a single readable column on phone-width screens. */
@@ -1225,7 +1226,7 @@ body.report-index {
 }
 
 .report-body > h2 {
-  border-top-width: var(--theme-border-width);
+  border-top-width: 0;
 }
 
 .report-body > h2:not(:first-child) {

--- a/src/summarize/report.css
+++ b/src/summarize/report.css
@@ -303,6 +303,22 @@ details.article-inventory ol {
   --font-display: "Bricolage Grotesque", sans-serif;
   --font-body: "IBM Plex Mono", monospace;
   --font-mono: "IBM Plex Mono", monospace;
+  --theme-hero-padding: 3.5rem 0 3rem;
+  --theme-layout-gap: clamp(2rem, 6vw, 5rem);
+  --theme-layout-top: 3rem;
+  --theme-card-gap: 0.75rem;
+  --theme-card-padding: 1.25rem;
+  --theme-card-radius: 0;
+  --theme-border-width: 2px;
+  --theme-hero-border-width: 8px;
+  --theme-toc-border-width: 2px;
+  --theme-card-shadow: none;
+  --theme-card-hover-shadow: 6px 6px 0 var(--text);
+  --theme-hero-shadow: none;
+  --theme-section-space: 4rem;
+  --theme-body-size: 0.95rem;
+  --theme-body-leading: 1.6;
+  --theme-card-leading: 1;
 }
 
 :root[data-theme="ink-editorial"] {
@@ -319,6 +335,22 @@ details.article-inventory ol {
   --font-display: "Instrument Serif", Georgia, serif;
   --font-body: "Space Grotesk", sans-serif;
   --font-mono: "Space Grotesk", sans-serif;
+  --theme-hero-padding: 4.5rem 0 4rem;
+  --theme-layout-gap: clamp(3rem, 8vw, 6rem);
+  --theme-layout-top: 4rem;
+  --theme-card-gap: 1.25rem;
+  --theme-card-padding: 1.5rem;
+  --theme-card-radius: 0;
+  --theme-border-width: 1px;
+  --theme-hero-border-width: 2px;
+  --theme-toc-border-width: 1px;
+  --theme-card-shadow: none;
+  --theme-card-hover-shadow: none;
+  --theme-hero-shadow: none;
+  --theme-section-space: 5rem;
+  --theme-body-size: 1.02rem;
+  --theme-body-leading: 1.75;
+  --theme-card-leading: 0.98;
 }
 
 :root[data-theme="neon-observatory"] {
@@ -335,6 +367,22 @@ details.article-inventory ol {
   --font-display: "Syne", sans-serif;
   --font-body: "DM Mono", monospace;
   --font-mono: "DM Mono", monospace;
+  --theme-hero-padding: 3rem 0 2.75rem;
+  --theme-layout-gap: clamp(2rem, 5vw, 4rem);
+  --theme-layout-top: 2.5rem;
+  --theme-card-gap: 0.75rem;
+  --theme-card-padding: 1.1rem;
+  --theme-card-radius: 10px;
+  --theme-border-width: 1px;
+  --theme-hero-border-width: 1px;
+  --theme-toc-border-width: 1px;
+  --theme-card-shadow: 0 0 1.5rem rgba(117, 228, 255, 0.08);
+  --theme-card-hover-shadow: 0 0 2rem rgba(255, 107, 169, 0.3);
+  --theme-hero-shadow: 0 0 0 1px var(--accent), 0 0 3rem rgba(117, 228, 255, 0.12);
+  --theme-section-space: 3.5rem;
+  --theme-body-size: 0.9rem;
+  --theme-body-leading: 1.55;
+  --theme-card-leading: 1.02;
 }
 
 :root[data-mode="dark"] {
@@ -351,6 +399,7 @@ details.article-inventory ol {
 :root[data-theme="civic-brutalist"][data-mode="dark"] {
   --accent: #f06b4d;
   --theme-gradient: linear-gradient(135deg, rgba(245, 213, 71, 0.16), transparent 36%);
+  --theme-card-hover-shadow: 6px 6px 0 var(--accent);
 }
 
 :root[data-theme="ink-editorial"][data-mode="dark"] {
@@ -378,6 +427,7 @@ details.article-inventory ol {
   :root[data-theme="civic-brutalist"][data-mode="system"] {
     --accent: #f06b4d;
     --theme-gradient: linear-gradient(135deg, rgba(245, 213, 71, 0.16), transparent 36%);
+    --theme-card-hover-shadow: 6px 6px 0 var(--accent);
   }
 
   :root[data-theme="ink-editorial"][data-mode="system"] {
@@ -1151,6 +1201,74 @@ body.report-index {
 .report-hero {
   padding-left: 0;
   padding-right: 0;
+}
+
+/* Theme rhythm and surface application */
+.report-hero {
+  border-bottom-width: var(--theme-hero-border-width);
+  box-shadow: var(--theme-hero-shadow);
+  gap: var(--theme-layout-gap);
+  padding: var(--theme-hero-padding);
+}
+
+.report-layout {
+  gap: var(--theme-layout-gap);
+  padding-top: var(--theme-layout-top);
+}
+
+.report-index-archive {
+  margin-top: var(--theme-layout-top);
+}
+
+.report-rail .toc {
+  border-left-width: var(--theme-toc-border-width);
+}
+
+.report-body {
+  font-size: var(--theme-body-size);
+  line-height: var(--theme-body-leading);
+}
+
+.report-body > h2 {
+  border-top-width: var(--theme-border-width);
+}
+
+.report-body > h2:not(:first-child) {
+  margin-top: var(--theme-section-space);
+}
+
+.report-body details.article-inventory {
+  border-width: var(--theme-border-width);
+  border-radius: var(--theme-card-radius);
+  padding: var(--theme-card-padding);
+}
+
+.report-index-heading {
+  margin-bottom: var(--theme-card-gap);
+}
+
+.report-card-grid {
+  gap: var(--theme-card-gap);
+}
+
+.report-card {
+  border-radius: var(--theme-card-radius);
+  border-width: var(--theme-border-width);
+  border-left-width: var(--theme-border-width);
+  box-shadow: var(--theme-card-shadow);
+  padding: var(--theme-card-padding);
+}
+
+.report-card:hover {
+  box-shadow: var(--theme-card-hover-shadow);
+}
+
+.report-card-title {
+  line-height: var(--theme-card-leading);
+}
+
+.report-hero .settings-button {
+  box-shadow: var(--theme-card-shadow);
 }
 
 /* Keep display controls available without competing with report content. */

--- a/src/summarize/report.css
+++ b/src/summarize/report.css
@@ -313,7 +313,7 @@ details.article-inventory ol {
   --theme-hero-border-width: 8px;
   --theme-toc-border-width: 2px;
   --theme-card-shadow: none;
-  --theme-card-hover-shadow: 6px 6px 0 var(--text);
+  --theme-card-hover-shadow: 8px 8px 0 var(--accent);
   --theme-hero-shadow: none;
   --theme-section-space: 4rem;
   --theme-body-size: 0.95rem;
@@ -344,8 +344,8 @@ details.article-inventory ol {
   --theme-border-width: 1px;
   --theme-hero-border-width: 2px;
   --theme-toc-border-width: 1px;
-  --theme-card-shadow: none;
-  --theme-card-hover-shadow: none;
+  --theme-card-shadow: 0 6px 18px rgba(23, 33, 31, 0.06);
+  --theme-card-hover-shadow: 0 14px 30px rgba(23, 33, 31, 0.12);
   --theme-hero-shadow: none;
   --theme-section-space: 5rem;
   --theme-body-size: 1.02rem;
@@ -376,8 +376,8 @@ details.article-inventory ol {
   --theme-border-width: 1px;
   --theme-hero-border-width: 1px;
   --theme-toc-border-width: 1px;
-  --theme-card-shadow: 0 0 1.5rem rgba(117, 228, 255, 0.08);
-  --theme-card-hover-shadow: 0 0 2rem rgba(255, 107, 169, 0.3);
+  --theme-card-shadow: 0 0 18px rgba(117, 228, 255, 0.12), inset 0 0 0 1px rgba(117, 228, 255, 0.08);
+  --theme-card-hover-shadow: 0 0 28px rgba(255, 107, 169, 0.35), 0 0 8px rgba(117, 228, 255, 0.18);
   --theme-hero-shadow: 0 0 0 1px var(--accent), 0 0 3rem rgba(117, 228, 255, 0.12);
   --theme-section-space: 3.5rem;
   --theme-body-size: 0.9rem;
@@ -399,7 +399,7 @@ details.article-inventory ol {
 :root[data-theme="civic-brutalist"][data-mode="dark"] {
   --accent: #f06b4d;
   --theme-gradient: linear-gradient(135deg, rgba(245, 213, 71, 0.16), transparent 36%);
-  --theme-card-hover-shadow: 6px 6px 0 var(--accent);
+  --theme-card-hover-shadow: 8px 8px 0 var(--accent);
 }
 
 :root[data-theme="ink-editorial"][data-mode="dark"] {
@@ -427,7 +427,7 @@ details.article-inventory ol {
   :root[data-theme="civic-brutalist"][data-mode="system"] {
     --accent: #f06b4d;
     --theme-gradient: linear-gradient(135deg, rgba(245, 213, 71, 0.16), transparent 36%);
-    --theme-card-hover-shadow: 6px 6px 0 var(--accent);
+    --theme-card-hover-shadow: 8px 8px 0 var(--accent);
   }
 
   :root[data-theme="ink-editorial"][data-mode="system"] {

--- a/src/summarize/report.css
+++ b/src/summarize/report.css
@@ -1266,6 +1266,30 @@ body.report-index {
   box-shadow: var(--theme-card-shadow);
 }
 
+:root[data-theme="civic-brutalist"][data-mode="light"] .report-hero {
+  background: var(--page-bg);
+  border-top: 2px solid var(--text);
+  color: var(--text);
+}
+
+:root[data-theme="civic-brutalist"][data-mode="light"] .report-hero .report-description,
+:root[data-theme="civic-brutalist"][data-mode="light"] .report-index-count span {
+  color: var(--muted);
+}
+
+@media (prefers-color-scheme: light) {
+  :root[data-theme="civic-brutalist"][data-mode="system"] .report-hero {
+    background: var(--page-bg);
+    border-top: 2px solid var(--text);
+    color: var(--text);
+  }
+
+  :root[data-theme="civic-brutalist"][data-mode="system"] .report-hero .report-description,
+  :root[data-theme="civic-brutalist"][data-mode="system"] .report-index-count span {
+    color: var(--muted);
+  }
+}
+
 /* Keep display controls available without competing with report content. */
 .report-hero .settings-button {
   align-items: center;


### PR DESCRIPTION
## Summary
- Add explicit per-theme tokens for hero padding, layout gaps, card spacing, border widths, radii, shadows, section rhythm, body leading, and card leading.
- Civic Brutalist: light ink-on-paper hero, hard borders, no resting shadow, decisive 8px offset card hover shadow, compressed rhythm.
- Ink Editorial: airy spacing, hairline rules, soft editorial card lift, generous reading leading.
- Neon Observatory: rounded surfaces, layered cyan/pink glow shadows, tighter spacing, compact dashboard rhythm.
- Apply the tokens consistently to heroes, archive cards, report layout, rail, report body, article inventory, and display controls.
- Give each hero responsive theme-specific horizontal padding so the shell does not feel flush on desktop or phone screens.
- Document the differentiated surface language.

## Verification
- `pnpm run regen-html` passed.
- `pnpm run test` passed: 216 tests.
- `pnpm run typecheck` passed.
- Per-theme token/application probe passed.
- Responsive hero-padding probe passed.
- Distinct card-shadow probe passed.
- Civic light-hero probe passed.
- `git diff --check` passed.

## Commits
- `feat: dial in report theme surfaces and rhythm`
- `fix: add responsive theme hero spacing`
- `fix: differentiate report card shadows`
- `fix: refine theme surface contrast`