### PR TITLE
feat: prioritize ACF release feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ Both templates walk you through what's needed — takes about a minute.
 
 ## Changelog
 
+### 0.14.0
+
+- Added the first-party ACF Releases feed as a Tier 1 source.
+- Reclassified the broader ACF Blog feed as Tier 2 to reduce the priority of lower-signal posts.
+
 ### 0.13.0
 
 - Added a static RSS 2.0 feed at `reports/feed.xml`, generated from the published report archive with the newest report first.

--- a/docs/adding-sources.md
+++ b/docs/adding-sources.md
@@ -40,7 +40,9 @@ These are the kinds of sources that belong in the project, with explanations of 
 | Source | Feed | Why it works |
 |--------|------|--------------|
 | [Gutenberg Times](https://gutenbergtimes.com/) | `https://gutenbergtimes.com/feed/` | Curated Gutenberg ecosystem coverage with consistent community perspective. Fills gaps between official announcements and developer adoption. |
-| [ACF Blog](https://www.advancedcustomfields.com/blog/) | `https://www.advancedcustomfields.com/blog/feed/` | ACF-specific developer workflow updates and modern WordPress implementation patterns. Valuable for the large ACF user base. |
+| [ACF Releases](https://www.advancedcustomfields.com/blog/tag/release/) | `https://www.advancedcustomfields.com/blog/tag/release/feed/` | First-party ACF release announcements and version-specific changes. |
+
+The broader [ACF Blog](https://www.advancedcustomfields.com/blog/) remains included as a Tier 2 source so its posts can contribute without receiving the same priority as primary release announcements.
 
 ### Plugin/theme developer blogs
 

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -48,13 +48,13 @@ Core development activity, release planning, technical proposals, and dev notes.
 Why included:
 Official release and ecosystem updates.
 
-### ACF Blog
+### ACF Releases
 
-- URL: <https://www.advancedcustomfields.com/blog/>
-- Feed: <https://www.advancedcustomfields.com/blog/feed/>
+- URL: <https://www.advancedcustomfields.com/blog/tag/release/>
+- Feed: <https://www.advancedcustomfields.com/blog/tag/release/feed/>
 
 Why included:
-ACF-specific developer workflow updates and modern WordPress implementation patterns.
+First-party ACF release announcements and version-specific changes.
 
 ## Tier 2 Sources
 
@@ -67,6 +67,14 @@ Included in the default collection since v0.1.3. The collector fetches all sourc
 
 Why included:
 Curated Gutenberg ecosystem coverage and community perspective.
+
+### ACF Blog
+
+- URL: <https://www.advancedcustomfields.com/blog/>
+- Feed: <https://www.advancedcustomfields.com/blog/feed/>
+
+Why included:
+ACF-specific developer workflow updates and modern WordPress implementation patterns, retained as a lower-priority source for broader coverage.
 
 ### ACF Chat Fridays
 

--- a/sources.example.yaml
+++ b/sources.example.yaml
@@ -26,13 +26,19 @@ sources:
     feedUrl: https://wordpress.org/news/feed/
     tier: 1
 
+  - id: acf-releases
+    name: ACF Releases
+    url: https://www.advancedcustomfields.com/blog/tag/release/
+    feedUrl: https://www.advancedcustomfields.com/blog/tag/release/feed/
+    tier: 1
+
+  # ── Tier 2: Broader ecosystem ──────────────────────────────────
   - id: acf-blog
     name: ACF Blog
     url: https://www.advancedcustomfields.com/blog/
     feedUrl: https://www.advancedcustomfields.com/blog/feed/
-    tier: 1
+    tier: 2
 
-  # ── Tier 2: Broader ecosystem ──────────────────────────────────
   - id: gutenberg-times
     name: Gutenberg Times
     url: https://gutenbergtimes.com/

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -35,6 +35,13 @@ export const sources: Source[] = [
     name: "ACF Blog",
     url: "https://www.advancedcustomfields.com/blog/",
     feedUrl: "https://www.advancedcustomfields.com/blog/feed/",
+    tier: 2,
+  },
+  {
+    id: "acf-releases",
+    name: "ACF Releases",
+    url: "https://www.advancedcustomfields.com/blog/tag/release/",
+    feedUrl: "https://www.advancedcustomfields.com/blog/tag/release/feed/",
     tier: 1,
   },
   {


### PR DESCRIPTION
## Summary
- Add the first-party ACF Releases RSS feed as a Tier 1 source.
- Reclassify the broader ACF Blog feed as Tier 2.
- Update source examples, documentation, changelog, and operating notes.

## Verification
- pnpm run test — 234 passed
- pnpm run typecheck — passed
- pnpm run doctor — passed with the expected missing sources.yaml warning
- ACF Releases feed probe — HTTP 200, application/rss+xml
- git diff --check — passed