### PR TITLE
feat: add static RSS feed for published reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The goal is to collect useful WordPress ecosystem updates, summarize them effici
 
 ## Latest Reports
 
-Published weekly reports are available at [colorful-tones.github.io/wp-trend-watcher](https://colorful-tones.github.io/wp-trend-watcher/).
+Published weekly reports are available at [colorful-tones.github.io/wp-trend-watcher](https://colorful-tones.github.io/wp-trend-watcher/). Subscribe to new reports via RSS at [colorful-tones.github.io/wp-trend-watcher/feed.xml](https://colorful-tones.github.io/wp-trend-watcher/feed.xml).
 
 ## Intended Audience
 
@@ -47,7 +47,7 @@ Summarization requires a local LLM provider (see Requirements above). LM Studio 
 pnpm collect         # Fetch RSS feeds from 6 sources (4 Tier 1 + 2 Tier 2), store articles as JSON
 pnpm summarize       # Fetch article content, generate summaries, synthesize the weekly report, and build HTML + index
 pnpm generate-report # Regenerate the report from saved article summaries
-pnpm index-page      # Regenerate the reports index.html listing page
+pnpm index-page      # Regenerate the reports index.html listing page and RSS feed
 pnpm doctor          # Check environment readiness before first summarize
 pnpm review          # Review checklist for the latest report
 pnpm generate-descriptions # Fill or regenerate SEO descriptions
@@ -61,6 +61,8 @@ Use `pnpm weekly -- --no-open` to skip the automatic browser launch.
 Individual commands remain available for diagnosis and recovery — for example, running `pnpm collect` or `pnpm summarize` separately when you only need that step.
 
 `pnpm summarize` produces an HTML report alongside the Markdown file and writes shared report styles to `reports/assets/report.css`. The Radio Canada variable font is copied to `reports/assets/` alongside it. Reports are deployed to [GitHub Pages](https://colorful-tones.github.io/wp-trend-watcher/) on every push to `main` via the `pages.yml` workflow. Configure GitHub Pages to deploy from the `github-pages` environment (Settings → Pages → Source: GitHub Actions).
+
+The `reports/feed.xml` RSS feed is rebuilt alongside the reports index by `pnpm index-page`, `pnpm summarize`, `pnpm generate-report`, and `pnpm regen-html`, so subscribers always see the current archive.
 
 Generated report pages include Style and Mode controls for Aurora Blueprint, Aurora Mesh, and Signal Stripe, with Light, Dark, and System modes. The selected preferences are saved in the browser's local storage and reused across the report index and individual reports.
 
@@ -99,6 +101,11 @@ Both templates walk you through what's needed — takes about a minute.
 
 ## Changelog
 
+### 0.13.0
+
+- Added a static RSS 2.0 feed at `reports/feed.xml`, generated from the published report archive with the newest report first.
+- Added RSS autodiscovery and a visible "Subscribe via RSS" link to the reports index.
+
 ### 0.12.0
 
 - Added an editorial archive layout for the reports index with richer report cards and issue count treatment.
@@ -110,19 +117,5 @@ Both templates walk you through what's needed — takes about a minute.
 - Replaced the report styles with Civic Brutalist, Ink Editorial, and Neon Observatory.
 - Added dedicated light, dark, and system-mode presentation for each style.
 - Made Civic Brutalist the default report style and added unusual Google Font pairings.
-
-### 0.10.2
-
-- Added optional GoatCounter analytics to generated report pages and the reports index. Configure `WP_TREND_GOATCOUNTER_URL` to enable it; local previews remain analytics-free when unset.
-
-### 0.9.0
-
-- Added generated SEO titles and descriptions to reports, including visible report introductions and concise descriptions on index cards.
-- Reused generated metadata for report page titles, descriptions, canonical social metadata, and index-card headings.
-
-### 0.8.0
-
-- Added GitHub project links to the report index and individual report footers.
-- Added persistent report style and color-mode controls with accessible light and dark variants for all three visual directions.
 
 For older releases, see the [GitHub Releases page](https://github.com/colorful-tones/wp-trend-watcher/releases).

--- a/reports/feed.xml
+++ b/reports/feed.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>WP Trend Watcher</title>
+    <link>https://colorful-tones.github.io/wp-trend-watcher/</link>
+    <description>Weekly human-reviewed WordPress ecosystem trend reports.</description>
+    <language>en-us</language>
+    <atom:link href="https://colorful-tones.github.io/wp-trend-watcher/feed.xml" rel="self" type="application/rss+xml"/>
+    <lastBuildDate>Mon, 24 Aug 2026 12:00:00 GMT</lastBuildDate>
+    <item>
+      <title>WordPress 7.1, Gutenberg updates, and AI tooling in August 2026</title>
+      <link>https://colorful-tones.github.io/wp-trend-watcher/2026-08-24.html</link>
+      <guid isPermaLink="true">https://colorful-tones.github.io/wp-trend-watcher/2026-08-24.html</guid>
+      <description>WordPress 7.1 &quot;Mary Lou&quot; released with new blocks, responsive styling tools, and an Icon Registration API, alongside the Accessibility Lab plugin for testing ac</description>
+      <pubDate>Mon, 24 Aug 2026 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>WordPress 7.1 Release Final Steps and Developer Toolkits for August 20</title>
+      <link>https://colorful-tones.github.io/wp-trend-watcher/2026-08-18.html</link>
+      <guid isPermaLink="true">https://colorful-tones.github.io/wp-trend-watcher/2026-08-18.html</guid>
+      <description>WordPress 7.1 finalizes on August 19, 2026, with RC4 available for testing and accessibility improvements highlighted.</description>
+      <pubDate>Tue, 18 Aug 2026 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>WordPress Trend Report — 2026-08-10</title>
+      <link>https://colorful-tones.github.io/wp-trend-watcher/2026-08-10.html</link>
+      <guid isPermaLink="true">https://colorful-tones.github.io/wp-trend-watcher/2026-08-10.html</guid>
+      <description>WordPress 7.1 enters Release Candidate phase, introducing client-side media processing and responsive block styles, with final release scheduled for August 19,</description>
+      <pubDate>Mon, 10 Aug 2026 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>WordPress Trend Report — 2026-08-03</title>
+      <link>https://colorful-tones.github.io/wp-trend-watcher/2026-08-03.html</link>
+      <guid isPermaLink="true">https://colorful-tones.github.io/wp-trend-watcher/2026-08-03.html</guid>
+      <description>WordPress 7.1 Beta 4 introduces an always-iframed post editor, Abilities API enhancements, and new JSON schema tools to improve client compatibility and develop</description>
+      <pubDate>Mon, 03 Aug 2026 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>WordPress Trend Report — 2026-07-26</title>
+      <link>https://colorful-tones.github.io/wp-trend-watcher/2026-07-26.html</link>
+      <guid isPermaLink="true">https://colorful-tones.github.io/wp-trend-watcher/2026-07-26.html</guid>
+      <description>WordPress 7.1 Beta 3 introduces new block support, client-side media processing, and SVG icon registration ahead of its August 19 release.</description>
+      <pubDate>Sun, 26 Jul 2026 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>WordPress Trend Report — 2026-07-19</title>
+      <link>https://colorful-tones.github.io/wp-trend-watcher/2026-07-19.html</link>
+      <guid isPermaLink="true">https://colorful-tones.github.io/wp-trend-watcher/2026-07-19.html</guid>
+      <description>WordPress 7.1 Beta 1 now available, featuring persistent toolbar, iframed post editor, and enhanced styling controls, with testing encouraged for developers.</description>
+      <pubDate>Sun, 19 Jul 2026 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>WordPress Trend Report — 2026-07-11</title>
+      <link>https://colorful-tones.github.io/wp-trend-watcher/2026-07-11.html</link>
+      <guid isPermaLink="true">https://colorful-tones.github.io/wp-trend-watcher/2026-07-11.html</guid>
+      <description>WordPress 7.1, releasing August 19, introduces new blocks, responsive styling, and a redesigned command palette, with betas starting July 15.</description>
+      <pubDate>Sat, 11 Jul 2026 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>WordPress Trend Report — 2026-07-05</title>
+      <link>https://colorful-tones.github.io/wp-trend-watcher/2026-07-05.html</link>
+      <guid isPermaLink="true">https://colorful-tones.github.io/wp-trend-watcher/2026-07-05.html</guid>
+      <description>WordPress 7.1 introduces responsive styling, daily bug scrubs, read-only abilities, and security updates, with a general release planned for August 19, 2026.</description>
+      <pubDate>Sun, 05 Jul 2026 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>WordPress Trend Report — 2026-06-27</title>
+      <link>https://colorful-tones.github.io/wp-trend-watcher/2026-06-27.html</link>
+      <guid isPermaLink="true">https://colorful-tones.github.io/wp-trend-watcher/2026-06-27.html</guid>
+      <description>WordPress 7.1 removes the Classic block, introduces `wp_knowledge` for site standards, and features a block-based e-commerce storefront, with feedback sought on</description>
+      <pubDate>Sat, 27 Jun 2026 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>WordPress Trend Report — 2026-06-21</title>
+      <link>https://colorful-tones.github.io/wp-trend-watcher/2026-06-21.html</link>
+      <guid isPermaLink="true">https://colorful-tones.github.io/wp-trend-watcher/2026-06-21.html</guid>
+      <description>WordPress 7.1 development progresses with new Notes feature, emoji reactions, and expanded responsive styling, alongside React 19 testing in Gutenberg 23.4 and</description>
+      <pubDate>Sun, 21 Jun 2026 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>WordPress Trend Report — 2026-06-12</title>
+      <link>https://colorful-tones.github.io/wp-trend-watcher/2026-06-12.html</link>
+      <guid isPermaLink="true">https://colorful-tones.github.io/wp-trend-watcher/2026-06-12.html</guid>
+      <description>WordPress 7.1&apos;s collaborative editing represents a significant workflow shift, alongside client-side media processing and ACF 6.8.4 updates.</description>
+      <pubDate>Fri, 12 Jun 2026 12:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/reports/index.html
+++ b/reports/index.html
@@ -117,6 +117,7 @@
   <meta name="twitter:title" content="WP Trend Watcher — Reports">
   <meta name="twitter:description" content="Weekly human-reviewed WordPress ecosystem trend reports.">
   <meta name="twitter:image" content="https://colorful-tones.github.io/wp-trend-watcher/assets/WP-Trend-Watcher_1200x630.png">
+  <link rel="alternate" type="application/rss+xml" title="WP Trend Watcher" href="https://colorful-tones.github.io/wp-trend-watcher/feed.xml">
 </head>
 <body class="report-index">
   <header class="report-header report-hero report-index-hero">
@@ -180,7 +181,7 @@
       <a href="2026-08-24.html" class="report-card">
       <span class="report-card-date">August 24, 2026</span>
       <span class="report-card-title">WordPress 7.1, Gutenberg updates, and AI tooling in August 2026</span>
-      <span class="report-card-description">Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</span>
+      <span class="report-card-description">WordPress 7.1 &quot;Mary Lou&quot; released with new blocks, responsive styling tools, and an Icon Registration API, alongside the Accessibility Lab plugin for testing ac</span>
     <span class="report-card-label">Latest report</span>
     </a>
     <a href="2026-08-18.html" class="report-card">
@@ -242,6 +243,8 @@
       <a href="https://github.com/colorful-tones/wp-trend-watcher/issues/new?template=source-suggestion.yml">Suggest a source</a>
       &nbsp;·&nbsp;
       <a href="https://github.com/colorful-tones/wp-trend-watcher/issues/new?template=report-feedback.yml">Send feedback</a>
+      &nbsp;·&nbsp;
+      <a href="https://colorful-tones.github.io/wp-trend-watcher/feed.xml">Subscribe via RSS</a>
     </p>
   </footer>
 </body>

--- a/src/dev/regen-html.ts
+++ b/src/dev/regen-html.ts
@@ -11,6 +11,7 @@ import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { loadEnvFile } from "../env.js";
 import { generateHtmlReport, generateIndexPage } from "../summarize/html.js";
+import { generateRssFeed } from "../summarize/rss.js";
 
 loadEnvFile();
 const reportsDir = join(process.cwd(), "reports");
@@ -24,3 +25,5 @@ for (const file of mdFiles.sort()) {
 }
 await generateIndexPage(reportsDir);
 console.log("  regenerated: reports/index.html");
+const feedPath = await generateRssFeed(reportsDir);
+console.log(`  regenerated: ${feedPath}`);

--- a/src/generate-report/index.ts
+++ b/src/generate-report/index.ts
@@ -3,6 +3,7 @@ import { join, dirname, basename } from "node:path";
 import { loadEnvFile } from "../env.js";
 import { createProvider, type SummarizeResult } from "../providers.js";
 import { generateHtmlReport, generateIndexPage } from "../summarize/html.js";
+import { generateRssFeed } from "../summarize/rss.js";
 import {
   type ArticlesJson,
   type ArticleSummary,
@@ -156,6 +157,16 @@ async function main(): Promise<void> {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.warn(`Warning: Index page generation failed: ${message}`);
+  }
+
+  // 9. Regenerate RSS feed (non-blocking)
+  try {
+    const reportsDir = join(process.cwd(), "reports");
+    const feedPath = await generateRssFeed(reportsDir);
+    console.log(`RSS feed written: ${feedPath}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`Warning: RSS feed generation failed: ${message}`);
   }
 
   console.log("\nDone.");

--- a/src/summarize/html.ts
+++ b/src/summarize/html.ts
@@ -35,8 +35,9 @@ const REPORT_OG_IMAGE_SOURCE = new URL(
 );
 
 // Canonical site base URL for absolute Open Graph / Twitter / canonical URLs.
-// Must match the GitHub Pages deployment root (see README).
-const SITE_BASE_URL = "https://colorful-tones.github.io/wp-trend-watcher/";
+// Must match the GitHub Pages deployment root (see README). Exported so the
+// RSS feed module can build absolute report URLs without duplicating the base.
+export const SITE_BASE_URL = "https://colorful-tones.github.io/wp-trend-watcher/";
 const GITHUB_REPO_URL = "https://github.com/colorful-tones/wp-trend-watcher";
 const DEFAULT_REPORT_THEME = "civic-brutalist";
 const DEFAULT_REPORT_MODE = "system";
@@ -487,6 +488,7 @@ ${analyticsScript}
     url: `${SITE_BASE_URL}index.html`,
     type: "website",
   })}
+  <link rel="alternate" type="application/rss+xml" title="WP Trend Watcher" href="${SITE_BASE_URL}feed.xml">
 </head>
 <body class="report-index">
   <header class="report-header report-hero report-index-hero">
@@ -515,6 +517,8 @@ ${analyticsScript}
       <a href="https://github.com/colorful-tones/wp-trend-watcher/issues/new?template=source-suggestion.yml">Suggest a source</a>
       &nbsp;·&nbsp;
       <a href="https://github.com/colorful-tones/wp-trend-watcher/issues/new?template=report-feedback.yml">Send feedback</a>
+      &nbsp;·&nbsp;
+      <a href="${SITE_BASE_URL}feed.xml">Subscribe via RSS</a>
     </p>
   </footer>
 </body>

--- a/src/summarize/index-page.ts
+++ b/src/summarize/index-page.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { loadEnvFile } from "../env.js";
 import { generateIndexPage } from "./html.js";
+import { generateRssFeed } from "./rss.js";
 
 /**
  * Standalone script to regenerate reports/index.html.
@@ -12,6 +13,8 @@ async function main(): Promise<void> {
   const reportsDir = join(process.cwd(), "reports");
   const indexPath = await generateIndexPage(reportsDir);
   console.log(`Index page written: ${indexPath}`);
+  const feedPath = await generateRssFeed(reportsDir);
+  console.log(`RSS feed written: ${feedPath}`);
 }
 
 await main();

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -4,6 +4,7 @@ import { loadEnvFile, parsePositiveIntegerEnv } from "../env.js";
 import { createProvider, type SummarizeResult } from "../providers.js";
 import { fetchArticleContent } from "./content.js";
 import { generateHtmlReport, generateIndexPage } from "./html.js";
+import { generateRssFeed } from "./rss.js";
 import {
   type CollectedArticle,
   type ArticlesJson,
@@ -257,6 +258,16 @@ async function main(): Promise<void> {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.warn(`Warning: Index page generation failed: ${message}`);
+  }
+
+  // 11. Regenerate RSS feed (non-blocking)
+  try {
+    const reportsDir = join(process.cwd(), "reports");
+    const feedPath = await generateRssFeed(reportsDir);
+    console.log(`RSS feed written: ${feedPath}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`Warning: RSS feed generation failed: ${message}`);
   }
 }
 

--- a/src/summarize/rss.ts
+++ b/src/summarize/rss.ts
@@ -1,0 +1,213 @@
+import { readFile, writeFile, readdir } from "node:fs/promises";
+import { join, basename } from "node:path";
+import {
+  DEFAULT_REPORT_SEO_DESCRIPTION,
+  extractReportSeoMetadata,
+} from "./report.js";
+import { SITE_BASE_URL } from "./html.js";
+
+/** RSS 2.0 feed filename written into the reports directory. */
+export const RSS_FEED_FILE = "feed.xml";
+
+/** Channel title for the reports feed. */
+const FEED_TITLE = "WP Trend Watcher";
+
+/** Channel description for the reports feed. */
+const FEED_DESCRIPTION =
+  "Weekly human-reviewed WordPress ecosystem trend reports.";
+
+/** Fixed publication time-of-day (UTC) for deterministic report dates. */
+const PUBLICATION_HOUR_UTC = 12;
+
+/**
+ * A single report entry destined for the RSS feed.
+ *
+ * `date` is the canonical `YYYY-MM-DD` report date; `title` and `description`
+ * come from the report's SEO metadata (or a safe fallback).
+ */
+export interface RssReportItem {
+  date: string;
+  title: string;
+  description: string;
+}
+
+/**
+ * Validate a `YYYY-MM-DD` date string against the real calendar.
+ *
+ * @param date - Date string in `YYYY-MM-DD` format
+ * @returns Parsed year/month/day components, or null when invalid
+ */
+function parseReportDate(
+  date: string,
+): { year: number; month: number; day: number } | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const candidate = new Date(year, month - 1, day);
+  if (
+    candidate.getFullYear() !== year ||
+    candidate.getMonth() !== month - 1 ||
+    candidate.getDate() !== day
+  ) {
+    return null;
+  }
+  return { year, month, day };
+}
+
+/**
+ * Extract a valid `YYYY-MM-DD` report date from a Markdown filename, or null
+ * when the filename is not a canonical date-named report.
+ *
+ * @param filename - A file basename such as `2026-08-24.md`
+ * @returns The `YYYY-MM-DD` date string, or null when the filename is not a
+ *   valid date-named report
+ */
+function dateFromReportFilename(filename: string): string | null {
+  if (!filename.endsWith(".md")) return null;
+  const date = basename(filename, ".md");
+  return parseReportDate(date) ? date : null;
+}
+
+/**
+ * Escape text for safe inclusion in XML element content.
+ *
+ * Escapes the five XML-significant characters so titles and descriptions
+ * cannot break out of their element or inject markup.
+ *
+ * @param value - Raw text to escape
+ * @returns XML-safe text
+ */
+export function escapeXml(value: string): string {
+  return value.replace(/[<>&'"]/g, (character) => {
+    switch (character) {
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case "&":
+        return "&amp;";
+      case "'":
+        return "&apos;";
+      case '"':
+        return "&quot;";
+      default:
+        return character;
+    }
+  });
+}
+
+/**
+ * Format a `YYYY-MM-DD` report date as a deterministic RFC 822 publication
+ * date.
+ *
+ * Uses a fixed noon UTC timestamp so the feed output is reproducible and
+ * stable across regenerations regardless of the local timezone.
+ *
+ * @param date - Date string in `YYYY-MM-DD` format
+ * @returns RFC 822 date string such as `Mon, 24 Aug 2026 12:00:00 GMT`
+ * @throws When the date is not a valid calendar date
+ */
+export function formatReportPubDate(date: string): string {
+  const parsed = parseReportDate(date);
+  if (!parsed) {
+    throw new Error(`Invalid report date: ${date}`);
+  }
+  const { year, month, day } = parsed;
+  return new Date(
+    Date.UTC(year, month - 1, day, PUBLICATION_HOUR_UTC, 0, 0),
+  ).toUTCString();
+}
+
+/**
+ * Build a complete RSS 2.0 document from report items.
+ *
+ * Items are emitted in the order given (callers sort newest-first). Each item
+ * links to its canonical report page with a stable perma-link GUID and a
+ * deterministic report-date publication date.
+ *
+ * @param items - Report entries in desired (newest-first) order
+ * @returns RSS 2.0 XML document string
+ */
+export function buildRssFeed(items: RssReportItem[]): string {
+  const itemXml = items
+    .map((item) => {
+      const link = `${SITE_BASE_URL}${item.date}.html`;
+      return `    <item>
+      <title>${escapeXml(item.title)}</title>
+      <link>${escapeXml(link)}</link>
+      <guid isPermaLink="true">${escapeXml(link)}</guid>
+      <description>${escapeXml(item.description)}</description>
+      <pubDate>${formatReportPubDate(item.date)}</pubDate>
+    </item>`;
+    })
+    .join("\n");
+
+  const lastBuildDate =
+    items.length > 0
+      ? `    <lastBuildDate>${formatReportPubDate(items[0].date)}</lastBuildDate>\n`
+      : "";
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(FEED_TITLE)}</title>
+    <link>${escapeXml(SITE_BASE_URL)}</link>
+    <description>${escapeXml(FEED_DESCRIPTION)}</description>
+    <language>en-us</language>
+    <atom:link href="${escapeXml(`${SITE_BASE_URL}${RSS_FEED_FILE}`)}" rel="self" type="application/rss+xml"/>
+${lastBuildDate}${itemXml}
+  </channel>
+</rss>
+`;
+}
+
+/**
+ * Generate `reports/feed.xml` from canonical date-named Markdown reports.
+ *
+ * Scans the reports directory for `YYYY-MM-DD.md` files, extracts each
+ * report's SEO metadata (falling back to a date-derived title and the shared
+ * description when metadata is missing or empty), and writes a deterministic
+ * RSS 2.0 feed with the newest report first. Non-report files and files with
+ * invalid report dates are skipped.
+ *
+ * @param reportsDir - Directory containing Markdown reports
+ * @returns Absolute path to the generated feed.xml
+ */
+export async function generateRssFeed(reportsDir: string): Promise<string> {
+  const files = await readdir(reportsDir);
+
+  const reportDates = files
+    .map((file) => dateFromReportFilename(file))
+    .filter((date): date is string => date !== null)
+    .sort()
+    .reverse();
+
+  const items: RssReportItem[] = [];
+  for (const date of reportDates) {
+    const fallback = {
+      title: `WordPress Trend Report — ${date}`,
+      description: DEFAULT_REPORT_SEO_DESCRIPTION,
+    };
+
+    let markdown = "";
+    try {
+      markdown = await readFile(join(reportsDir, `${date}.md`), "utf8");
+    } catch {
+      // A missing source should not abort feed generation; fall back cleanly.
+    }
+
+    const seo = extractReportSeoMetadata(markdown, fallback);
+    items.push({
+      date,
+      title: seo.title.trim() || fallback.title,
+      description: seo.description.trim() || fallback.description,
+    });
+  }
+
+  const outPath = join(reportsDir, RSS_FEED_FILE);
+  await writeFile(outPath, buildRssFeed(items), "utf8");
+  return outPath;
+}

--- a/tests/summarize/html.test.ts
+++ b/tests/summarize/html.test.ts
@@ -483,3 +483,30 @@ test("generateIndexPage emits absolute SEO meta", async () => {
   assert.ok(html.includes('<meta property="og:url" content="https://colorful-tones.github.io/wp-trend-watcher/index.html">'));
   assert.ok(html.includes('<meta name="twitter:card" content="summary_large_image">'));
 });
+
+test("generateIndexPage includes an RSS autodiscovery link", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "rss-index-test-"));
+  await writeFile(join(tmpDir, "2026-06-21.html"), "<html></html>", "utf8");
+
+  const indexPath = await generateIndexPage(tmpDir);
+  const html = await readFile(indexPath, "utf8");
+
+  assert.ok(
+    html.includes(
+      '<link rel="alternate" type="application/rss+xml" title="WP Trend Watcher" href="https://colorful-tones.github.io/wp-trend-watcher/feed.xml">',
+    ),
+  );
+});
+
+test("generateIndexPage includes a visible Subscribe via RSS link", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "rss-index-test-"));
+  await writeFile(join(tmpDir, "2026-06-21.html"), "<html></html>", "utf8");
+
+  const indexPath = await generateIndexPage(tmpDir);
+  const html = await readFile(indexPath, "utf8");
+
+  assert.ok(html.includes("Subscribe via RSS"));
+  assert.ok(
+    html.includes('href="https://colorful-tones.github.io/wp-trend-watcher/feed.xml"'),
+  );
+});

--- a/tests/summarize/rss.test.ts
+++ b/tests/summarize/rss.test.ts
@@ -1,0 +1,215 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildRssFeed,
+  escapeXml,
+  formatReportPubDate,
+  generateRssFeed,
+  RSS_FEED_FILE,
+  type RssReportItem,
+} from "../../src/summarize/rss.js";
+
+/** Create an isolated reports directory with the given file contents. */
+async function makeReportsDir(
+  files: Record<string, string>,
+): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "rss-test-"));
+  for (const [name, content] of Object.entries(files)) {
+    await writeFile(join(dir, name), content, "utf8");
+  }
+  return dir;
+}
+
+/** Extract item <link> URLs (YYYY-MM-DD.html) from a feed string, in order. */
+function extractItemLinks(xml: string): string[] {
+  return [...xml.matchAll(/<link>([^<]+\.html)<\/link>/g)].map((m) => m[1]);
+}
+
+function makeItem(overrides: Partial<RssReportItem> = {}): RssReportItem {
+  return {
+    date: "2026-08-24",
+    title: "WordPress 7.1 and Gutenberg updates",
+    description: "This week's WordPress ecosystem changes.",
+    ...overrides,
+  };
+}
+
+// --- escapeXml ---
+
+test("escapeXml escapes all five XML-significant characters", () => {
+  assert.equal(escapeXml('a < b & c > d "e" \'f\''), "a &lt; b &amp; c &gt; d &quot;e&quot; &apos;f&apos;");
+});
+
+test("escapeXml leaves ordinary text unchanged", () => {
+  assert.equal(escapeXml("Plain report title"), "Plain report title");
+});
+
+// --- formatReportPubDate ---
+
+test("formatReportPubDate formats a valid date as deterministic RFC 822", () => {
+  assert.equal(
+    formatReportPubDate("2026-08-24"),
+    "Mon, 24 Aug 2026 12:00:00 GMT",
+  );
+  assert.equal(
+    formatReportPubDate("2026-07-01"),
+    "Wed, 01 Jul 2026 12:00:00 GMT",
+  );
+});
+
+test("formatReportPubDate throws on invalid calendar dates", () => {
+  assert.throws(() => formatReportPubDate("2026-13-40"), /Invalid report date/);
+  assert.throws(() => formatReportPubDate("2026-02-30"), /Invalid report date/);
+  assert.throws(() => formatReportPubDate("not-a-date"), /Invalid report date/);
+});
+
+// --- buildRssFeed ---
+
+test("buildRssFeed emits a valid RSS 2.0 channel structure", () => {
+  const xml = buildRssFeed([makeItem()]);
+  assert.ok(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>\n'));
+  assert.ok(xml.includes('<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">'));
+  assert.ok(xml.includes("<channel>"));
+  assert.ok(xml.includes("<title>WP Trend Watcher</title>"));
+  assert.ok(xml.includes("<description>Weekly human-reviewed WordPress ecosystem trend reports.</description>"));
+  assert.ok(xml.includes("<language>en-us</language>"));
+  assert.ok(
+    xml.includes(
+      '<atom:link href="https://colorful-tones.github.io/wp-trend-watcher/feed.xml" rel="self" type="application/rss+xml"/>',
+    ),
+  );
+  assert.ok(xml.trimEnd().endsWith("</rss>"));
+});
+
+test("buildRssFeed uses absolute report links and stable perma-link GUIDs", () => {
+  const xml = buildRssFeed([makeItem({ date: "2026-08-24" })]);
+  const link = "https://colorful-tones.github.io/wp-trend-watcher/2026-08-24.html";
+  assert.ok(xml.includes(`<link>${link}</link>`));
+  assert.ok(xml.includes(`<guid isPermaLink="true">${link}</guid>`));
+});
+
+test("buildRssFeed emits items in the given order", () => {
+  const xml = buildRssFeed([
+    makeItem({ date: "2026-08-24" }),
+    makeItem({ date: "2026-07-01" }),
+  ]);
+  assert.deepEqual(extractItemLinks(xml), [
+    "https://colorful-tones.github.io/wp-trend-watcher/2026-08-24.html",
+    "https://colorful-tones.github.io/wp-trend-watcher/2026-07-01.html",
+  ]);
+});
+
+test("buildRssFeed sets lastBuildDate from the newest item and omits it when empty", () => {
+  const withItems = buildRssFeed([
+    makeItem({ date: "2026-08-24" }),
+    makeItem({ date: "2026-07-01" }),
+  ]);
+  assert.ok(withItems.includes("<lastBuildDate>Mon, 24 Aug 2026 12:00:00 GMT</lastBuildDate>"));
+
+  const empty = buildRssFeed([]);
+  assert.ok(!empty.includes("<lastBuildDate>"));
+  assert.ok(!empty.includes("<item>"));
+});
+
+// --- generateRssFeed ---
+
+test("generateRssFeed writes reports/feed.xml and returns its path", async () => {
+  const dir = await makeReportsDir({
+    "2026-08-24.md": "# WordPress Trend Report — 2026-08-24\n",
+  });
+  const outPath = await generateRssFeed(dir);
+  assert.equal(outPath, join(dir, RSS_FEED_FILE));
+  const xml = await readFile(outPath, "utf8");
+  assert.ok(xml.includes("<rss version=\"2.0\""));
+});
+
+test("generateRssFeed orders reports newest first regardless of directory order", async () => {
+  const dir = await makeReportsDir({
+    "2026-06-14.md": "# Report\n",
+    "2026-08-24.md": "# Report\n",
+    "2026-07-01.md": "# Report\n",
+  });
+  const xml = await readFile(await generateRssFeed(dir), "utf8");
+  assert.deepEqual(extractItemLinks(xml), [
+    "https://colorful-tones.github.io/wp-trend-watcher/2026-08-24.html",
+    "https://colorful-tones.github.io/wp-trend-watcher/2026-07-01.html",
+    "https://colorful-tones.github.io/wp-trend-watcher/2026-06-14.html",
+  ]);
+});
+
+test("generateRssFeed uses SEO metadata for titles and descriptions", async () => {
+  const dir = await makeReportsDir({
+    "2026-08-24.md":
+      "<!-- SEO_TITLE: WordPress 7.1 shipped -->\n" +
+      "<!-- SEO_DESCRIPTION: A focused look at this week's releases. -->\n" +
+      "# WordPress Trend Report — 2026-08-24\n",
+  });
+  const xml = await readFile(await generateRssFeed(dir), "utf8");
+  assert.ok(xml.includes("<title>WordPress 7.1 shipped</title>"));
+  assert.ok(xml.includes("<description>A focused look at this week&apos;s releases.</description>"));
+});
+
+test("generateRssFeed falls back to a date-derived title and shared description when metadata is missing", async () => {
+  const dir = await makeReportsDir({
+    "2026-08-24.md": "# WordPress Trend Report — 2026-08-24\n",
+  });
+  const xml = await readFile(await generateRssFeed(dir), "utf8");
+  assert.ok(xml.includes("<title>WordPress Trend Report — 2026-08-24</title>"));
+  assert.ok(
+    xml.includes(
+      "<description>Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</description>",
+    ),
+  );
+});
+
+test("generateRssFeed falls back when SEO metadata is present but empty", async () => {
+  const dir = await makeReportsDir({
+    "2026-08-24.md":
+      "<!-- SEO_TITLE: -->\n<!-- SEO_DESCRIPTION: -->\n# Report\n",
+  });
+  const xml = await readFile(await generateRssFeed(dir), "utf8");
+  assert.ok(xml.includes("<title>WordPress Trend Report — 2026-08-24</title>"));
+  assert.ok(
+    xml.includes(
+      "<description>Weekly human-reviewed analysis of changes across the WordPress ecosystem, covering releases, tools, and developer implications.</description>",
+    ),
+  );
+});
+
+test("generateRssFeed escapes special characters in metadata", async () => {
+  const dir = await makeReportsDir({
+    "2026-08-24.md":
+      "<!-- SEO_TITLE: Releases &amp; <bets> -->\n" +
+      "<!-- SEO_DESCRIPTION: A \"quoted\" look at it's & more. -->\n" +
+      "# Report\n",
+  });
+  const xml = await readFile(await generateRssFeed(dir), "utf8");
+  assert.ok(xml.includes("<title>Releases &amp;amp; &lt;bets&gt;</title>"));
+  assert.ok(xml.includes("<description>A &quot;quoted&quot; look at it&apos;s &amp; more.</description>"));
+});
+
+test("generateRssFeed skips non-report and malformed filenames", async () => {
+  const dir = await makeReportsDir({
+    "2026-08-24.md": "# Report\n",
+    "index.md": "# not a report\n",
+    "notes.txt": "ignored\n",
+    "2026-13-40.md": "# invalid date\n",
+    "2026-02-30.md": "# invalid calendar date\n",
+  });
+  const xml = await readFile(await generateRssFeed(dir), "utf8");
+  assert.deepEqual(extractItemLinks(xml), [
+    "https://colorful-tones.github.io/wp-trend-watcher/2026-08-24.html",
+  ]);
+});
+
+test("generateRssFeed produces a valid empty feed when no reports exist", async () => {
+  const dir = await makeReportsDir({});
+  const xml = await readFile(await generateRssFeed(dir), "utf8");
+  assert.ok(xml.includes("<channel>"));
+  assert.ok(xml.includes("<title>WP Trend Watcher</title>"));
+  assert.ok(!xml.includes("<item>"));
+  assert.ok(xml.trimEnd().endsWith("</rss>"));
+});


### PR DESCRIPTION
## Summary
- Add a deterministic RSS 2.0 feed at `reports/feed.xml` from canonical Markdown report metadata.
- Add RSS autodiscovery and a visible Subscribe via RSS link to the report index.
- Regenerate the feed through the existing index, summarize, report-regeneration, and HTML-regeneration paths.
- Add XML escaping, metadata fallbacks, date validation, focused tests, and documentation.

## Verification
- `pnpm run test` — 234 passed
- `pnpm run typecheck` — passed
- `pnpm index-page` — feed regenerated
- `pnpm regen-html` — feed and report archive regenerated without report HTML changes
- `xmllint --noout reports/feed.xml` — passed
- Feed output is byte-identical across repeated regenerations

## Review
- Independently reviewed through the Hermes `code-review` pipeline.
- No security, correctness, scope, or maintainability findings.