### PR TITLE
feat: add smooth report navigation

### DIFF
--- a/reports/assets/report.css
+++ b/reports/assets/report.css
@@ -1320,3 +1320,18 @@ body.report-index {
   height: 1.1rem;
   width: 1.1rem;
 }
+
+html {
+  scroll-behavior: smooth;
+}
+
+.report-body [id],
+.report-index-archive [id] {
+  scroll-margin-top: 1.5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}

--- a/src/summarize/report.css
+++ b/src/summarize/report.css
@@ -1320,3 +1320,18 @@ body.report-index {
   height: 1.1rem;
   width: 1.1rem;
 }
+
+html {
+  scroll-behavior: smooth;
+}
+
+.report-body [id],
+.report-index-archive [id] {
+  scroll-margin-top: 1.5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- Add smooth scrolling for table-of-contents and archive anchor navigation.
- Add `scroll-margin-top` so anchored headings have comfortable spacing from the viewport edge.
- Respect `prefers-reduced-motion` by disabling animated scrolling for users who request reduced motion.

## Verification
- `pnpm run regen-html` passed.
- `pnpm run test` passed: 216 tests.
- `pnpm run typecheck` passed.
- Smooth-scroll contract probe passed.
- `git diff --check` passed.