### PR TITLE
feat: add reader action summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ Both templates walk you through what's needed — takes about a minute.
 
 ## Changelog
 
+### 0.15.0
+
+- Added an optional human-authored Reader Action Summary section with bounded labels, source/state validation, review-page editing, and legacy-report compatibility.
+- Preserved the existing Developer Implications section and weekly report workflow; no AI impact scoring or tutorial generation was added.
+
 ### 0.14.0
 
 - Added the first-party ACF Releases feed as a Tier 1 source.

--- a/docs/human-review.md
+++ b/docs/human-review.md
@@ -39,7 +39,7 @@ Before publishing a report:
 
 The `pnpm weekly` command starts a local review server at http://127.0.0.1:3001/review after running the automated pipeline. The review page displays:
 
-- Automated review checks (Weekly Summary, source references, weasel words, Build Notes, What I'm Watching, markdown links, HTML report presence)
+- Automated review checks (Weekly Summary, source references, weasel words, Build Notes, What I'm Watching, Reader Action Summary, markdown links, HTML report presence)
 - A rendered preview of the report
 - An editable textarea for the "What I'm Watching" section
 - A free-form "Review time" field that records how long you spent reviewing and publishing the report
@@ -55,6 +55,17 @@ Each report should include:
 ### What I'm Watching
 
 A short section with personal observations about what seems important, uncertain, or worth following.
+
+### Reader Action Summary
+
+An optional, human-authored section with no more than four items grouped under these labels:
+
+- `### Act now` — confirmed maintenance, security, or time-sensitive compatibility work.
+- `### Prepare` — a concrete testing, audit, or scheduling task.
+- `### Watch` — a proposal or emerging direction that does not justify action yet.
+- `### No action` — useful context that does not require work.
+
+Each bullet should identify the audience, include a `State:`, and link to the source article. Do not use this section to turn proposals into migrations, generate production code, or assign an unsupported `critical` severity.
 
 ### Build Notes
 

--- a/docs/weekly-workflow.md
+++ b/docs/weekly-workflow.md
@@ -53,7 +53,7 @@ The heavy step. Fetches each article's content, generates per-article summaries 
 pnpm review
 ```
 
-Runs the automated review checklist against the latest report. Checks: Weekly Summary presence, source article references, weasel words, Build Notes completeness, What I'm Watching content, markdown link validity, and HTML report presence. Exits nonzero only for true blockers.
+Runs the automated review checklist against the latest report. Checks: Weekly Summary presence, source article references, weasel words, Build Notes completeness, What I'm Watching content, Reader Action Summary structure, markdown link validity, and HTML report presence. Exits nonzero only for true blockers.
 
 ### 5. Human Review
 
@@ -63,6 +63,7 @@ Open `reports/YYYY-MM-DD.md` and:
 - Remove weak or unsupported claims.
 - Decide which trends actually matter.
 - Fill in the `What I'm Watching` section with personal observations.
+- Optionally fill in `Reader Action Summary` with up to four reviewed action items using `Act now`, `Prepare`, `Watch`, or `No action` headings. Include an audience, `State:`, and source link for each item.
 - Add any missing developer implications.
 - Update Build Notes with review time.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-trend-watcher",
-  "version": "0.10.2",
+  "version": "0.14.0",
   "description": "A lightweight, human-reviewed WordPress ecosystem trend watching workflow.",
   "type": "module",
   "private": false,

--- a/src/review/checks.ts
+++ b/src/review/checks.ts
@@ -233,6 +233,48 @@ export function checkWatchingSection(report: string): ReviewCheck {
   return { name: "What I'm Watching", status: "pass", message: "has human note" };
 }
 
+/** Allowed editorial labels for Reader Action Summary items. */
+const ACTION_LABELS = ["Act now", "Prepare", "Watch", "No action"];
+
+/**
+ * Validate the bounded human-authored Reader Action Summary contract.
+ *
+ * @param report - Full Markdown content of the report.
+ * @returns Review check result; missing sections warn for backwards compatibility.
+ */
+export function checkReaderActionSummary(report: string): ReviewCheck {
+  const marker = "## Reader Action Summary";
+  const idx = report.indexOf(marker);
+  if (idx < 0) {
+    return { name: "Reader Action Summary", status: "warn", message: "section not found" };
+  }
+  const remainder = report.slice(idx + marker.length);
+  const nextSection = remainder.search(/\n## /);
+  const section = remainder.slice(0, nextSection < 0 ? undefined : nextSection);
+  const content = section.replace(/<!--[\s\S]*?-->/g, "").trim();
+  if (!content) {
+    return { name: "Reader Action Summary", status: "warn", message: "empty — add up to 4 reviewed items" };
+  }
+  const headings = [...content.matchAll(/^###\s+(.+)$/gm)].map((match) => match[1].trim());
+  const invalid = headings.filter((heading) => !ACTION_LABELS.includes(heading));
+  if (invalid.length > 0) {
+    return { name: "Reader Action Summary", status: "warn", message: `unsupported label: ${invalid[0]}` };
+  }
+  const items = content.split("\n").filter((line) => /^\s*[-*]\s+/.test(line));
+  if (items.length > 4) {
+    return { name: "Reader Action Summary", status: "warn", message: `${items.length} items found (maximum is 4)` };
+  }
+  const incomplete = items.filter(
+    (item) =>
+      !/\bState:\s*[^.]+/i.test(item) ||
+      !/\[[^\]]+\]\(https?:\/\/[^)]+\)/.test(item),
+  );
+  if (incomplete.length > 0) {
+    return { name: "Reader Action Summary", status: "warn", message: `${incomplete.length} item(s) missing State or source link` };
+  }
+  return { name: "Reader Action Summary", status: "pass", message: `${items.length} reviewed item(s)` };
+}
+
 /**
  * Check that markdown links are well-formed (no empty []() patterns).
  *

--- a/src/review/index.ts
+++ b/src/review/index.ts
@@ -20,6 +20,7 @@ import {
   checkWeaselWords,
   checkBuildNotes,
   checkWatchingSection,
+  checkReaderActionSummary,
   checkMarkdownLinks,
   checkHtmlReport,
   type ReviewCheck,
@@ -97,6 +98,7 @@ async function main(): Promise<void> {
     checkWeaselWords(body),
     checkBuildNotes(report),
     checkWatchingSection(report),
+    checkReaderActionSummary(report),
     checkMarkdownLinks(report),
     checkHtmlReport(htmlExists, htmlPath),
   ];

--- a/src/review/report-edit.ts
+++ b/src/review/report-edit.ts
@@ -24,6 +24,7 @@ export interface SectionSpan {
 }
 
 const WATCHING_HEADING = "## What I'm Watching";
+const ACTION_SUMMARY_HEADING = "## Reader Action Summary";
 
 /**
  * Known placeholder patterns that indicate no human-authored content.
@@ -178,6 +179,75 @@ export function replaceWatchingSection(
   }
 
   return beforeBody.trimEnd() + "\n\n" + cleanContent + "\n" + afterBody;
+}
+
+/**
+ * Find the Reader Action Summary section in a report.
+ *
+ * @param report - Full Markdown report text.
+ * @returns SectionSpan with body and offsets, or null.
+ */
+export function findReaderActionSummarySection(report: string): SectionSpan | null {
+  return findSection(report, ACTION_SUMMARY_HEADING);
+}
+
+/**
+ * Replace the Reader Action Summary section body while preserving the report.
+ *
+ * @param report - Full Markdown report text.
+ * @param newContent - Human-authored action summary Markdown.
+ * @returns Modified report, or null when the section is missing.
+ */
+export function replaceReaderActionSummarySection(
+  report: string,
+  newContent: string,
+): string | null {
+  const span = findReaderActionSummarySection(report);
+  if (span === null) {
+    const sourceMarker = "\n## Source Articles";
+    const sourceIdx = report.indexOf(sourceMarker);
+    if (sourceIdx === -1) return null;
+    const content = newContent.trim() ||
+      "<!-- Human-authored: add up to 4 action items here -->";
+    return `${report.slice(0, sourceIdx)}\n\n## Reader Action Summary\n\n${content}\n${report.slice(sourceIdx)}`;
+  }
+  const before = report.slice(0, span.bodyStart).trimEnd();
+  const after = report.slice(span.bodyEnd);
+  const content = newContent.trim() ||
+    "<!-- Human-authored: add up to 4 action items here -->";
+  return `${before}\n\n${content}\n${after}`;
+}
+
+/** Find a top-level Markdown section body and its offsets. */
+function findSection(report: string, heading: string): SectionSpan | null {
+  const headingIdx = report.indexOf(heading);
+  if (headingIdx === -1) return null;
+  const headingEnd = headingIdx + heading.length;
+  const newlineIdx = report.indexOf("\n", headingEnd);
+  if (newlineIdx === -1) {
+    return { body: "", bodyStart: headingEnd, bodyEnd: headingEnd };
+  }
+  let bodyStart = newlineIdx + 1;
+  while (bodyStart < report.length && report[bodyStart] === "\n") bodyStart++;
+  const afterHeading = report.slice(bodyStart);
+  const hrMatch = afterHeading.match(/\n---\s*\n/);
+  const h2Match = afterHeading.match(/\n## /);
+  let bodyEnd: number;
+  if (hrMatch && h2Match) {
+    bodyEnd = bodyStart + Math.min(hrMatch.index!, h2Match.index!);
+  } else if (hrMatch) {
+    bodyEnd = bodyStart + hrMatch.index!;
+  } else if (h2Match) {
+    bodyEnd = bodyStart + h2Match.index!;
+  } else {
+    bodyEnd = report.length;
+  }
+  while (bodyEnd > bodyStart && report[bodyEnd - 1] === "\n") bodyEnd--;
+  return {
+    body: report.slice(bodyStart, bodyEnd).trim(),
+    bodyStart,
+    bodyEnd,
+  };
 }
 
 /** Marker line prefix used in Build Notes for the human review time. */

--- a/src/review/server.ts
+++ b/src/review/server.ts
@@ -48,7 +48,9 @@ import {
 } from "../summarize/report.js";
 import {
   findWatchingSection,
+  findReaderActionSummarySection,
   replaceWatchingSection,
+  replaceReaderActionSummarySection,
   isPlaceholderContent,
   findReviewTime,
   replaceReviewTime,
@@ -61,6 +63,7 @@ import {
   checkWeaselWords,
   checkBuildNotes,
   checkWatchingSection,
+  checkReaderActionSummary,
   checkMarkdownLinks,
   checkHtmlReport,
   type ReviewCheck,
@@ -78,6 +81,7 @@ export interface ReviewData {
   html: string;
   summary: string;
   reviewTime: string;
+  actionSummary: string;
   checks: ReviewCheck[];
   descriptionStatus: "generated" | "fallback";
 }
@@ -412,9 +416,12 @@ function reviewPageHtml(): string {
 
 <section class="editor-section">
   <h2>Your Review Summary</h2>
-  <p class="meta">Edit the <em>What I'm Watching</em> section below. Saving updates the canonical Markdown report, generates its SEO description, and regenerates the matching HTML.</p>
+  <p class="meta">Edit the human-authored sections below. Saving updates the canonical Markdown report, generates its SEO description, and regenerates the matching HTML.</p>
   <label class="editor-label" for="summary-textarea">What I'm Watching</label>
   <textarea id="summary-textarea" placeholder="Add your observations here…"></textarea>
+  <label class="editor-label" for="action-summary-textarea">Reader Action Summary</label>
+  <p class="meta">Use up to four bullet items under <code>### Act now</code>, <code>### Prepare</code>, <code>### Watch</code>, or <code>### No action</code>. Include <code>State:</code> and a source link in each item.</p>
+  <textarea id="action-summary-textarea" placeholder="### Prepare\n\n- **Audience:** Test the change. **State:** beta. **Source:** [Release notes](https://example.com)"></textarea>
   <label class="editor-label" for="review-time-input">Review time</label>
   <input id="review-time-input" type="text" placeholder="e.g. ~15 minutes" autocomplete="off">
   <button class="btn" id="save-btn" onclick="saveSummary()">💾 Save summary</button>
@@ -434,6 +441,7 @@ async function loadReview() {
     renderChecks(data.checks);
     document.getElementById('report-container').innerHTML = data.html;
     document.getElementById('summary-textarea').value = data.summary;
+    document.getElementById('action-summary-textarea').value = data.actionSummary;
     document.getElementById('review-time-input').value = data.reviewTime || '';
   } catch (err) {
     document.getElementById('meta-info').textContent = 'Failed to load: ' + err.message;
@@ -458,6 +466,7 @@ async function saveSummary() {
   const btn = document.getElementById('save-btn');
   const summary = document.getElementById('summary-textarea').value;
   const reviewTime = document.getElementById('review-time-input').value;
+  const actionSummary = document.getElementById('action-summary-textarea').value;
 
   statusEl.className = 'status loading';
   statusEl.textContent = 'Saving…';
@@ -467,7 +476,7 @@ async function saveSummary() {
     const res = await fetch('/api/review-summary', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ summary: summary, reviewTime: reviewTime }),
+      body: JSON.stringify({ summary: summary, actionSummary: actionSummary, reviewTime: reviewTime }),
     });
 
     if (!res.ok) {
@@ -482,6 +491,7 @@ async function saveSummary() {
       : '✓ Saved — Markdown and HTML updated. SEO description generation was unavailable.';
     document.getElementById('report-container').innerHTML = data.html;
     document.getElementById('summary-textarea').value = data.summary;
+    document.getElementById('action-summary-textarea').value = data.actionSummary;
     document.getElementById('review-time-input').value = data.reviewTime || '';
     document.getElementById('meta-info').textContent =
       'Report: ' + data.date + ' — ' + data.checks.length + ' checks run';
@@ -597,6 +607,7 @@ async function serveReviewChecks(
       checkWeaselWords(body),
       checkBuildNotes(report),
       checkWatchingSection(report),
+      checkReaderActionSummary(report),
       checkMarkdownLinks(report),
       checkHtmlReport(htmlExists, htmlPath),
     ];
@@ -632,6 +643,8 @@ async function serveReviewData(
     // Extract summary (What I'm Watching content)
     const section = findWatchingSection(report);
     const summary = section ? section.body : "";
+    const actionSection = findReaderActionSummarySection(report);
+    const actionSummary = actionSection ? actionSection.body : "";
 
     // Extract review time from Build Notes
     const reviewTime = findReviewTime(report);
@@ -650,6 +663,7 @@ async function serveReviewData(
       checkWeaselWords(body),
       checkBuildNotes(report),
       checkWatchingSection(report),
+      checkReaderActionSummary(report),
       checkMarkdownLinks(report),
       checkHtmlReport(htmlExists, htmlPath),
     ];
@@ -658,6 +672,7 @@ async function serveReviewData(
       date,
       html,
       summary,
+      actionSummary,
       reviewTime,
       checks,
       descriptionStatus:
@@ -702,7 +717,7 @@ async function handleSaveSummary(
     return;
   }
 
-  let payload: { summary?: unknown; reviewTime?: unknown };
+  let payload: { summary?: unknown; actionSummary?: unknown; reviewTime?: unknown };
   try {
     payload = JSON.parse(body);
   } catch {
@@ -719,6 +734,12 @@ async function handleSaveSummary(
     return;
   }
 
+  if (payload.actionSummary !== undefined && typeof payload.actionSummary !== "string") {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: 'Missing or invalid "actionSummary" field' }) + "\n");
+    return;
+  }
+
   // reviewTime is optional; when provided it must be a string.
   if (payload.reviewTime !== undefined && typeof payload.reviewTime !== "string") {
     res.writeHead(400, { "Content-Type": "application/json" });
@@ -729,6 +750,7 @@ async function handleSaveSummary(
   }
 
   const newSummary = payload.summary;
+  const newActionSummary = typeof payload.actionSummary === "string" ? payload.actionSummary : "";
   const newReviewTime = typeof payload.reviewTime === "string" ? payload.reviewTime : "";
 
   // Find latest report
@@ -762,10 +784,17 @@ async function handleSaveSummary(
     return;
   }
 
+  const withActionSummary = replaceReaderActionSummarySection(updatedReport, newActionSummary);
+  if (withActionSummary === null) {
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Reader Action Summary section not found in report" }) + "\n");
+    return;
+  }
+
   // Update review time in Build Notes when provided.
-  let finalReport = updatedReport;
+  let finalReport = withActionSummary;
   if (newReviewTime !== "") {
-    const withReviewTime = replaceReviewTime(updatedReport, newReviewTime);
+    const withReviewTime = replaceReviewTime(withActionSummary, newReviewTime);
     if (withReviewTime !== null) {
       finalReport = withReviewTime;
     }
@@ -825,6 +854,8 @@ async function handleSaveSummary(
   const html = markdownToHtml(finalReport);
   const section = findWatchingSection(finalReport);
   const summary = section ? section.body : "";
+  const actionSection = findReaderActionSummarySection(finalReport);
+  const actionSummary = actionSection ? actionSection.body : "";
   const reviewTime = findReviewTime(finalReport);
   const rbody = extractReportBody(finalReport);
   const articles = parseSourceArticles(finalReport);
@@ -843,6 +874,7 @@ async function handleSaveSummary(
     checkWeaselWords(rbody),
     checkBuildNotes(finalReport),
     checkWatchingSection(finalReport),
+    checkReaderActionSummary(finalReport),
     checkMarkdownLinks(finalReport),
     checkHtmlReport(htmlExists, htmlPath),
   ];
@@ -851,6 +883,7 @@ async function handleSaveSummary(
     date,
     html,
     summary,
+    actionSummary,
     reviewTime,
     checks,
     descriptionStatus,

--- a/src/summarize/renderer.ts
+++ b/src/summarize/renderer.ts
@@ -12,6 +12,7 @@ export type ReportSection =
   | "weekly-summary"
   | "since-last-report"
   | "what-i-m-watching"
+  | "reader-action-summary"
   | "source-articles"
   | "build-notes";
 
@@ -26,6 +27,7 @@ export const DEFAULT_PRESENTATION_ORDER: ReportSection[] = [
   "weekly-summary",
   "since-last-report",
   "what-i-m-watching",
+  "reader-action-summary",
   "source-articles",
   "build-notes",
 ];
@@ -41,6 +43,7 @@ const SECTION_HEADINGS: Record<ReportSection, string> = {
   "weekly-summary": "## Weekly Summary",
   "since-last-report": "## Since Last Report",
   "what-i-m-watching": "## What I'm Watching",
+  "reader-action-summary": "## Reader Action Summary",
   "source-articles": "## Source Articles",
   "build-notes": "## Build Notes",
 };

--- a/src/summarize/report.ts
+++ b/src/summarize/report.ts
@@ -8,6 +8,7 @@ import {
 } from "./report-comparison.js";
 import {
   findWatchingSection,
+  findReaderActionSummarySection,
   isPlaceholderContent,
 } from "../review/report-edit.js";
 
@@ -500,6 +501,15 @@ export function assembleReport(
     }
   }
 
+  let actionSummaryContent =
+    "<!-- Human-authored: add up to 4 action items here -->";
+  if (existingReportMd) {
+    const existingSection = findReaderActionSummarySection(existingReportMd);
+    if (existingSection && !isPlaceholderContent(existingSection.body)) {
+      actionSummaryContent = existingSection.body;
+    }
+  }
+
   return `<!-- SEO_TITLE: ${metadata.title} -->
 <!-- SEO_DESCRIPTION: ${metadata.description} -->
 # WordPress Trend Report — ${date}
@@ -511,6 +521,12 @@ ${weeklySummary}${sinceLastReportBlock}
 ## What I'm Watching
 
 ${watchingContent}
+
+---
+
+## Reader Action Summary
+
+${actionSummaryContent}
 
 ---
 

--- a/tests/review/checks.test.ts
+++ b/tests/review/checks.test.ts
@@ -8,6 +8,7 @@ import {
   checkWeaselWords,
   checkBuildNotes,
   checkWatchingSection,
+  checkReaderActionSummary,
   checkMarkdownLinks,
   checkHtmlReport,
   type SourceArticle,
@@ -200,6 +201,38 @@ test("checkWatchingSection warns on placeholder text", () => {
   const result = checkWatchingSection(report);
   assert.equal(result.status, "warn");
   assert.ok(result.message.includes("placeholder"));
+});
+
+// --- checkReaderActionSummary ---
+
+test("checkReaderActionSummary passes for a bounded reviewed item", () => {
+  const report = `## Reader Action Summary
+### Prepare
+- **Audience:** Block developers should test the beta. **State:** beta. **Source:** [Release notes](https://example.com/release)`;
+  const result = checkReaderActionSummary(report);
+  assert.equal(result.status, "pass");
+  assert.ok(result.message.includes("1 reviewed item"));
+});
+
+test("checkReaderActionSummary warns when an item lacks state or source", () => {
+  const result = checkReaderActionSummary(
+    "## Reader Action Summary\n### Watch\n- Follow this proposal.",
+  );
+  assert.equal(result.status, "warn");
+  assert.ok(result.message.includes("missing State or source link"));
+});
+
+test("checkReaderActionSummary warns on unsupported labels and too many items", () => {
+  const invalid = checkReaderActionSummary("## Reader Action Summary\n### Critical\n- Item");
+  assert.equal(invalid.status, "warn");
+  assert.ok(invalid.message.includes("unsupported label"));
+
+  const tooMany = Array.from({ length: 5 }, (_, i) =>
+    `- Item ${i + 1}. **State:** shipped. **Source:** [Source](https://example.com/${i})`,
+  ).join("\n");
+  const result = checkReaderActionSummary(`## Reader Action Summary\n### Watch\n${tooMany}`);
+  assert.equal(result.status, "warn");
+  assert.ok(result.message.includes("maximum is 4"));
 });
 
 // --- checkMarkdownLinks ---

--- a/tests/review/report-edit.test.ts
+++ b/tests/review/report-edit.test.ts
@@ -6,6 +6,8 @@ import {
   isPlaceholderContent,
   findReviewTime,
   replaceReviewTime,
+  findReaderActionSummarySection,
+  replaceReaderActionSummarySection,
 } from "../../src/review/report-edit.js";
 
 // --- Stripped-down test report ---
@@ -196,6 +198,28 @@ test("replaceWatchingSection is idempotent when replacing with same content", ()
   // Should still have correct structure
   assert.ok(result!.includes("## Source Articles"));
   assert.ok(result!.includes("## Build Notes"));
+});
+
+test("Reader Action Summary helpers extract and replace authored content", () => {
+  const report = PLACEHOLDER_REPORT.replace(
+    "## Source Articles",
+    "## Reader Action Summary\n\n### Watch\n\nOld item.\n\n---\n\n## Source Articles",
+  );
+  const section = findReaderActionSummarySection(report);
+  assert.ok(section);
+  assert.ok(section!.body.includes("Old item"));
+  const result = replaceReaderActionSummarySection(report, "### Prepare\n\nNew item.");
+  assert.ok(result);
+  assert.ok(result!.includes("### Prepare\n\nNew item."));
+  assert.ok(result!.includes("## Source Articles"));
+  assert.ok(!result!.includes("Old item"));
+});
+
+test("replaceReaderActionSummarySection adds the section to legacy reports", () => {
+  const result = replaceReaderActionSummarySection(PLACEHOLDER_REPORT, "### Watch\n\nA proposal.");
+  assert.ok(result);
+  assert.ok(result!.includes("## Reader Action Summary"));
+  assert.ok(result!.includes("A proposal."));
 });
 
 // --- isPlaceholderContent ---

--- a/tests/review/server.test.ts
+++ b/tests/review/server.test.ts
@@ -238,12 +238,14 @@ test("POST /api/review-summary saves summary and returns updated state", async (
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           summary: "Updated observation: this is important.",
+          actionSummary: "### Prepare\n\n- Test the change. **State:** beta. **Source:** [Notes](https://example.com)",
         }),
       },
     );
     assert.equal(status, 200);
     const data = JSON.parse(body);
     assert.ok(data.summary.includes("Updated observation"));
+    assert.ok(data.actionSummary.includes("Test the change"));
     assert.ok(!data.summary.includes("Human-authored"));
     assert.ok(data.html.includes("Updated observation"));
     assert.equal(data.descriptionStatus, "generated");

--- a/tests/summarize/report.test.ts
+++ b/tests/summarize/report.test.ts
@@ -286,6 +286,7 @@ test("assembleReport produces a complete Markdown report", () => {
   assert.ok(report.includes("### Emerging Trends"));
   assert.ok(report.includes("### Developer Implications"));
   assert.ok(report.includes("## What I'm Watching"));
+  assert.ok(report.includes("## Reader Action Summary"));
   assert.ok(report.includes("## Source Articles"));
   assert.ok(report.includes("## Build Notes"));
   assert.ok(report.includes("[Article One](https://example.com/1)"));


### PR DESCRIPTION
## Summary
- Add an optional human-authored Reader Action Summary to weekly reports.
- Support bounded Act now, Prepare, Watch, and No action labels with source/state validation.
- Extend the local review page, report preservation, HTML rendering, tests, and workflow documentation.
- Preserve Developer Implications and keep AI impact scoring, persistent watch records, alerts, and tutorial generation out of scope.

## Verification
- `pnpm run test` — 239 passed
- `pnpm run typecheck` — passed
- `pnpm run review` — completed with one expected warning for the pre-feature latest report
- `git diff --check` — passed

## Follow-up
Before merging, use the feature during the next three weekly report review cycles and assess whether it clarifies reader decisions without duplicating Developer Implications.